### PR TITLE
billing: replace raw frappe.db.sql with the query builder

### DIFF
--- a/central/billing/patches/v01_rates_to_standalone/migrate_rate_children_to_standalone.py
+++ b/central/billing/patches/v01_rates_to_standalone/migrate_rate_children_to_standalone.py
@@ -22,6 +22,7 @@ Self-guarding + idempotent:
 """
 
 import frappe
+from pypika import Table
 
 from central.billing.patches.v01_rates_to_standalone.snapshot_legacy_rate_children import (
 	raw_table_exists,
@@ -55,9 +56,12 @@ def execute():
 		if not raw_table_exists(scratch):
 			continue
 
-		rows = frappe.db.sql(
-			f"SELECT `parent`, `cluster`, `currency`, `rate` FROM `{scratch}`",
-			as_dict=True,
+		# A plain scratch table (no `tab` prefix), so reference it directly.
+		scratch_tbl = Table(scratch)
+		rows = (
+			frappe.qb.from_(scratch_tbl)
+			.select(scratch_tbl.parent, scratch_tbl.cluster, scratch_tbl.currency, scratch_tbl.rate)
+			.run(as_dict=True)
 		)
 		for row in rows:
 			_migrate_row(priced_doctype, row)

--- a/central/billing/patches/v01_rates_to_standalone/snapshot_legacy_rate_children.py
+++ b/central/billing/patches/v01_rates_to_standalone/snapshot_legacy_rate_children.py
@@ -47,10 +47,5 @@ def scratch_table(doctype: str) -> str:
 
 def raw_table_exists(table_name: str) -> bool:
 	"""Existence check for a plain (non-DocType) table, e.g. a scratch table."""
-	return bool(
-		frappe.db.sql(
-			"SELECT 1 FROM information_schema.tables "
-			"WHERE table_schema = DATABASE() AND table_name = %s LIMIT 1",
-			table_name,
-		)
-	)
+	# Uncached: the scratch table may have just been created/dropped this run.
+	return table_name in frappe.db.get_tables(cached=False)

--- a/central/billing/patches/v03_team_link_to_central_team/migrate_team_to_central_team.py
+++ b/central/billing/patches/v03_team_link_to_central_team/migrate_team_to_central_team.py
@@ -84,10 +84,15 @@ def _distinct_team_slugs() -> set[str]:
 	"""Every non-empty `team` value across the 16 tables (raw SQL — still Data)."""
 	slugs: set[str] = set()
 	for doctype in TEAM_DOCTYPES:
-		rows = frappe.db.sql(
-			f"SELECT DISTINCT team FROM `tab{doctype}` WHERE team IS NOT NULL AND team != ''"
+		table = frappe.qb.DocType(doctype)
+		rows = (
+			frappe.qb.from_(table)
+			.select(table.team)
+			.distinct()
+			.where(table.team.isnotnull() & (table.team != ""))
+			.run(pluck=True)
 		)
-		slugs.update(row[0] for row in rows)
+		slugs.update(rows)
 	return slugs
 
 
@@ -99,10 +104,12 @@ def _legacy_billing_access() -> dict[str, list[str]]:
 	if not _billing_team_column_exists():
 		return {}
 	access: dict[str, list[str]] = defaultdict(list)
-	rows = frappe.db.sql(
-		"SELECT name, billing_team FROM `tabUser` "
-		"WHERE billing_team IS NOT NULL AND billing_team != ''",
-		as_dict=True,
+	user = frappe.qb.DocType("User")
+	rows = (
+		frappe.qb.from_(user)
+		.select(user.name, user.billing_team)
+		.where(user.billing_team.isnotnull() & (user.billing_team != ""))
+		.run(as_dict=True)
 	)
 	for row in rows:
 		access[row.billing_team].append(row.name)
@@ -169,22 +176,27 @@ def _snapshot_team_counts() -> dict[str, Counter]:
 	round-trip proof that no row changes team ownership."""
 	snapshot: dict[str, Counter] = {}
 	for doctype in TEAM_DOCTYPES:
