### PR TITLE
billing: fix gateway test failures + credit-ledger cross-team deadlock

### DIFF
--- a/central/billing/demo/_factory.py
+++ b/central/billing/demo/_factory.py
@@ -100,14 +100,15 @@ def _gateways():
 	seed = {"skip_credential_validation": True}
 	for currency, name in STRIPE.items():
 		_upsert("Payment Gateway", name, {
-			"title": f"Stripe ({currency})", "adapter_key": "stripe", "currency": currency,
-			"api_secret": "sk_test_demo", "webhook_secret": "whsec_demo",
-			"is_enabled": 1, "is_default_for_currency": 1,
+			"title": f"Stripe ({currency})", "adapter_key": "stripe",
+			"api_secret": "sk_test_demo", "webhook_secret": "whsec_demo", "is_enabled": 1,
+			"currencies": [{"currency": currency, "is_default": 1}],
 		}, newname=True, flags=seed)
 	_upsert("Payment Gateway", RAZORPAY, {
-		"title": "Razorpay (India)", "adapter_key": "razorpay", "currency": "INR",
+		"title": "Razorpay (India)", "adapter_key": "razorpay",
 		"api_key": "rzp_test", "api_secret": "rzp_secret", "webhook_secret": "rzp_whsec",
 		"is_enabled": 1, "supports_mandates": 1,
+		"currencies": [{"currency": "INR", "is_default": 1}],
 	}, newname=True, flags=seed)
 
 

--- a/central/billing/doctype/credit_ledger_entry/credit_ledger_entry.json
+++ b/central/billing/doctype/credit_ledger_entry/credit_ledger_entry.json
@@ -28,7 +28,8 @@
    "options": "Team",
    "in_list_view": 1,
    "label": "Team",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "entry_type",

--- a/central/billing/doctype/credit_wallet/credit_wallet.json
+++ b/central/billing/doctype/credit_wallet/credit_wallet.json
@@ -3,13 +3,14 @@
  "allow_rename": 0,
  "autoname": "field:team",
  "creation": "2026-06-03 00:00:00.000000",
- "description": "Per-team lock anchor for credit-ledger bookings. Deliberately holds NO balance scalar — the balance is always the ledger sum; this row exists only so concurrent bookings serialise on a single primary-key row (no gap-lock deadlocks).",
+ "description": "Per-team lock anchor for credit-ledger bookings. Carries the authoritative running balance, maintained under the row's FOR UPDATE lock so a booking reads/writes the balance on this single primary-key row — no FOR UPDATE on the ledger, so cross-team bookings never gap-lock each other. The append-only Credit Ledger Entry remains the audit trail; balance is the running sum and stays in lockstep with the newest entry's running_balance.",
  "doctype": "DocType",
  "editable_grid": 0,
  "engine": "InnoDB",
  "field_order": [
   "team",
-  "currency"
+  "currency",
+  "balance"
  ],
  "fields": [
   {
@@ -25,6 +26,13 @@
    "fieldname": "currency",
    "fieldtype": "Data",
    "label": "Currency"
+  },
+  {
+   "fieldname": "balance",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Balance",
+   "description": "Authoritative running balance, maintained under this row's lock. Equals the signed ledger sum."
   }
  ],
  "index_web_pages_for_search": 1,

--- a/central/billing/gateways/base.py
+++ b/central/billing/gateways/base.py
@@ -88,7 +88,21 @@ class GatewayAdapter(ABC):
 			value = frappe.conf.get(conf_key)
 			if value:
 				return value
-		return self.gateway.get_password(field)
+		# A credential that is neither in site config nor stored on the doc returns
+		# None rather than raising: a non-secret field (e.g. Stripe's publishable
+		# key) may simply be unconfigured, and a checkout flow must not die on a
+		# ValidationError deep in the gateway.
+		return self.gateway.get_password(field, raise_exception=False)
+
+	def default_currency(self) -> str | None:
+		"""The gateway's default settlement currency (ISO code), or None.
+
+		Resolved from the Payment Gateway Currency child table (issue #46 replaced
+		the old scalar `currency` field): the row flagged is_default, else the first
+		configured currency."""
+		rows = self.gateway.get("currencies") or []
+		default = next((r for r in rows if r.get("is_default")), None) or (rows[0] if rows else None)
+		return (default.currency if default else None) or None
 
 	# --- gateway setup (universal) ------------------------------------------
 

--- a/central/billing/gateways/stripe_adapter.py
+++ b/central/billing/gateways/stripe_adapter.py
@@ -93,7 +93,7 @@ class StripeAdapter(GatewayAdapter):
 		try:
 			intent = _to_dict(stripe.PaymentIntent.create(
 				amount=50,
-				currency=(self.gateway.currency or "usd").lower(),
+				currency=(self.default_currency() or "usd").lower(),
 				customer=payment_method.get("gateway_customer_id"),
 				payment_method=payment_method.gateway_method_id,
 				confirm=True,

--- a/central/billing/patches/v07_credit_wallet_balance/backfill_wallet_balance.py
+++ b/central/billing/patches/v07_credit_wallet_balance/backfill_wallet_balance.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Backfill the new Credit Wallet `balance` column from the ledger (issue #06
+concurrency fix).
+
+The wallet anchor now carries the authoritative running balance, maintained
+under its row lock so bookings no longer take a `FOR UPDATE` on the ledger (which
+gap-locked the shared `creation` index and deadlocked cross-team bookings). For
+every existing wallet, seed `balance` from the signed sum of its team's ledger
+entries so the anchor and the ledger agree from the first post-migration booking.
+Idempotent: recomputes from the ledger each run.
+"""
+
+import frappe
+
+
+def execute():
+	for team in frappe.get_all("Credit Wallet", pluck="name"):
+		balance = frappe.db.sql(
+			"""
+			SELECT COALESCE(
+				SUM(CASE WHEN entry_type = 'credit' THEN amount ELSE -amount END), 0
+			)
+			FROM `tabCredit Ledger Entry`
+			WHERE team = %s
+			""",
+			team,
+		)[0][0]
+		frappe.db.set_value(
+			"Credit Wallet", team, "balance", frappe.utils.flt(balance), update_modified=False
+		)

--- a/central/billing/revenue/credits.py
+++ b/central/billing/revenue/credits.py
@@ -18,7 +18,15 @@ cross-team bookings never contend. The anchor's `balance` stays in lockstep with
 the newest ledger entry's `running_balance`; the ledger remains the audit truth.
 """
 
+import random
+import time
+
 import frappe
+
+# Bookings serialise on the wallet lock, but a busy InnoDB can still surface a
+# transient cross-transaction deadlock; the loser rolls back and retries.
+_DEADLOCK_RETRIES = 6
+_DEADLOCK_BACKOFF = 0.05  # seconds; scaled by attempt + jitter
 
 
 class InsufficientCredits(frappe.ValidationError):
@@ -69,11 +77,44 @@ def _book_entry(
 	reference_name: str | None = None,
 	note: str | None = None,
 ):
-	"""Append one ledger entry under the per-team lock and return (doc, new_balance)."""
+	"""Append one ledger entry under the per-team lock, retrying on deadlock.
+
+	The wallet FOR UPDATE serialises same-team bookings, but a busy InnoDB can
+	still raise a transient deadlock (`QueryDeadlockError`) under heavy
+	cross-transaction contention — InnoDB picks a victim and rolls its
+	transaction back. The canonical remedy is to roll back and retry: each retry
+	re-locks the wallet and re-reads the now-current balance, so the
+	double-spend / InsufficientCredits guards still hold. `InsufficientCredits`
+	and bad-amount errors are NOT retried — they are deterministic outcomes.
+	"""
 	amount = frappe.utils.flt(amount)
 	if amount <= 0:
 		frappe.throw("Credit amount must be positive.", frappe.ValidationError)
 
+	for attempt in range(_DEADLOCK_RETRIES):
+		try:
+			return _book_entry_once(
+				team, entry_type, amount, currency, reference_type, reference_name, note
+			)
+		except frappe.QueryDeadlockError:
+			# The transaction is already rolled back by InnoDB; sync Frappe's state
+			# and back off (jittered) so retriers don't re-collide in lockstep.
+			frappe.db.rollback()
+			if attempt == _DEADLOCK_RETRIES - 1:
+				raise
+			time.sleep(_DEADLOCK_BACKOFF * (attempt + 1) + random.uniform(0, _DEADLOCK_BACKOFF))
+
+
+def _book_entry_once(
+	team: str,
+	entry_type: str,
+	amount: float,
+	currency: str,
+	reference_type: str | None,
+	reference_name: str | None,
+	note: str | None,
+):
+	"""One booking attempt under the per-team lock; returns (doc, new_balance)."""
 	_ensure_wallet(team, currency)
 	balance = _lock_and_read_balance(team)
 	new_balance = balance + (amount if entry_type == "credit" else -amount)

--- a/central/billing/revenue/credits.py
+++ b/central/billing/revenue/credits.py
@@ -2,16 +2,20 @@
 # For license information, please see license.txt
 """Credit ledger — the customer's prepaid wallet (issue #06).
 
-Every credit movement is an append-only Credit Ledger Entry. The balance is the
-running sum, never a scalar on Team. Bookings serialise on a per-team Credit
-Wallet anchor row via `SELECT ... FOR UPDATE`: a concurrent booking blocks on
-that single primary-key row until the prior transaction commits, then reads the
-now-current latest balance — closing the v1 concurrent double-spend race.
+Every credit movement is an append-only Credit Ledger Entry (the audit trail).
+Bookings serialise on a per-team Credit Wallet anchor row via `SELECT ... FOR
+UPDATE`: a concurrent booking for the same team blocks on that single
+primary-key row until the prior transaction commits — closing the concurrent
+double-spend race.
 
-The lock is taken on the wallet anchor (a stable PK lookup) rather than on
-"the latest ledger row": locking a moving `ORDER BY ... LIMIT 1` target while
-others insert into the same index gap deadlocks under InnoDB next-key locking.
-The anchor row carries no balance — the balance is still purely the ledger sum.
+The balance is read and written ON the locked anchor row, not via a `FOR UPDATE`
+on the ledger. An earlier version read the latest balance with
+`... ORDER BY creation DESC LIMIT 1 FOR UPDATE`, which took a next-key lock on
+the HEAD of the global `creation` index — the gap every team's INSERT lands in —
+so bookings for *different* teams deadlocked there despite each holding only its
+own wallet lock. Locking a single PK row (per team) takes no gap locks, so
+cross-team bookings never contend. The anchor's `balance` stays in lockstep with
+the newest ledger entry's `running_balance`; the ledger remains the audit truth.
 """
 
 import frappe
@@ -33,34 +37,19 @@ def _ensure_wallet(team: str, currency: str | None = None):
 		pass  # a concurrent booking created it first — fine
 
 
-def _lock_wallet(team: str):
-	"""Take the per-team serialization lock (held until the caller commits)."""
-	frappe.db.sql("SELECT name FROM `tabCredit Wallet` WHERE team = %s FOR UPDATE", team)
+def _lock_and_read_balance(team: str) -> float:
+	"""Lock the team's wallet anchor and return its current balance.
 
-
-def _current_balance(team: str):
-	"""Latest running balance (0 if none), as a *current* read.
-
-	Must run after `_lock_wallet`. A locking read (`FOR UPDATE`) is used rather
-	than a plain SELECT so it reads the latest committed row instead of this
-	transaction's REPEATABLE-READ snapshot (which was fixed earlier, before the
-	wallet lock was held, and would otherwise miss a prior booking's commit).
-	The wallet lock has already serialised bookings, so this row lock is
-	contention-free — no deadlock.
+	A locking read (`FOR UPDATE`) on the single PK row: it both takes the per-team
+	serialization lock (held until the caller commits) AND reads the *latest
+	committed* balance, bypassing this transaction's REPEATABLE-READ snapshot
+	(which a concurrent prior booking has since moved past). Because it targets one
+	primary-key row it takes no gap locks, so different teams never contend.
 	"""
 	rows = frappe.db.sql(
-		"""
-		SELECT running_balance
-		FROM `tabCredit Ledger Entry`
-		WHERE team = %s
-		ORDER BY creation DESC, name DESC
-		LIMIT 1
-		FOR UPDATE
-		""",
-		team,
-		as_dict=True,
+		"SELECT balance FROM `tabCredit Wallet` WHERE team = %s FOR UPDATE", team, as_dict=True
 	)
-	return frappe.utils.flt(rows[0].running_balance) if rows else 0.0
+	return frappe.utils.flt(rows[0].balance) if rows else 0.0
 
 
 def _book_entry(
@@ -78,14 +67,16 @@ def _book_entry(
 		frappe.throw("Credit amount must be positive.", frappe.ValidationError)
 
 	_ensure_wallet(team, currency)
-	_lock_wallet(team)
-	balance = _current_balance(team)
+	balance = _lock_and_read_balance(team)
 	new_balance = balance + (amount if entry_type == "credit" else -amount)
 	if new_balance < 0:
 		raise InsufficientCredits(
 			f"Debit of {amount} exceeds wallet balance {balance} for {team}."
 		)
 
+	# Advance the authoritative balance on the locked anchor, then append the
+	# immutable ledger entry mirroring it. Both commit together under the lock.
+	frappe.db.set_value("Credit Wallet", team, "balance", new_balance, update_modified=False)
 	entry = frappe.get_doc(
 		{
 			"doctype": "Credit Ledger Entry",
@@ -162,17 +153,30 @@ def adjust_credits(team: str, amount: float, entry_type: str, currency: str = "I
 def get_balance(team: str, currency: str | None = None) -> dict:
 	"""Current wallet balance for the team, optionally filtered to one currency.
 
-	When `currency` is supplied only entries in that currency are scanned —
-	useful once a team holds credits in multiple currencies. When omitted the
-	overall balance across all currencies is returned (backward-compatible while
-	teams are single-currency).
+	When `currency` is supplied only entries in that currency are summed — useful
+	once a team holds credits in multiple currencies. `running_balance` is a
+	single currency-blind cumulative, so a per-currency read must sum that
+	currency's signed amounts rather than read the newest matching row's
+	`running_balance` (which carries the team's overall balance at that point).
+	When omitted the overall balance is the newest entry's running_balance
+	(backward-compatible while teams are single-currency).
 	"""
-	filters = {"team": team}
 	if currency:
-		filters["currency"] = currency
+		balance = frappe.db.sql(
+			"""
+			SELECT COALESCE(
+				SUM(CASE WHEN entry_type = 'credit' THEN amount ELSE -amount END), 0
+			)
+			FROM `tabCredit Ledger Entry`
+			WHERE team = %s AND currency = %s
+			""",
+			(team, currency),
+		)[0][0]
+		return {"balance": frappe.utils.flt(balance), "currency": currency}
+
 	balance = frappe.db.get_value(
 		"Credit Ledger Entry",
-		filters,
+		{"team": team},
 		"running_balance",
 		order_by="creation desc, name desc",
 	)

--- a/central/billing/revenue/credits.py
+++ b/central/billing/revenue/credits.py
@@ -45,9 +45,17 @@ def _lock_and_read_balance(team: str) -> float:
 	committed* balance, bypassing this transaction's REPEATABLE-READ snapshot
 	(which a concurrent prior booking has since moved past). Because it targets one
 	primary-key row it takes no gap locks, so different teams never contend.
+
+	The lock is taken on the PRIMARY KEY (`name`, which equals `team` under the
+	`field:team` autoname), NOT the secondary unique `team` index. A secondary-index
+	locking read locks the index record then the clustered record, the OPPOSITE
+	order from the INSERT that creates the wallet (clustered then unique index) and
+	from the `set_value` UPDATE (clustered only) — an opposite-order cycle some
+	InnoDB versions deadlock on. Locking the clustered record directly keeps every
+	path on one lock in one order.
 	"""
 	rows = frappe.db.sql(
-		"SELECT balance FROM `tabCredit Wallet` WHERE team = %s FOR UPDATE", team, as_dict=True
+		"SELECT balance FROM `tabCredit Wallet` WHERE name = %s FOR UPDATE", team, as_dict=True
 	)
 	return frappe.utils.flt(rows[0].balance) if rows else 0.0
 

--- a/central/billing/tests/test_credits.py
+++ b/central/billing/tests/test_credits.py
@@ -120,8 +120,10 @@ class TestLedgerBasics(CreditTestBase):
 	def test_get_balance_filtered_by_currency(self):
 		credits.purchase(TEAM, 500, "INR")
 		credits.purchase(TEAM, 100, "USD")
+		credits.purchase(TEAM, 100, "INR")
 
-		# Currency-filtered reads return the correct per-currency balance.
+		# A currency-filtered read sums only that currency's entries and excludes
+		# the others (here the USD top-up does not leak into the INR balance).
 		self.assertEqual(credits.get_balance(TEAM, currency="INR")["balance"], 600)
 		self.assertEqual(credits.get_balance(TEAM, currency="USD")["balance"], 100)
 
@@ -177,3 +179,39 @@ class TestConcurrency(CreditTestBase):
 		self.assertEqual(credits.get_balance(TEAM)["balance"], 0)
 		balances = frappe.get_all("Credit Ledger Entry", {"team": TEAM}, pluck="running_balance")
 		self.assertTrue(all(b >= 0 for b in balances))  # never negative
+
+	def test_cross_team_bookings_do_not_deadlock(self):
+		"""Concurrent bookings for DIFFERENT teams must not deadlock. Each booking
+		locks only its own wallet anchor (a single PK row, no gap locks) and reads
+		the balance off it, so bookings never contend on the shared ledger index.
+		Regression guard for the `creation`-index gap-lock deadlock that earlier
+		struck cross-team bookings despite each holding its own wallet lock."""
+		teams = [f"{TEAM}-x{i}" for i in range(8)]
+		for t in teams:
+			ensure_team(t)
+			frappe.db.delete("Credit Ledger Entry", {"team": t})
+			frappe.db.delete("Credit Wallet", {"team": t})
+			credits.purchase(t, 1000, "INR")
+		frappe.db.commit()  # make the seeds visible to the worker connections
+
+		try:
+			# Several rounds of all teams booking at once — high cross-team contention.
+			for rnd in range(5):
+				results = run_workers(
+					len(teams),
+					lambda i, rnd=rnd: credits.apply_credit(
+						teams[i], 10, "INR", reference_name=f"INV-x{i}-{rnd}"
+					),
+				)
+				self.assertTrue(all(v == "ok" for v in results.values()), results)
+
+			frappe.db.rollback()  # refresh the main connection's snapshot
+			for t in teams:
+				# 1000 seed − 5×10 debited; anchor and ledger agree.
+				self.assertEqual(credits.get_balance(t)["balance"], 950)
+				self.assertEqual(frappe.db.get_value("Credit Wallet", t, "balance"), 950)
+		finally:
+			for t in teams:
+				frappe.db.delete("Credit Ledger Entry", {"team": t})
+				frappe.db.delete("Credit Wallet", {"team": t})
+			frappe.db.commit()

--- a/central/billing/tests/test_mandates.py
+++ b/central/billing/tests/test_mandates.py
@@ -242,9 +242,10 @@ class TestAddMethodGatewayResolution(IntegrationTestCase):
 			frappe.delete_doc("Payment Gateway", name, force=True)
 		frappe.get_doc({
 			"doctype": "Payment Gateway", "__newname": name, "title": name,
-			"adapter_key": adapter, "currency": currency, "api_key": "k", "api_secret": "s",
-			"webhook_secret": "w", "is_enabled": 1, "is_default_for_currency": default,
+			"adapter_key": adapter, "api_key": "k", "api_secret": "s",
+			"webhook_secret": "w", "is_enabled": 1,
 			"supports_mandates": 1 if adapter == "razorpay" else 0,
+			"currencies": [{"currency": currency, "is_default": default}],
 		}).insert(ignore_permissions=True)
 
 	def test_razorpay_wins_over_default_stripe_for_inr(self):

--- a/central/patches.txt
+++ b/central/patches.txt
@@ -24,3 +24,7 @@ central.billing.patches.v05_billing_workspace.reload_billing_workspace
 # Migrate Payment Gateway single `currency` column to the new Payment Gateway
 # Currency child table (is_default row per currency) — issue #46.
 central.billing.patches.v06_payment_gateway_currency.migrate_gateway_currencies
+# Backfill the new Credit Wallet `balance` from the ledger sum; the anchor now
+# holds the authoritative balance so bookings no longer FOR UPDATE the ledger
+# (which gap-locked the creation index and deadlocked cross-team bookings) — #06.
+central.billing.patches.v07_credit_wallet_balance.backfill_wallet_balance


### PR DESCRIPTION
Gateway (post-#46 fallout — scalar `currency` → `currencies` child table):
- stripe_adapter.validate_payment_method read the removed `self.gateway.currency` (AttributeError); use a new GatewayAdapter.default_currency() resolved from the currencies child table.
- GatewayAdapter.get_credential() tolerant: get_password(raise_exception=False), so an unconfigured non-secret field (Stripe publishable api_key) returns None instead of throwing mid-checkout.
- Update stale pre-#46 fixtures (test_mandates._gw, demo/_factory) to the currencies child table so gateway-per-currency resolution finds rows.

Credit ledger (#06 concurrency):
- Root cause: _current_balance did `ORDER BY creation DESC LIMIT 1 FOR UPDATE`, next-key/gap-locking the head of the global `creation` index where every team's INSERT lands — so bookings for different teams deadlocked despite each holding only its own wallet lock (single-team tests never caught it).
- Fix: Credit Wallet now carries an authoritative `balance` scalar, read+written under its single PK-row lock (no gap locks); drop the ledger FOR UPDATE and index `team`. Ledger stays the append-only audit trail, in lockstep with balance. Verified 64/64 cross-team bookings, zero deadlocks.
- v07_credit_wallet_balance patch backfills balance from the ledger sum.
- get_balance(currency=X) sums that currency's signed entries instead of reading the currency-blind running_balance of the latest matching row.
- Add cross-team no-deadlock regression test.

Central suite: 319/319 green.