-		rows = frappe.db.sql(
-			f"SELECT team FROM `tab{doctype}` WHERE team IS NOT NULL AND team != ''"
+		table = frappe.qb.DocType(doctype)
+		rows = (
+			frappe.qb.from_(table)
+			.select(table.team)
+			.where(table.team.isnotnull() & (table.team != ""))
+			.run(pluck=True)
 		)
-		snapshot[doctype] = Counter(row[0] for row in rows)
+		snapshot[doctype] = Counter(rows)
 	return snapshot
 
 
 def _rewrite_team_values(mapping: dict[str, str]) -> None:
-	"""Slug → Team.name on every table (raw SQL, before the Link constraint)."""
+	"""Slug → Team.name on every table (direct UPDATE, before the Link constraint)."""
 	for doctype in TEAM_DOCTYPES:
+		table = frappe.qb.DocType(doctype)
 		for slug, team_name in mapping.items():
 			if slug == team_name:
 				continue
-			frappe.db.sql(
-				f"UPDATE `tab{doctype}` SET team = %s WHERE team = %s", (team_name, slug)
-			)
+			frappe.qb.update(table).set(table.team, team_name).where(
+				table.team == slug
+			).run()
 
 
 def _rename_field_team_docs(mapping: dict[str, str]) -> None:
@@ -211,11 +223,12 @@ def _assert_round_trip(before: dict[str, Counter], mapping: dict[str, str]) -> N
 		expected: Counter = Counter()
 		for slug, count in before[doctype].items():
 			expected[mapping[slug]] += count
+		table = frappe.qb.DocType(doctype)
 		actual = Counter(
-			row[0]
-			for row in frappe.db.sql(
-				f"SELECT team FROM `tab{doctype}` WHERE team IS NOT NULL AND team != ''"
-			)
+			frappe.qb.from_(table)
+			.select(table.team)
+			.where(table.team.isnotnull() & (table.team != ""))
+			.run(pluck=True)
 		)
 		if expected != actual:
 			frappe.throw(

--- a/central/billing/patches/v03_team_link_to_central_team/validate_team_links.py
+++ b/central/billing/patches/v03_team_link_to_central_team/validate_team_links.py
@@ -21,16 +21,18 @@ def execute() -> None:
 		if field.fieldtype != "Link" or field.options != "Team":
 			frappe.throw(f"{doctype}.team is not a Link → Team (got {field.fieldtype}).")
 
-		orphans = frappe.db.sql(
-			f"""
-			SELECT DISTINCT child.team
-			FROM `tab{doctype}` child
-			LEFT JOIN `tabTeam` team ON team.name = child.team
-			WHERE child.team IS NOT NULL AND child.team != '' AND team.name IS NULL
-			"""
+		child = frappe.qb.DocType(doctype)
+		team = frappe.qb.DocType("Team")
+		orphans = (
+			frappe.qb.from_(child)
+			.left_join(team)
+			.on(team.name == child.team)
+			.select(child.team)
+			.distinct()
+			.where(child.team.isnotnull() & (child.team != "") & team.name.isnull())
+			.run(pluck=True)
 		)
 		if orphans:
 			frappe.throw(
-				f"{doctype} has {len(orphans)} team value(s) linking to no Team: "
-				f"{[row[0] for row in orphans]}"
+				f"{doctype} has {len(orphans)} team value(s) linking to no Team: {orphans}"
 			)

--- a/central/billing/patches/v06_payment_gateway_currency/migrate_gateway_currencies.py
+++ b/central/billing/patches/v06_payment_gateway_currency/migrate_gateway_currencies.py
@@ -25,10 +25,14 @@ def execute():
 		# Read the old column directly — the field may have been removed from the
 		# DocType JSON but the column survives in the DB until explicitly dropped.
 		try:
-			currency = frappe.db.sql(
-				"SELECT currency FROM `tabPayment Gateway` WHERE name = %s", gw.name
+			gateway = frappe.qb.DocType("Payment Gateway")
+			rows = (
+				frappe.qb.from_(gateway)
+				.select(gateway.currency)
+				.where(gateway.name == gw.name)
+				.run(pluck=True)
 			)
-			currency = currency[0][0] if currency and currency[0][0] else None
+			currency = rows[0] if rows and rows[0] else None
 		except Exception:
 			currency = None
 

--- a/central/billing/patches/v07_credit_wallet_balance/backfill_wallet_balance.py
+++ b/central/billing/patches/v07_credit_wallet_balance/backfill_wallet_balance.py
@@ -12,19 +12,16 @@ Idempotent: recomputes from the ledger each run.
 """
 
 import frappe
+from frappe.query_builder import Case
+from frappe.query_builder.functions import Sum
 
 
 def execute():
+	cle = frappe.qb.DocType("Credit Ledger Entry")
+	signed = Case().when(cle.entry_type == "credit", cle.amount).else_(-cle.amount)
 	for team in frappe.get_all("Credit Wallet", pluck="name"):
-		balance = frappe.db.sql(
-			"""
-			SELECT COALESCE(
-				SUM(CASE WHEN entry_type = 'credit' THEN amount ELSE -amount END), 0
-			)
-			FROM `tabCredit Ledger Entry`
-			WHERE team = %s
-			""",
-			team,
+		balance = (
+			frappe.qb.from_(cle).select(Sum(signed)).where(cle.team == team).run()
 		)[0][0]
 		frappe.db.set_value(
 			"Credit Wallet", team, "balance", frappe.utils.flt(balance), update_modified=False

--- a/central/billing/payments/charges.py
+++ b/central/billing/payments/charges.py
@@ -52,7 +52,10 @@ def pay_invoice(invoice: str, payment_method: str | None = None, gateway: str | 
 	in flight and return without starting a second charge. The invoice is never
 	marked Paid here — that waits for the webhook.
 	"""
-	frappe.db.sql("SELECT name FROM `tabInvoice` WHERE name = %s FOR UPDATE", invoice)
+	invoice_tbl = frappe.qb.DocType("Invoice")
+	frappe.qb.from_(invoice_tbl).select(invoice_tbl.name).where(
+		invoice_tbl.name == invoice
+	).for_update().run()
 	inv = frappe.get_doc("Invoice", invoice)
 
 	if inv.status != "Open":
@@ -208,7 +211,10 @@ def apply_webhook(event_name: str) -> dict:
 
 def _settle_invoice(attempt) -> bool:
 	"""Mark the attempt's invoice Paid (idempotent, under a row lock)."""
-	frappe.db.sql("SELECT name FROM `tabInvoice` WHERE name = %s FOR UPDATE", attempt.invoice)
+	invoice_tbl = frappe.qb.DocType("Invoice")
+	frappe.qb.from_(invoice_tbl).select(invoice_tbl.name).where(
+		invoice_tbl.name == attempt.invoice
+	).for_update().run()
 	inv = frappe.get_doc("Invoice", attempt.invoice)
 	if inv.status == "Paid":
 		return False  # a duplicate webhook — already settled

--- a/central/billing/revenue/credits.py
+++ b/central/billing/revenue/credits.py
@@ -22,6 +22,8 @@ import random
 import time
 
 import frappe
+from frappe.query_builder import Case
+from frappe.query_builder.functions import Sum
 
 # Bookings serialise on the wallet lock, but a busy InnoDB can still surface a
 # transient cross-transaction deadlock; the loser rolls back and retries.
@@ -62,10 +64,15 @@ def _lock_and_read_balance(team: str) -> float:
 	InnoDB versions deadlock on. Locking the clustered record directly keeps every
 	path on one lock in one order.
 	"""
-	rows = frappe.db.sql(
-		"SELECT balance FROM `tabCredit Wallet` WHERE name = %s FOR UPDATE", team, as_dict=True
+	wallet = frappe.qb.DocType("Credit Wallet")
+	rows = (
+		frappe.qb.from_(wallet)
+		.select(wallet.balance)
+		.where(wallet.name == team)
+		.for_update()
+		.run(pluck=True)
 	)
-	return frappe.utils.flt(rows[0].balance) if rows else 0.0
+	return frappe.utils.flt(rows[0]) if rows else 0.0
 
 
 def _book_entry(
@@ -211,15 +218,13 @@ def get_balance(team: str, currency: str | None = None) -> dict:
 	(backward-compatible while teams are single-currency).
 	"""
 	if currency:
-		balance = frappe.db.sql(
-			"""
-			SELECT COALESCE(
-				SUM(CASE WHEN entry_type = 'credit' THEN amount ELSE -amount END), 0
-			)
-			FROM `tabCredit Ledger Entry`
-			WHERE team = %s AND currency = %s
-			""",
-			(team, currency),
+		cle = frappe.qb.DocType("Credit Ledger Entry")
+		signed = Case().when(cle.entry_type == "credit", cle.amount).else_(-cle.amount)
+		balance = (
+			frappe.qb.from_(cle)
+			.select(Sum(signed))
+			.where((cle.team == team) & (cle.currency == currency))
+			.run()
 		)[0][0]
 		return {"balance": frappe.utils.flt(balance), "currency": currency}
 

--- a/central/billing/revenue/invoicing/lifecycle.py
+++ b/central/billing/revenue/invoicing/lifecycle.py
@@ -31,8 +31,13 @@ def open_and_collect(invoice: str, collect: bool = True) -> dict:
 	fires from `Draft`, so parallel workers never process the same invoice
 	twice — the loser sees a non-Draft status and returns.
 	"""
-	rows = frappe.db.sql(
-		"SELECT status FROM `tabInvoice` WHERE name = %s FOR UPDATE", invoice, as_dict=True
+	invoice_tbl = frappe.qb.DocType("Invoice")
+	rows = (
+		frappe.qb.from_(invoice_tbl)
+		.select(invoice_tbl.status)
+		.where(invoice_tbl.name == invoice)
+		.for_update()
+		.run(as_dict=True)
 	)
 	if not rows or rows[0].status != "Draft":
 		return {"invoice": invoice, "claimed": False}

--- a/central/billing/tests/test_team_migration.py
+++ b/central/billing/tests/test_team_migration.py
@@ -5,8 +5,8 @@
 The live `bench migrate` exercised the plain-rewrite path on real Subscription /
 Invoice data. This proves the two paths that need a populated table to show:
 the `field:team` rename (so `name == team` survives) and re-runnability — by
-planting a legacy `Data` slug via raw SQL (simulating un-migrated data) and
-running the patch helpers, then running them again.
+planting a legacy `Data` slug with a direct query-builder UPDATE (simulating
+un-migrated data) and running the patch helpers, then running them again.
 """
 
 import frappe
@@ -45,13 +45,14 @@ class TestTeamMigration(IntegrationTestCase):
 
 		# Plant un-migrated state: a free-text slug on both the plain row and the
 		# field:team-named row (its `name` is the slug too).
-		frappe.db.sql(
-			"UPDATE `tabSubscription` SET team = %s WHERE name = %s", (self.slug, sub.name)
-		)
-		frappe.db.sql(
-			"UPDATE `tabTrust Tier` SET name = %s, team = %s WHERE name = %s",
-			(self.slug, self.slug, real_team),
-		)
+		subscription = frappe.qb.DocType("Subscription")
+		frappe.qb.update(subscription).set(subscription.team, self.slug).where(
+			subscription.name == sub.name
+		).run()
+		trust_tier = frappe.qb.DocType("Trust Tier")
+		frappe.qb.update(trust_tier).set(trust_tier.name, self.slug).set(
+			trust_tier.team, self.slug
+		).where(trust_tier.name == real_team).run()
 		self.sub = sub.name
 
 	def test_slug_is_repointed_to_a_real_team(self):
@@ -90,9 +91,10 @@ class TestTeamMigration(IntegrationTestCase):
 			sub = frappe.get_doc(
 				{"doctype": "Subscription", "team": make_billing_team(make_user()).name}
 			).insert(ignore_permissions=True)
-			frappe.db.sql(
-				"UPDATE `tabSubscription` SET team = %s WHERE name = %s", (slug, sub.name)
-			)
+			subscription = frappe.qb.DocType("Subscription")
+			frappe.qb.update(subscription).set(subscription.team, slug).where(
+				subscription.name == sub.name
+			).run()
 			subs[slug] = sub.name
 
 		_run_migration()


### PR DESCRIPTION
frappe.db.sql (hand-written SQL strings) is an antipattern — no field/identifier safety, bypasses the query builder, and f-string interpolation invites injection. Convert every frappe.db.sql() call in the billing module (core, patches, tests) to frappe.qb / frappe.db helpers, on top of the credit-deadlock fixes:

- credits.py: wallet FOR UPDATE by PK via .for_update(); per-currency balance via Sum(Case().when(...)).
- charges.py / invoicing/lifecycle.py: invoice-row FOR UPDATE locks via qb.
- v07 backfill: Sum/Case query builder.
- v06: read the dropped `currency` column via qb select.
- v03 migrate/validate: distinct-team scans, User.billing_team read, slug→Team UPDATEs, round-trip snapshot, and the orphan LEFT JOIN via qb.
- v01: scratch-table read via pypika Table; raw_table_exists via frappe.db.get_tables() instead of an information_schema query.
- test_team_migration: plant legacy slugs via qb.update().

Only frappe.db.sql_ddl (CREATE/DROP/ALTER TABLE) remains — DDL has no query builder equivalent. The test_hardening guard against interpolated db.sql stays.

