### PR TITLE
billing: Title-case all Select option values

### DIFF
--- a/central/billing/api/admin/_shared.py
+++ b/central/billing/api/admin/_shared.py
@@ -13,7 +13,7 @@ _BILLABLE_LIVE = ("Open", "Paid", "Overdue")
 # Teams bill in mixed currencies; normalise revenue to INR for one comparable axis.
 _FX_TO_INR = {"INR": 1.0, "EUR": 90.0, "USD": 83.0}
 _MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
-_STANDING_RANK = {"current": 0, "past_due": 1, "suspended": 2}
+_STANDING_RANK = {"Current": 0, "Past Due": 1, "Suspended": 2}
 
 
 def _period_filter(field, from_date, to_date):

--- a/central/billing/api/admin/catalog.py
+++ b/central/billing/api/admin/catalog.py
@@ -121,7 +121,7 @@ def get_trial_detail() -> dict:
 
 	entry = entry_tier()
 	invoices = frappe.get_all(
-		"Invoice", filters={"invoice_type": "cost_report"},
+		"Invoice", filters={"invoice_type": "Cost Report"},
 		fields=["name", "team", "subtotal", "currency", "period_start", "period_end"],
 		order_by="period_start desc",
 	)
@@ -160,7 +160,7 @@ def get_trial_costs_detail() -> dict:
 
 	entry = entry_tier()
 	unconverted, converted = 0.0, 0.0
-	for inv in frappe.get_all("Invoice", filters={"invoice_type": "cost_report"}, fields=["team", "subtotal"]):
+	for inv in frappe.get_all("Invoice", filters={"invoice_type": "Cost Report"}, fields=["team", "subtotal"]):
 		tier = frappe.db.get_value("Trust Tier", inv.team, "tier")
 		if tier == entry:
 			unconverted += frappe.utils.flt(inv.subtotal)

--- a/central/billing/api/admin/revenue.py
+++ b/central/billing/api/admin/revenue.py
@@ -22,7 +22,7 @@ def get_summary(from_date: str | None = None, to_date: str | None = None) -> dic
 	require_operator()
 	invoices = frappe.get_all(
 		"Invoice",
-		filters=[["invoice_type", "=", "billable"]] + _period_filter("period_start", from_date, to_date),
+		filters=[["invoice_type", "=", "Billable"]] + _period_filter("period_start", from_date, to_date),
 		fields=["status", "total", "amount_paid", "currency"],
 	)
 	billed = sum(_to_inr(i.total, i.currency) for i in invoices)
@@ -55,7 +55,7 @@ def get_revenue_trend(months: int = 12) -> list[dict]:
 	buckets = {}
 	for inv in frappe.get_all(
 		"Invoice",
-		filters={"invoice_type": "billable"},
+		filters={"invoice_type": "Billable"},
 		fields=["period_start", "total", "amount_paid", "currency"],
 	):
 		if not inv.period_start:
@@ -83,7 +83,7 @@ def get_cluster_breakdown(from_date: str | None = None, to_date: str | None = No
 	require_operator()
 	invoices = frappe.get_all(
 		"Invoice",
-		filters=[["invoice_type", "=", "billable"]] + _period_filter("period_start", from_date, to_date),
+		filters=[["invoice_type", "=", "Billable"]] + _period_filter("period_start", from_date, to_date),
 		pluck="name",
 	)
 	if not invoices:
@@ -103,7 +103,7 @@ def get_team_breakdown(from_date: str | None = None, to_date: str | None = None)
 	totals = {}
 	for i in frappe.get_all(
 		"Invoice",
-		filters=[["invoice_type", "=", "billable"]] + _period_filter("period_start", from_date, to_date),
+		filters=[["invoice_type", "=", "Billable"]] + _period_filter("period_start", from_date, to_date),
 		fields=["team", "total"],
 	):
 		totals[i.team] = totals.get(i.team, 0) + frappe.utils.flt(i.total)
@@ -125,9 +125,9 @@ def get_payment_analytics(from_date: str | None = None, to_date: str | None = No
 	for a in attempts:
 		g = by_gateway.setdefault(a.gateway or "unknown", {"total": 0, "captured": 0})
 		g["total"] += 1
-		if a.status == "captured":
+		if a.status == "Captured":
 			g["captured"] += 1
-		elif a.status == "failed":
+		elif a.status == "Failed":
 			failure_reasons[a.failure_code or "unknown"] = failure_reasons.get(a.failure_code or "unknown", 0) + 1
 	for g in by_gateway.values():
 		g["success_rate"] = round(g["captured"] / g["total"], 3) if g["total"] else 0
@@ -142,7 +142,7 @@ def get_overdue_aging(now: str | None = None) -> dict:
 	buckets = {label: {"count": 0, "amount": 0.0} for label, _lo, _hi in AGING_BUCKETS}
 	for inv in frappe.get_all(
 		"Invoice",
-		filters=[["status", "in", ["Open", "Overdue"]], ["invoice_type", "=", "billable"]],
+		filters=[["status", "in", ["Open", "Overdue"]], ["invoice_type", "=", "Billable"]],
 		fields=["total", "amount_paid", "due_date"],
 	):
 		if not inv.due_date:
@@ -165,7 +165,7 @@ def get_free_trial_costs(from_date: str | None = None, to_date: str | None = Non
 	require_operator()
 	invoices = frappe.get_all(
 		"Invoice",
-		filters=[["invoice_type", "=", "cost_report"]] + _period_filter("period_start", from_date, to_date),
+		filters=[["invoice_type", "=", "Cost Report"]] + _period_filter("period_start", from_date, to_date),
 		fields=["name", "subtotal"],
 	)
 	total = sum(frappe.utils.flt(i.subtotal) for i in invoices)
@@ -194,7 +194,7 @@ def list_all_invoices(status: str = None, team: str = None, limit: int = 500) ->
 	pseudo-filters `outstanding` (Open+Overdue) and `paid`.
 	"""
 	require_operator()
-	filters = {"invoice_type": "billable"}
+	filters = {"invoice_type": "Billable"}
 	if team:
 		filters["team"] = team
 	if status == "outstanding":

--- a/central/billing/api/admin/teams.py
+++ b/central/billing/api/admin/teams.py
@@ -51,12 +51,12 @@ def get_retention() -> dict:
 	require_operator()
 	standing = {}
 	for s in frappe.get_all("Subscription", fields=["team", "account_standing"]):
-		cur = standing.get(s.team, "current")
+		cur = standing.get(s.team, "Current")
 		standing[s.team] = s.account_standing if _STANDING_RANK.get(s.account_standing, 0) > _STANDING_RANK.get(cur, 0) else cur
 	total = len(standing)
-	active = sum(1 for v in standing.values() if v == "current")
-	at_risk = sum(1 for v in standing.values() if v == "past_due")
-	churned = sum(1 for v in standing.values() if v == "suspended")
+	active = sum(1 for v in standing.values() if v == "Current")
+	at_risk = sum(1 for v in standing.values() if v == "Past Due")
+	churned = sum(1 for v in standing.values() if v == "Suspended")
 	rows = [{"team": t, "standing": v} for t, v in sorted(standing.items())]
 	return {
 		"total_teams": total,
@@ -79,18 +79,18 @@ def get_metrics() -> dict:
 	teams, mrr = {}, 0.0
 	for s in subs:
 		rate = _plan_monthly_inr(s.plan, s.cluster)
-		mrr += rate / 12 if s.billing_cycle == "annual" else rate
-		cur = teams.get(s.team, "current")
+		mrr += rate / 12 if s.billing_cycle == "Annual" else rate
+		cur = teams.get(s.team, "Current")
 		teams[s.team] = s.account_standing if _STANDING_RANK.get(s.account_standing, 0) > _STANDING_RANK.get(cur, 0) else cur
 
-	on_time = sum(1 for st in teams.values() if st == "current")
+	on_time = sum(1 for st in teams.values() if st == "Current")
 	team_count = len(teams)
 	return {
 		"team_count": team_count,
 		"paying_on_time": on_time,
 		"delinquent": team_count - on_time,            # past_due or suspended
-		"suspended": sum(1 for st in teams.values() if st == "suspended"),
-		"payment_failures": frappe.db.count("Payment Attempt", {"status": "failed"}),
+		"suspended": sum(1 for st in teams.values() if st == "Suspended"),
+		"payment_failures": frappe.db.count("Payment Attempt", {"status": "Failed"}),
 		"mrr": frappe.utils.flt(mrr, 2),
 		"active_subscriptions": len(subs),
 	}
@@ -102,9 +102,9 @@ def list_teams() -> list[dict]:
 	require_operator()
 	teams = {}
 	for s in frappe.get_all("Subscription", fields=["team", "plan", "cluster", "account_standing", "billing_cycle"]):
-		t = teams.setdefault(s.team, {"team": s.team, "standing": "current", "mrr": 0.0, "subscriptions": 0, "resources": 0})
+		t = teams.setdefault(s.team, {"team": s.team, "standing": "Current", "mrr": 0.0, "subscriptions": 0, "resources": 0})
 		rate = _plan_monthly_inr(s.plan, s.cluster)
-		t["mrr"] += rate / 12 if s.billing_cycle == "annual" else rate
+		t["mrr"] += rate / 12 if s.billing_cycle == "Annual" else rate
 		t["subscriptions"] += 1
 		if _STANDING_RANK.get(s.account_standing, 0) > _STANDING_RANK.get(t["standing"], 0):
 			t["standing"] = s.account_standing
@@ -130,7 +130,7 @@ def get_payment_failures(limit: int = 50) -> list[dict]:
 	"""Drill-down: which charges are failing and why."""
 	require_operator()
 	return frappe.get_all(
-		"Payment Attempt", filters={"status": "failed"},
+		"Payment Attempt", filters={"status": "Failed"},
 		fields=["name", "team", "invoice", "amount", "currency", "gateway", "failure_code", "failure_reason", "creation"],
 		order_by="creation desc", limit=limit)
 
@@ -140,7 +140,7 @@ def get_delinquent_teams() -> list[dict]:
 	"""Drill-down: who is past_due/suspended + their outstanding invoices."""
 	require_operator()
 	seen, rows = set(), []
-	for s in frappe.get_all("Subscription", filters=[["account_standing", "in", ["past_due", "suspended"]]],
+	for s in frappe.get_all("Subscription", filters=[["account_standing", "in", ["Past Due", "Suspended"]]],
 			fields=["team", "account_standing"]):
 		if s.team in seen:
 			continue

--- a/central/billing/api/dashboard/_shared.py
+++ b/central/billing/api/dashboard/_shared.py
@@ -84,14 +84,14 @@ def _add_method_gateway(currency: str):
 		return frappe._dict()
 
 	gw = frappe.db.get_value("Payment Gateway", gw_name, ["name", "adapter_key"], as_dict=True)
-	if gw and gw.adapter_key == "razorpay":
+	if gw and gw.adapter_key == "Razorpay":
 		return gw
 
 	# The default gateway is not Razorpay — but if an enabled Razorpay gateway
 	# also handles this currency (non-default), prefer it for UPI.
 	rzp = frappe.db.get_value(
 		"Payment Gateway",
-		{"adapter_key": "razorpay", "is_enabled": 1},
+		{"adapter_key": "Razorpay", "is_enabled": 1},
 		["name", "adapter_key"],
 		as_dict=True,
 		order_by="creation asc",

--- a/central/billing/api/dashboard/account.py
+++ b/central/billing/api/dashboard/account.py
@@ -56,9 +56,9 @@ def get_billing_settings(team: str | None = None) -> dict:
 	"""Payment mode + thresholds (wireframe: Billing Settings)."""
 	team = _resolve_team(team)
 	if not frappe.db.exists("Billing Profile", team):
-		return {"team": team, "billing_mode": "postpaid", "min_balance": 0, "spend_alert_threshold": 0}
+		return {"team": team, "billing_mode": "Postpaid", "min_balance": 0, "spend_alert_threshold": 0}
 	p = frappe.get_doc("Billing Profile", team)
-	return {"team": team, "billing_mode": p.billing_mode or "postpaid",
+	return {"team": team, "billing_mode": p.billing_mode or "Postpaid",
 			"min_balance": p.min_balance, "spend_alert_threshold": p.spend_alert_threshold}
 
 
@@ -87,8 +87,8 @@ def get_team_overview(team: str | None = None) -> dict:
 	"""Team header: trust tier, account standing, payment mode, resource count."""
 	team = _resolve_team(team)
 	tier = frappe.db.get_value("Trust Tier", team, ["tier", "max_spend"], as_dict=True) or {}
-	standing = frappe.db.get_value("Subscription", {"team": team}, "account_standing") or "current"
-	mode = frappe.db.get_value("Billing Profile", team, "billing_mode") or "postpaid"
+	standing = frappe.db.get_value("Subscription", {"team": team}, "account_standing") or "Current"
+	mode = frappe.db.get_value("Billing Profile", team, "billing_mode") or "Postpaid"
 	resources = frappe.db.count("Price Lock", {"team": team, "ended_at": ["is", "not set"]})
 	clusters = len(_team_clusters(team))
 	currency = _team_currency(team)
@@ -123,8 +123,8 @@ def get_trust_tier(team: str | None = None) -> dict:
 
 	# Progress signals toward the next level.
 	resources_used = frappe.db.count("Price Lock", {"team": team, "ended_at": ["is", "not set"]})
-	paid_invoices = frappe.db.count("Invoice", {"team": team, "status": "Paid", "invoice_type": "billable"})
-	paid_rows = frappe.get_all("Invoice", {"team": team, "status": "Paid", "invoice_type": "billable"},
+	paid_invoices = frappe.db.count("Invoice", {"team": team, "status": "Paid", "invoice_type": "Billable"})
+	paid_rows = frappe.get_all("Invoice", {"team": team, "status": "Paid", "invoice_type": "Billable"},
 							   ["amount_paid", "currency"])
 	cumulative_paid_inr = sum(frappe.utils.flt(r.amount_paid) * _FX_TO_INR.get(r.currency, 1.0) for r in paid_rows)
 
@@ -161,5 +161,5 @@ def list_switchable_teams() -> list[dict]:
 	out = []
 	for t in teams:
 		out.append({"team": t, "tier": frappe.db.get_value("Trust Tier", t, "tier"),
-					"standing": frappe.db.get_value("Subscription", {"team": t}, "account_standing") or "current"})
+					"standing": frappe.db.get_value("Subscription", {"team": t}, "account_standing") or "Current"})
 	return out

--- a/central/billing/api/dashboard/invoices.py
+++ b/central/billing/api/dashboard/invoices.py
@@ -44,7 +44,7 @@ def get_forecast(team: str | None = None) -> dict:
 	tax = resolve_tax(team, subtotal)
 	projected_total = frappe.utils.flt(subtotal + tax["output_tax_amount"], 2)
 	credit_balance = frappe.utils.flt(credits.get_balance(team)["balance"])
-	mode = frappe.db.get_value("Billing Profile", team, "billing_mode") or "postpaid"
+	mode = frappe.db.get_value("Billing Profile", team, "billing_mode") or "Postpaid"
 	shortfall = max(0.0, frappe.utils.flt(projected_total - credit_balance, 2))
 	currency = frappe.db.get_value("Price Lock", {"team": team}, "currency") or "INR"
 
@@ -61,7 +61,7 @@ def get_forecast(team: str | None = None) -> dict:
 		"billing_mode": mode,
 		"currency": currency,
 		# On prepaid, warn when the projected bill outruns the wallet.
-		"credit_alert": mode == "prepaid" and shortfall > 0,
+		"credit_alert": mode == "Prepaid" and shortfall > 0,
 		# Spell out each service/plan + metered overage driving the projection.
 		"line_items": [_describe_line(team, frappe._dict(li)) for li in line_items],
 	}
@@ -186,7 +186,7 @@ def create_topup_order(team: str | None = None, amount: float | None = None,
 	adapter = get_adapter(gw_doc)
 	receipt = f"topup-{team}-{frappe.generate_hash(8)}"
 	notes = {"team": team, "purpose": "wallet_topup"}
-	if gw_doc.adapter_key == "stripe":
+	if gw_doc.adapter_key == "Stripe":
 		# Hosted Stripe Checkout: the SPA redirects out and returns to /billing/credits,
 		# which confirms the session. Stripe fills in {CHECKOUT_SESSION_ID}.
 		from urllib.parse import quote
@@ -218,7 +218,7 @@ def confirm_topup(team: str | None = None, amount: float | None = None, gateway:
 
 	gw_doc = frappe.get_doc("Payment Gateway", gateway)
 	adapter = get_adapter(gw_doc)
-	if gw_doc.adapter_key == "razorpay":
+	if gw_doc.adapter_key == "Razorpay":
 		ok = adapter.verify_payment_signature({
 			"razorpay_order_id": razorpay_order_id,
 			"razorpay_payment_id": razorpay_payment_id,

--- a/central/billing/api/dashboard/methods.py
+++ b/central/billing/api/dashboard/methods.py
@@ -21,7 +21,7 @@ def list_payment_methods(team: str | None = None) -> list[dict]:
 	team = _resolve_team(team)
 	return frappe.get_all(
 		"Payment Method",
-		filters={"team": team, "status": ["!=", "cancelled"]},
+		filters={"team": team, "status": ["!=", "Cancelled"]},
 		fields=["name", "method_type", "status", "display_label", "is_default", "priority",
 				"reauth_required", "expiry_month", "expiry_year"],
 		order_by="priority asc, creation asc",
@@ -37,21 +37,21 @@ def get_payment_method_options(team: str | None = None) -> dict:
 	currency = _team_currency(team)
 	gw = _add_method_gateway(currency)
 
-	if gw.get("adapter_key") == "razorpay":
+	if gw.get("adapter_key") == "Razorpay":
 		from central.billing.payments import mandates
 
 		elig = mandates.upi_eligibility(team)
-		return {"gateway": gw.name, "adapter_key": "razorpay", "currency": currency,
-				"methods": ["card", "upi_autopay"], "allow_upi": elig["eligible"],
+		return {"gateway": gw.name, "adapter_key": "Razorpay", "currency": currency,
+				"methods": ["Card", "UPI Autopay"], "allow_upi": elig["eligible"],
 				"upi_block_reason": elig["reason"], "upi_limit": elig["limit"]}
 
 	publishable_key = None
-	if gw.get("adapter_key") == "stripe":
+	if gw.get("adapter_key") == "Stripe":
 		from central.billing.gateways.registry import get_adapter
 
 		publishable_key = get_adapter(frappe.get_doc("Payment Gateway", gw.name)).get_credential("api_key")
 	return {"gateway": gw.get("name"), "adapter_key": gw.get("adapter_key"), "currency": currency,
-			"methods": ["card"], "allow_upi": False, "upi_block_reason": None, "upi_limit": None,
+			"methods": ["Card"], "allow_upi": False, "upi_block_reason": None, "upi_limit": None,
 			"publishable_key": publishable_key}
 
 
@@ -90,18 +90,18 @@ def add_demo_card(team: str | None = None, gateway: str | None = None,
 	from central.billing.payments import payments
 
 	name = frappe.get_doc({
-		"doctype": "Payment Method", "team": team, "gateway": gateway, "method_type": "card",
-		"status": "active", "display_label": display_label, "gateway_method_id": f"pm_{frappe.generate_hash(6)}",
+		"doctype": "Payment Method", "team": team, "gateway": gateway, "method_type": "Card",
+		"status": "Active", "display_label": display_label, "gateway_method_id": f"pm_{frappe.generate_hash(6)}",
 		"gateway_customer_id": f"cus_{team}", "expiry_month": expiry_month, "expiry_year": expiry_year,
 		"validated_at": frappe.utils.now_datetime(),
 	}).insert(ignore_permissions=True).name
 	payments.densify_priorities(team)  # append at the end of the fallback order
-	return {"payment_method": name, "status": "active"}
+	return {"payment_method": name, "status": "Active"}
 
 
 @frappe.whitelist()
 def setup_payment_method_order(team: str | None = None, gateway: str | None = None,
-							   method_type: str = "upi_autopay") -> dict:
+							   method_type: str = "UPI Autopay") -> dict:
 	"""Begin adding a Razorpay recurring method — UPI Autopay mandate (ceiling =
 	trust-tier cap) or a card token. Returns the order handles the UI runs
 	Razorpay Checkout against (#08)."""
@@ -109,7 +109,7 @@ def setup_payment_method_order(team: str | None = None, gateway: str | None = No
 	gw = gateway or _add_method_gateway(_team_currency(team)).get("name")
 	from central.billing.payments import mandates
 
-	if method_type == "card":
+	if method_type == "Card":
 		return mandates.setup_card(team, gw)
 	return mandates.setup_mandate(team, gw)
 

--- a/central/billing/catalog/plans.py
+++ b/central/billing/catalog/plans.py
@@ -27,9 +27,9 @@ def configure_includes(vcpu: float, ratio: str = "1:2", disk_gb: float = 0, memo
 		frappe.throw(f"Unknown memory ratio {ratio!r}; expected one of {sorted(RATIO_FACTORS)}.")
 	memory = frappe.utils.flt(memory_gb) if memory_gb is not None else frappe.utils.flt(vcpu * RATIO_FACTORS[ratio])
 	return [
-		{"resource_type": "compute", "quantity": vcpu, "unit": "vCPU"},
-		{"resource_type": "memory", "quantity": memory, "unit": "GB"},
-		{"resource_type": "disk", "quantity": frappe.utils.flt(disk_gb), "unit": "GB"},
+		{"resource_type": "Compute", "quantity": vcpu, "unit": "vCPU"},
+		{"resource_type": "Memory", "quantity": memory, "unit": "GB"},
+		{"resource_type": "Disk", "quantity": frappe.utils.flt(disk_gb), "unit": "GB"},
 	]
 
 
@@ -41,7 +41,7 @@ def create_configured_plan(
 	ratio: str = "1:2",
 	disk_gb: float = 0,
 	memory_gb: float | None = None,
-	billing_cycle: str = "monthly",
+	billing_cycle: str = "Monthly",
 ) -> str:
 	"""Create a bundle Plan from configurator inputs; return its name.
 

--- a/central/billing/catalog/subscriptions.py
+++ b/central/billing/catalog/subscriptions.py
@@ -25,16 +25,16 @@ class InvalidTransition(frappe.ValidationError):
 # past_due (grace) — never a direct current -> suspended jump; reactivation
 # returns to current from either past_due or suspended.
 _STANDING_TRANSITIONS = {
-	"current": {"past_due"},
-	"past_due": {"current", "suspended"},
-	"suspended": {"current"},
+	"Current": {"Past Due"},
+	"Past Due": {"Current", "Suspended"},
+	"Suspended": {"Current"},
 }
 
 # The Subscription Change type that records a move *into* a standing.
 _STANDING_CHANGE_TYPE = {
-	"past_due": "past_due",
-	"suspended": "suspended",
-	"current": "reactivated",
+	"Past Due": "Past Due",
+	"Suspended": "Suspended",
+	"Current": "Reactivated",
 }
 
 
@@ -57,7 +57,7 @@ def create_subscription(
 	team: str,
 	cluster: str,
 	plan: str,
-	billing_cycle: str = "monthly",
+	billing_cycle: str = "Monthly",
 	start_date=None,
 	default_payment_method: str | None = None,
 	gateway: str | None = None,
@@ -73,14 +73,14 @@ def create_subscription(
 			"cluster": cluster,
 			"plan": plan,
 			"billing_cycle": billing_cycle,
-			"account_standing": "current",
+			"account_standing": "Current",
 			"start_date": start_date or frappe.utils.nowdate(),
 			"default_payment_method": default_payment_method,
 			"gateway": gateway,
 		}
 	).insert(ignore_permissions=True)
 
-	_record_change(doc.name, "created", new_value=plan, changed_by=changed_by)
+	_record_change(doc.name, "Created", new_value=plan, changed_by=changed_by)
 	return doc
 
 
@@ -93,7 +93,7 @@ def change_plan(subscription: str, new_plan: str, changed_by: str | None = None)
 		return doc
 	doc.plan = new_plan
 	doc.save(ignore_permissions=True)
-	_record_change(subscription, "plan_changed", old_plan, new_plan, changed_by)
+	_record_change(subscription, "Plan Changed", old_plan, new_plan, changed_by)
 	return doc
 
 
@@ -102,7 +102,7 @@ def change_payment_method(subscription: str, new_method: str, changed_by: str | 
 	old_method = doc.default_payment_method
 	doc.default_payment_method = new_method
 	doc.save(ignore_permissions=True)
-	_record_change(subscription, "payment_method_changed", old_method, new_method, changed_by)
+	_record_change(subscription, "Payment Method Changed", old_method, new_method, changed_by)
 	return doc
 
 
@@ -110,7 +110,7 @@ def cancel_subscription(subscription: str, changed_by: str | None = None):
 	"""Cancel the subscription intent. The contract record is kept; the
 	cancellation is logged. Stopping/terminating running resources is a separate
 	operational concern owned by the Agent."""
-	_record_change(subscription, "cancelled", changed_by=changed_by)
+	_record_change(subscription, "Cancelled", changed_by=changed_by)
 	return frappe.get_doc("Subscription", subscription)
 
 

--- a/central/billing/catalog/trials.py
+++ b/central/billing/catalog/trials.py
@@ -32,7 +32,7 @@ def is_trial_team(team: str) -> bool:
 
 def invoice_type_for(team: str) -> str:
 	"""`cost_report` for entry-tier teams, `billable` otherwise."""
-	return "cost_report" if is_trial_team(team) else "billable"
+	return "Cost Report" if is_trial_team(team) else "Billable"
 
 
 def convert_to_paid(team: str, level: str | None = None):
@@ -89,7 +89,7 @@ def expire_trial(team: str, cluster_slices: dict | None = None) -> dict:
 	from central.billing.platform import notifications
 	from central.billing.catalog.entitlements import issue_token
 
-	notifications.notify(team, "trial_expiring", context={})
+	notifications.notify(team, "Trial Expiring", context={})
 	return issue_token(team, cluster_slices or {}, suspend=True)
 
 
@@ -99,7 +99,7 @@ def subsidy_total(from_date=None, to_date=None) -> float:
 	The true cost-to-company of non-paying teams; surfaced on the admin
 	dashboard (#19).
 	"""
-	filters = [["invoice_type", "=", "cost_report"]]
+	filters = [["invoice_type", "=", "Cost Report"]]
 	if from_date:
 		filters.append(["period_start", ">=", from_date])
 	if to_date:

--- a/central/billing/demo/_factory.py
+++ b/central/billing/demo/_factory.py
@@ -75,19 +75,19 @@ def _catalog():
 				rate = round(base_inr * CLUSTER_MULT[cslug] / FX[currency], 2)
 				rates.append({"cluster": cslug, "currency": currency, "rate": rate})
 		plan = _upsert("Plan", slug, {
-			"title": title, "billing_cycle": "monthly", "is_active": 1,
+			"title": title, "billing_cycle": "Monthly", "is_active": 1,
 			"includes": [
-				{"resource_type": "compute", "quantity": vcpu, "unit": "vCPU"},
-				{"resource_type": "memory", "quantity": ram, "unit": "GB"},
-				{"resource_type": "disk", "quantity": disk, "unit": "GB"},
-				{"resource_type": "transfer", "quantity": transfer, "unit": "GB"},
+				{"resource_type": "Compute", "quantity": vcpu, "unit": "vCPU"},
+				{"resource_type": "Memory", "quantity": ram, "unit": "GB"},
+				{"resource_type": "Disk", "quantity": disk, "unit": "GB"},
+				{"resource_type": "Transfer", "quantity": transfer, "unit": "GB"},
 			],
 		}, newname=True)
 		set_catalog_rates("Plan", plan, rates)
 
 	addon = _upsert("Add-on", ADDON, {
-		"title": "Bandwidth Overage", "resource_type": "transfer", "unit": "GB",
-		"billing_type": "metered", "billing_interval": "monthly",
+		"title": "Bandwidth Overage", "resource_type": "Transfer", "unit": "GB",
+		"billing_type": "Metered", "billing_interval": "Monthly",
 	}, newname=True)
 	set_catalog_rates(
 		"Add-on", addon, [{"cluster": "", "currency": c, "rate": ADDON_RATE[c]} for c in CURRENCIES]
@@ -100,12 +100,12 @@ def _gateways():
 	seed = {"skip_credential_validation": True}
 	for currency, name in STRIPE.items():
 		_upsert("Payment Gateway", name, {
-			"title": f"Stripe ({currency})", "adapter_key": "stripe",
+			"title": f"Stripe ({currency})", "adapter_key": "Stripe",
 			"api_secret": "sk_test_demo", "webhook_secret": "whsec_demo", "is_enabled": 1,
 			"currencies": [{"currency": currency, "is_default": 1}],
 		}, newname=True, flags=seed)
 	_upsert("Payment Gateway", RAZORPAY, {
-		"title": "Razorpay (India)", "adapter_key": "razorpay",
+		"title": "Razorpay (India)", "adapter_key": "Razorpay",
 		"api_key": "rzp_test", "api_secret": "rzp_secret", "webhook_secret": "rzp_whsec",
 		"is_enabled": 1, "supports_mandates": 1,
 		"currencies": [{"currency": "INR", "is_default": 1}],
@@ -136,7 +136,7 @@ def _profile(team, slug, currency, cluster, prepaid):
 		"address_line1": "1 Demo Street", "city": region.split("—")[-1].strip(),
 		"state": "Maharashtra" if india else "", "country": "India" if india else region.split("—")[0].strip(),
 		"pincode": "400001" if india else "",
-		"billing_mode": "prepaid" if prepaid else "postpaid",
+		"billing_mode": "Prepaid" if prepaid else "Postpaid",
 	})
 
 
@@ -148,7 +148,7 @@ def _payment_setup(team, slug, currency, state):
 		# An INR team on UPI Autopay (mandate ceiling = tier cap).
 		pm = frappe.get_doc({
 			"doctype": "Payment Method", "team": team, "gateway": RAZORPAY,
-			"method_type": "upi_autopay", "status": "active", "display_label": "UPI Autopay",
+			"method_type": "UPI Autopay", "status": "Active", "display_label": "UPI Autopay",
 			"gateway_method_id": f"token_{slug}", "gateway_customer_id": f"cust_{slug}",
 			"mandate_max_amount": 200000, "mandate_currency": "INR", "is_default": 1,
 			"validated_at": frappe.utils.now_datetime(),
@@ -156,8 +156,8 @@ def _payment_setup(team, slug, currency, state):
 		return RAZORPAY, pm
 	gateway = STRIPE[currency]
 	pm = frappe.get_doc({
-		"doctype": "Payment Method", "team": team, "gateway": gateway, "method_type": "card",
-		"status": "active", "display_label": "Visa ····4242", "gateway_method_id": f"pm_{slug}",
+		"doctype": "Payment Method", "team": team, "gateway": gateway, "method_type": "Card",
+		"status": "Active", "display_label": "Visa ····4242", "gateway_method_id": f"pm_{slug}",
 		"gateway_customer_id": f"cus_{slug}", "expiry_month": 11, "expiry_year": 2030,
 		"is_default": 1, "validated_at": frappe.utils.now_datetime(),
 	}).insert(ignore_permissions=True).name
@@ -168,7 +168,7 @@ def _failed_attempt(team, invoice, pm, gateway, retry):
 	frappe.get_doc({
 		"doctype": "Payment Attempt", "invoice": invoice, "team": team, "gateway": gateway,
 		"payment_method": pm, "amount": frappe.db.get_value("Invoice", invoice, "expected_collection"),
-		"currency": frappe.db.get_value("Invoice", invoice, "currency"), "status": "failed",
+		"currency": frappe.db.get_value("Invoice", invoice, "currency"), "status": "Failed",
 		"failure_code": "card_declined", "failure_reason": "Your card was declined.",
 		"retry_number": retry, "completed_at": frappe.utils.now_datetime(),
 	}).insert(ignore_permissions=True)

--- a/central/billing/demo/demo.py
+++ b/central/billing/demo/demo.py
@@ -33,7 +33,7 @@ def seed():
 	_tier_and_tax()
 	card = _payment_method()
 	sub = subscriptions.create_subscription(
-		team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="monthly"
+		team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="Monthly"
 	).name
 
 	# Runtime from 1 May: a full May (paid) and a partial-changed June (open).
@@ -79,8 +79,8 @@ def _event(event_id, resource_id, rate, effective_from, event_type):
 def _meter(qty):
 	return {
 		"resource_id": RESOURCE,
-		"resource_type": "transfer",
-		"meter_type": "counter",
+		"resource_type": "Transfer",
+		"meter_type": "Counter",
 		"period_start": "2026-06-01 00:00:00",
 		"period_end": "2026-06-30 23:59:59",
 		"quantity": qty,
@@ -96,13 +96,13 @@ def _catalog():
 		PLAN,
 		{
 			"title": "2 vCPU Bundle",
-			"billing_cycle": "monthly",
+			"billing_cycle": "Monthly",
 			"is_active": 1,
 			"includes": [
-				{"resource_type": "compute", "quantity": 2, "unit": "vCPU"},
-				{"resource_type": "memory", "quantity": 4, "unit": "GB"},
-				{"resource_type": "disk", "quantity": 80, "unit": "GB"},
-				{"resource_type": "transfer", "quantity": 100, "unit": "GB"},
+				{"resource_type": "Compute", "quantity": 2, "unit": "vCPU"},
+				{"resource_type": "Memory", "quantity": 4, "unit": "GB"},
+				{"resource_type": "Disk", "quantity": 80, "unit": "GB"},
+				{"resource_type": "Transfer", "quantity": 100, "unit": "GB"},
 			],
 		},
 	)
@@ -119,10 +119,10 @@ def _catalog():
 		ADDON,
 		{
 			"title": "Bandwidth Overage",
-			"resource_type": "transfer",
+			"resource_type": "Transfer",
 			"unit": "GB",
-			"billing_type": "metered",
-			"billing_interval": "monthly",
+			"billing_type": "Metered",
+			"billing_interval": "Monthly",
 		},
 	)
 	set_catalog_rates("Add-on", addon, [{"cluster": "", "currency": "INR", "rate": 0.8}])
@@ -134,7 +134,7 @@ def _gateway():
 		GATEWAY,
 		{
 			"title": "Stripe (Demo)",
-			"adapter_key": "stripe",
+			"adapter_key": "Stripe",
 			"currencies": [{"currency": "INR", "is_default": 1}],
 			"api_secret": "sk_test_demo",
 			"webhook_secret": "whsec_demo",
@@ -178,8 +178,8 @@ def _payment_method():
 		"doctype": "Payment Method",
 		"team": TEAM,
 		"gateway": GATEWAY,
-		"method_type": "card",
-		"status": "active",
+		"method_type": "Card",
+		"status": "Active",
 		"display_label": "Visa ····4242",
 		"gateway_method_id": "pm_demo",
 		"gateway_customer_id": "cus_demo",
@@ -273,7 +273,7 @@ def _ensure_workspace():
 	for label, _dt, _color in shortcuts:
 		content.append({"type": "shortcut", "data": {"shortcut_name": label, "col": 3}})
 	for card_name in cards:
-		content.append({"type": "card", "data": {"card_name": card_name, "col": 4}})
+		content.append({"type": "Card", "data": {"card_name": card_name, "col": 4}})
 
 	frappe.get_doc(
 		{

--- a/central/billing/demo/demo_scenarios.py
+++ b/central/billing/demo/demo_scenarios.py
@@ -51,20 +51,20 @@ from central.billing.demo._factory import (
 #                 style: any plan in any region, capped by the tier. A team bills
 #                 in ONE currency regardless of where its instances run.
 TEAMS = [
-	("acme-corp", "t3", "INR", 9, "grandfathered", [
+	("acme-corp", "t3", "INR", 9, "Grandfathered", [
 		("in-mumbai", "plan-8vcpu"), ("in-mumbai", "plan-2vcpu"),
 		("eu-frankfurt", "plan-4vcpu"), ("me-dubai", "plan-1vcpu")]),
-	("globex", "t3", "EUR", 9, "active", [
+	("globex", "t3", "EUR", 9, "Active", [
 		("eu-frankfurt", "plan-16vcpu"), ("eu-frankfurt", "plan-4vcpu"),
 		("in-mumbai", "plan-2vcpu")]),
-	("initech", "t2", "USD", 5, "active", [
+	("initech", "t2", "USD", 5, "Active", [
 		("me-dubai", "plan-4vcpu"), ("me-dubai", "plan-1vcpu"), ("eu-frankfurt", "plan-2vcpu")]),
-	("umbrella", "t2", "INR", 5, "active", [            # INR billing, EU + India
+	("umbrella", "t2", "INR", 5, "Active", [            # INR billing, EU + India
 		("eu-frankfurt", "plan-4vcpu"), ("in-mumbai", "plan-2vcpu")]),
-	("wayne-ent", "t2", "INR", 5, "active", [           # INR billing, ME + India
+	("wayne-ent", "t2", "INR", 5, "Active", [           # INR billing, ME + India
 		("me-dubai", "plan-2vcpu"), ("in-mumbai", "plan-1vcpu")]),
 	("stark-ind", "t1", "INR", 1, "overdue", [("in-mumbai", "plan-2vcpu")]),
-	("cyberdyne", "t1", "EUR", 1, "suspended", [("eu-frankfurt", "plan-2vcpu")]),
+	("cyberdyne", "t1", "EUR", 1, "Suspended", [("eu-frankfurt", "plan-2vcpu")]),
 	("hooli", "t1", "INR", 1, "credits", [("in-mumbai", "plan-1vcpu")]),
 	("soylent", "t1", "USD", 1, "refund", [("me-dubai", "plan-2vcpu")]),
 	("piedpiper", "t0", "INR", 0, "trial", [("in-mumbai", "plan-1vcpu")]),
@@ -120,17 +120,17 @@ def _build_team(team, slug, tier, currency, months, state, resources):
 			idx += 1
 			resource = f"srv-{slug}-{idx}"
 			catalog = frappe.get_doc("Plan", plan).get_rate(currency, cluster)
-			rate = round(catalog * 0.78, 2) if (state == "grandfathered" and idx == 1) else catalog
+			rate = round(catalog * 0.78, 2) if (state == "Grandfathered" and idx == 1) else catalog
 			receive_usage_events([{
 				"event_id": f"ev-{slug}-{idx}", "team": team, "resource_id": resource,
 				"cluster": cluster, "plan": plan, "shown_rate": rate, "currency": currency,
 				"event_type": "subscribed", "effective_from": f"{first_start} 00:00:00", "effective_to": None,
 			}])
 			# A metered bandwidth overage on the first active instance.
-			if idx == 1 and state in ("grandfathered", "active", "credits"):
+			if idx == 1 and state in ("Grandfathered", "Active", "credits"):
 				allowance = next(p[5] for p in PLAN_SIZES if p[0] == plan)
 				receive_meter_rollups([{
-					"resource_id": resource, "resource_type": "transfer", "meter_type": "counter",
+					"resource_id": resource, "resource_type": "Transfer", "meter_type": "Counter",
 					"period_start": f"{ANCHOR} 00:00:00", "period_end": "2026-06-30 23:59:59",
 					"quantity": round(allowance * 1.25), "unit": "GB",
 					"idempotency_key": f"{resource}:counter:{ANCHOR}", "status": "closed",
@@ -143,7 +143,7 @@ def _build_team(team, slug, tier, currency, months, state, resources):
 	subs = []
 	for cluster, plans in by_cluster.items():
 		subs.append(subscriptions.create_subscription(
-			team=team, cluster=cluster, plan=plans[0], billing_cycle="monthly",
+			team=team, cluster=cluster, plan=plans[0], billing_cycle="Monthly",
 			default_payment_method=pm, gateway=gateway,
 		).name)
 	primary_sub = subs[0]
@@ -181,31 +181,31 @@ def _finish_current_month(team, sub, currency, state, pm, gateway):
 
 	if state == "overdue":
 		frappe.db.set_value("Invoice", inv, {"status": "Overdue", "due_date": "2026-06-01", "amount_paid": 0})
-		_set_team_standing(team, "past_due")
+		_set_team_standing(team, "Past Due")
 		for n in range(3):
 			_failed_attempt(team, inv, pm, gateway, n)
-			notifications.notify(team, "payment_retry",
+			notifications.notify(team, "Payment Retry",
 				message=f"Payment retry {n + 1} for {inv} failed: card_declined",
 				reference_doctype="Invoice", reference_name=inv)
-		notifications.notify(team, "invoice_overdue", context={"invoice": inv},
+		notifications.notify(team, "Invoice Overdue", context={"invoice": inv},
 			reference_doctype="Invoice", reference_name=inv)
 		return "Overdue + past_due + 3 failed retries"
 
-	if state == "suspended":
+	if state == "Suspended":
 		frappe.db.set_value("Invoice", inv, {"status": "Overdue", "due_date": "2026-05-20", "amount_paid": 0})
-		_set_team_standing(team, "past_due")
+		_set_team_standing(team, "Past Due")
 		# Suspension follows EXHAUSTED dunning — the card on file was charged and
 		# declined on each retry. Those attempts are non-negotiable history.
 		for n in range(3):
 			_failed_attempt(team, inv, pm, gateway, n)
-			notifications.notify(team, "payment_retry",
+			notifications.notify(team, "Payment Retry",
 				message=f"Payment retry {n + 1} for {inv} failed: card_declined",
 				reference_doctype="Invoice", reference_name=inv)
-		_set_team_standing(team, "suspended")
+		_set_team_standing(team, "Suspended")
 		from central.billing.catalog.entitlements import issue_token
 
 		issue_token(team, {}, suspend=True)
-		notifications.notify(team, "invoice_overdue", context={"invoice": inv},
+		notifications.notify(team, "Invoice Overdue", context={"invoice": inv},
 			reference_doctype="Invoice", reference_name=inv)
 		return "Suspended + 3 failed retries + cap-0 suspend token"
 
@@ -220,13 +220,13 @@ def _finish_current_month(team, sub, currency, state, pm, gateway):
 		frappe.db.set_value("Invoice", inv, {"status": "Paid", "amount_paid": total, "due_date": "2026-07-07"})
 		attempt = frappe.get_doc({
 			"doctype": "Payment Attempt", "invoice": inv, "team": team, "gateway": gateway,
-			"payment_method": pm, "amount": total, "currency": currency, "status": "captured",
-			"gateway_transaction_id": f"pi_{team}", "resolved_by": "webhook",
+			"payment_method": pm, "amount": total, "currency": currency, "status": "Captured",
+			"gateway_transaction_id": f"pi_{team}", "resolved_by": "Webhook",
 		}).insert(ignore_permissions=True).name
 		frappe.get_doc({
 			"doctype": "Refund", "payment_attempt": attempt, "invoice": inv, "team": team,
-			"amount": round(total * 0.1, 2), "currency": currency, "destination": "wallet",
-			"status": "completed", "reason": "Partial overcharge",
+			"amount": round(total * 0.1, 2), "currency": currency, "destination": "Wallet",
+			"status": "Completed", "reason": "Partial overcharge",
 			"created_at": frappe.utils.now_datetime(), "completed_at": frappe.utils.now_datetime(),
 		}).insert(ignore_permissions=True)
 		credits.refund_to_wallet(team, round(total * 0.1, 2), currency=currency,
@@ -235,4 +235,4 @@ def _finish_current_month(team, sub, currency, state, pm, gateway):
 
 	# active / grandfathered
 	frappe.db.set_value("Invoice", inv, {"status": "Open", "due_date": "2026-07-07"})
-	return "grandfathered (locked launch rate)" if state == "grandfathered" else "active, open current invoice"
+	return "grandfathered (locked launch rate)" if state == "Grandfathered" else "active, open current invoice"

--- a/central/billing/doctype/add_on/add_on.json
+++ b/central/billing/doctype/add_on/add_on.json
@@ -29,7 +29,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Resource Type",
-   "options": "compute\nmemory\ndisk\ntransfer\nip\nsnapshot",
+   "options": "Compute\nMemory\nDisk\nTransfer\nIP\nSnapshot",
    "reqd": 1
   },
   {
@@ -43,27 +43,27 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "metered",
+   "default": "Metered",
    "fieldname": "billing_type",
    "fieldtype": "Select",
    "label": "Billing Type",
-   "options": "fixed\nmetered",
+   "options": "Fixed\nMetered",
    "reqd": 1
   },
   {
    "fieldname": "pricing_mode",
    "fieldtype": "Select",
    "label": "Pricing Mode",
-   "options": "grandfathered\nlive",
-   "default": "grandfathered",
+   "options": "Grandfathered\nLive",
+   "default": "Grandfathered",
    "description": "grandfathered = rate locked at provision (like bundles). live = rate read from the current Catalog Rate each period, no allowance (depreciating storage, e.g. snapshot). See ADR 0002."
   },
   {
-   "default": "monthly",
+   "default": "Monthly",
    "fieldname": "billing_interval",
    "fieldtype": "Select",
    "label": "Billing Interval",
-   "options": "hourly\ndaily\nmonthly",
+   "options": "Hourly\nDaily\nMonthly",
    "reqd": 1
   }
  ],

--- a/central/billing/doctype/billing_notification_log/billing_notification_log.json
+++ b/central/billing/doctype/billing_notification_log/billing_notification_log.json
@@ -24,12 +24,12 @@
   {"fieldname": "team", "fieldtype": "Link", "options": "Team", "in_list_view": 1, "label": "Team", "reqd": 1},
   {
    "fieldname": "event_type", "fieldtype": "Select", "in_list_view": 1, "label": "Event Type",
-   "options": "payment_success\npayment_failure\npayment_retry\ninvoice_overdue\ncredit_low\ncard_expiry\nmandate_reauth\ntrial_expiring"
+   "options": "Payment Success\nPayment Failure\nPayment Retry\nInvoice Overdue\nCredit Low\nCard Expiry\nMandate Reauth\nTrial Expiring"
   },
   {"default": "email", "fieldname": "channel", "fieldtype": "Data", "label": "Channel"},
   {
-   "default": "sent", "fieldname": "status", "fieldtype": "Select", "in_list_view": 1,
-   "label": "Status", "options": "sent\nsuppressed"
+   "default": "Sent", "fieldname": "status", "fieldtype": "Select", "in_list_view": 1,
+   "label": "Status", "options": "Sent\nSuppressed"
   },
   {"fieldname": "column_break_main", "fieldtype": "Column Break"},
   {"fieldname": "reference_doctype", "fieldtype": "Data", "label": "Reference DocType"},

--- a/central/billing/doctype/billing_profile/billing_profile.json
+++ b/central/billing/doctype/billing_profile/billing_profile.json
@@ -42,7 +42,7 @@
   {"default": "India", "fieldname": "country", "fieldtype": "Data", "label": "Country"},
   {"fieldname": "pincode", "fieldtype": "Data", "label": "Pincode"},
   {"fieldname": "section_break_settings", "fieldtype": "Section Break", "label": "Billing Settings"},
-  {"default": "postpaid", "fieldname": "billing_mode", "fieldtype": "Select", "label": "Payment Mode", "options": "postpaid\nprepaid", "description": "prepaid = wallet-first; postpaid = invoice in arrears"},
+  {"default": "Postpaid", "fieldname": "billing_mode", "fieldtype": "Select", "label": "Payment Mode", "options": "Postpaid\nPrepaid", "description": "prepaid = wallet-first; postpaid = invoice in arrears"},
   {"default": "0", "fieldname": "min_balance", "fieldtype": "Currency", "label": "Minimum Balance (prepaid)"},
   {"fieldname": "column_break_settings", "fieldtype": "Column Break"},
   {"default": "0", "fieldname": "spend_alert_threshold", "fieldtype": "Currency", "label": "Spend Alert Threshold (postpaid)"}

--- a/central/billing/doctype/credit_ledger_entry/credit_ledger_entry.json
+++ b/central/billing/doctype/credit_ledger_entry/credit_ledger_entry.json
@@ -36,7 +36,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Entry Type",
-   "options": "credit\ndebit",
+   "options": "Credit\nDebit",
    "reqd": 1
   },
   {

--- a/central/billing/doctype/invoice/invoice.json
+++ b/central/billing/doctype/invoice/invoice.json
@@ -60,12 +60,12 @@
    "options": "Subscription"
   },
   {
-   "default": "billable",
+   "default": "Billable",
    "fieldname": "invoice_type",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Invoice Type",
-   "options": "billable\ncost_report",
+   "options": "Billable\nCost Report",
    "description": "cost_report = free/trial true-cost (compute, don't charge)"
   },
   {
@@ -134,11 +134,11 @@
    "description": "Discount repaid when the team dropped below its Commitment floor before term-end (issue #31); added to the taxable base. 0 otherwise."
   },
   {
-   "default": "none",
+   "default": "None",
    "fieldname": "output_tax_type",
    "fieldtype": "Select",
    "label": "Output Tax Type",
-   "options": "none\nGST\nVAT",
+   "options": "None\nGST\nVAT",
    "description": "Additive output tax (added to total)"
   },
   {
@@ -158,8 +158,8 @@
    "fieldname": "zero_rating_reason",
    "fieldtype": "Select",
    "label": "Zero-Rating Reason",
-   "options": "\nsez_lut\nexport",
-   "description": "Why output tax is 0 (compliance reason \u2014 never blank when zero-rated)"
+   "options": "\nSEZ LUT\nExport",
+   "description": "Why output tax is 0 (compliance reason — never blank when zero-rated)"
   },
   {
    "fieldname": "total",
@@ -190,7 +190,7 @@
    "fieldname": "tds_amount",
    "fieldtype": "Currency",
    "label": "TDS Amount",
-   "description": "Withheld \u2014 reduces collected, NOT total. 0 at launch"
+   "description": "Withheld — reduces collected, NOT total. 0 at launch"
   },
   {
    "default": "0",
@@ -230,11 +230,11 @@
    "description": "Sales Invoice name in ERPNext (statutory SOR); set on successful sync"
   },
   {
-   "default": "pending",
+   "default": "Pending",
    "fieldname": "erpnext_sync_status",
    "fieldtype": "Select",
    "label": "ERPNext Sync Status",
-   "options": "pending\nsynced\nfailed",
+   "options": "Pending\nSynced\nFailed",
    "read_only": 1
   },
   {

--- a/central/billing/doctype/payment_attempt/payment_attempt.json
+++ b/central/billing/doctype/payment_attempt/payment_attempt.json
@@ -89,12 +89,12 @@
    "fieldtype": "Section Break"
   },
   {
-   "default": "initiated",
+   "default": "Initiated",
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "initiated\nauthorised\ncaptured\nfailed\nrefunded"
+   "options": "Initiated\nAuthorised\nCaptured\nFailed\nRefunded"
   },
   {
    "fieldname": "gateway_transaction_id",
@@ -105,7 +105,7 @@
    "fieldname": "resolved_by",
    "fieldtype": "Select",
    "label": "Resolved By",
-   "options": "\nwebhook\nreconciliation",
+   "options": "\nWebhook\nReconciliation",
    "description": "How the terminal state was reached — audit provenance (#21)"
   },
   {

--- a/central/billing/doctype/payment_gateway/payment_gateway.json
+++ b/central/billing/doctype/payment_gateway/payment_gateway.json
@@ -36,7 +36,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Adapter",
-   "options": "stripe\nrazorpay\npaypal",
+   "options": "Stripe\nRazorpay\nPaypal",
    "reqd": 1
   },
   {

--- a/central/billing/doctype/payment_gateway/payment_gateway.py
+++ b/central/billing/doctype/payment_gateway/payment_gateway.py
@@ -105,7 +105,7 @@ class PaymentGateway(Document):
 			self.webhook_secret = secret
 
 	def webhook_callback_url(self) -> str:
-		return f"{get_url()}/api/method/central.billing.payments.webhooks.{self.adapter_key}"
+		return f"{get_url()}/api/method/central.billing.payments.webhooks.{self.adapter_key.lower()}"
 
 	def _guard_enable(self):
 		"""A gateway only goes live once its keys have proven out — otherwise an

--- a/central/billing/doctype/payment_method/payment_method.json
+++ b/central/billing/doctype/payment_method/payment_method.json
@@ -51,7 +51,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Method Type",
-   "options": "card\nupi_autopay\nprepaid_credits",
+   "options": "Card\nUPI Autopay\nPrepaid Credits",
    "reqd": 1
   },
   {
@@ -59,12 +59,12 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "pending_validation",
+   "default": "Pending Validation",
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "pending_validation\nactive\npaused\ncancelled\nexpired\nfailed"
+   "options": "Pending Validation\nActive\nPaused\nCancelled\nExpired\nFailed"
   },
   {
    "default": "0",

--- a/central/billing/doctype/payment_method/payment_method.py
+++ b/central/billing/doctype/payment_method/payment_method.py
@@ -12,14 +12,14 @@ class PaymentMethod(Document):
 	def _reject_duplicate_card(self):
 		"""A team can't register the same card twice. Using one card as both the
 		primary and a backup gives no real fallback, so it is disallowed."""
-		if not self.gateway_method_id or self.status == "cancelled":
+		if not self.gateway_method_id or self.status == "Cancelled":
 			return
 		dup = frappe.get_all(
 			"Payment Method",
 			filters={
 				"team": self.team,
 				"gateway_method_id": self.gateway_method_id,
-				"status": ["!=", "cancelled"],
+				"status": ["!=", "Cancelled"],
 				"name": ["!=", self.name or ""],
 			},
 			limit=1,

--- a/central/billing/doctype/plan/plan.json
+++ b/central/billing/doctype/plan/plan.json
@@ -36,11 +36,11 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "monthly",
+   "default": "Monthly",
    "fieldname": "billing_cycle",
    "fieldtype": "Select",
    "label": "Billing Cycle",
-   "options": "monthly\nannual",
+   "options": "Monthly\nAnnual",
    "reqd": 1
   },
   {

--- a/central/billing/doctype/plan_includes/plan_includes.json
+++ b/central/billing/doctype/plan_includes/plan_includes.json
@@ -16,7 +16,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Resource Type",
-   "options": "compute\nmemory\ndisk\ntransfer\nip\nsnapshot",
+   "options": "Compute\nMemory\nDisk\nTransfer\nIP\nSnapshot",
    "reqd": 1
   },
   {

--- a/central/billing/doctype/refund/refund.json
+++ b/central/billing/doctype/refund/refund.json
@@ -68,7 +68,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Destination",
-   "options": "source\nwallet",
+   "options": "Source\nWallet",
    "description": "source = gateway (full dispute); wallet = credit ledger (partial overcharge)"
   },
   {
@@ -76,12 +76,12 @@
    "fieldtype": "Section Break"
   },
   {
-   "default": "initiated",
+   "default": "Initiated",
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "initiated\ncompleted\nfailed"
+   "options": "Initiated\nCompleted\nFailed"
   },
   {
    "fieldname": "gateway_refund_id",

--- a/central/billing/doctype/subscription/subscription.json
+++ b/central/billing/doctype/subscription/subscription.json
@@ -46,19 +46,19 @@
    "fieldname": "billing_cycle",
    "fieldtype": "Select",
    "label": "Billing Cycle",
-   "options": "monthly\nannual"
+   "options": "Monthly\nAnnual"
   },
   {
    "fieldname": "column_break_state",
    "fieldtype": "Column Break"
   },
   {
-   "default": "current",
+   "default": "Current",
    "fieldname": "account_standing",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Account Standing",
-   "options": "current\npast_due\nsuspended",
+   "options": "Current\nPast Due\nSuspended",
    "description": "Central-owned financial axis, derived from payment. Orthogonal to the Agent-owned operational axis — never one combined enum."
   },
   {

--- a/central/billing/doctype/subscription_change/subscription_change.json
+++ b/central/billing/doctype/subscription_change/subscription_change.json
@@ -31,7 +31,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Change Type",
-   "options": "created\nplan_changed\npayment_method_changed\npast_due\nsuspended\nreactivated\ncancelled"
+   "options": "Created\nPlan Changed\nPayment Method Changed\nPast Due\nSuspended\nReactivated\nCancelled"
   },
   {
    "fieldname": "column_break_values",

--- a/central/billing/doctype/tax_profile/tax_profile.json
+++ b/central/billing/doctype/tax_profile/tax_profile.json
@@ -29,12 +29,12 @@
    "reqd": 1
   },
   {
-   "default": "none",
+   "default": "None",
    "fieldname": "output_tax_type",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Output Tax Type",
-   "options": "none\nGST\nVAT"
+   "options": "None\nGST\nVAT"
   },
   {
    "default": "0",
@@ -57,7 +57,7 @@
    "fieldname": "zero_rating_reason",
    "fieldtype": "Select",
    "label": "Zero-Rating Reason",
-   "options": "\nsez_lut\nexport"
+   "options": "\nSEZ LUT\nExport"
   },
   {
    "fieldname": "section_break_tds",

--- a/central/billing/doctype/usage_rollup/usage_rollup.json
+++ b/central/billing/doctype/usage_rollup/usage_rollup.json
@@ -54,7 +54,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Meter Type",
-   "options": "counter\ngauge"
+   "options": "Counter\nGauge"
   },
   {
    "fieldname": "column_break_period",

--- a/central/billing/doctype/webhook_event/webhook_event.json
+++ b/central/billing/doctype/webhook_event/webhook_event.json
@@ -41,12 +41,12 @@
    "label": "Event Type"
   },
   {
-   "default": "received",
+   "default": "Received",
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "received\nprocessed\nfailed\nignored"
+   "options": "Received\nProcessed\nFailed\nIgnored"
   },
   {
    "fieldname": "column_break_main",

--- a/central/billing/gateways/paypal_adapter.py
+++ b/central/billing/gateways/paypal_adapter.py
@@ -98,7 +98,7 @@ class PayPalAdapter(GatewayAdapter):
 		completed = capture.get("status") == "COMPLETED"
 		return PaymentResult(
 			success=completed,
-			status="captured" if completed else "failed",
+			status="Captured" if completed else "Failed",
 			gateway_transaction_id=capture.get("id"),
 			failure_code=capture.get("failure_code"),
 			failure_reason=capture.get("failure_reason"),
@@ -119,7 +119,7 @@ class PayPalAdapter(GatewayAdapter):
 		done = refund.get("status") in ("COMPLETED", "PENDING")
 		return RefundResult(
 			success=done,
-			status="completed" if done else refund.get("status"),
+			status="Completed" if done else refund.get("status"),
 			gateway_refund_id=refund.get("id"),
 			raw=dict(refund),
 		)

--- a/central/billing/gateways/razorpay_adapter.py
+++ b/central/billing/gateways/razorpay_adapter.py
@@ -142,7 +142,7 @@ class RazorpayAdapter(GatewayAdapter):
 		except razorpay.errors.BadRequestError as e:
 			return PaymentResult(
 				success=False,
-				status="failed",
+				status="Failed",
 				failure_code=getattr(e, "code", None),
 				failure_reason=str(e),
 			)
@@ -152,7 +152,7 @@ class RazorpayAdapter(GatewayAdapter):
 		captured = payment.get("status") == "captured"
 		return PaymentResult(
 			success=captured,
-			status="captured" if captured else payment.get("status"),
+			status="Captured" if captured else payment.get("status"),
 			gateway_transaction_id=payment.get("id"),
 			raw=dict(payment),
 		)
@@ -170,7 +170,7 @@ class RazorpayAdapter(GatewayAdapter):
 		done = refund.get("status") in ("processed", "pending")
 		return RefundResult(
 			success=done,
-			status="completed" if done else refund.get("status"),
+			status="Completed" if done else refund.get("status"),
 			gateway_refund_id=refund.get("id"),
 			raw=dict(refund),
 		)

--- a/central/billing/gateways/registry.py
+++ b/central/billing/gateways/registry.py
@@ -33,9 +33,9 @@ def get_adapter(gateway) -> GatewayAdapter:
 	from central.billing.gateways.stripe_adapter import StripeAdapter
 
 	adapters = {
-		"stripe": StripeAdapter,
-		"razorpay": RazorpayAdapter,
-		"paypal": PayPalAdapter,
+		"Stripe": StripeAdapter,
+		"Razorpay": RazorpayAdapter,
+		"Paypal": PayPalAdapter,
 	}
 
 	adapter_class = adapters.get(gateway.adapter_key)

--- a/central/billing/gateways/stripe_adapter.py
+++ b/central/billing/gateways/stripe_adapter.py
@@ -129,7 +129,7 @@ class StripeAdapter(GatewayAdapter):
 		except stripe.error.CardError as e:
 			return PaymentResult(
 				success=False,
-				status="failed",
+				status="Failed",
 				failure_code=getattr(e, "code", None),
 				failure_reason=getattr(e, "user_message", None) or str(e),
 				raw=getattr(e, "json_body", None) or {},
@@ -140,7 +140,7 @@ class StripeAdapter(GatewayAdapter):
 		succeeded = intent.get("status") == "succeeded"
 		return PaymentResult(
 			success=succeeded,
-			status="captured" if succeeded else intent.get("status"),
+			status="Captured" if succeeded else intent.get("status"),
 			gateway_transaction_id=intent.get("id"),
 			raw=intent,
 		)
@@ -159,7 +159,7 @@ class StripeAdapter(GatewayAdapter):
 		completed = refund.get("status") in ("succeeded", "pending")
 		return RefundResult(
 			success=completed,
-			status="completed" if completed else refund.get("status"),
+			status="Completed" if completed else refund.get("status"),
 			gateway_refund_id=refund.get("id"),
 			raw=refund,
 		)

--- a/central/billing/patches/v02_payment_method_priority/backfill_priority.py
+++ b/central/billing/patches/v02_payment_method_priority/backfill_priority.py
@@ -15,7 +15,7 @@ def execute():
 	for team in teams:
 		names = frappe.get_all(
 			"Payment Method",
-			filters={"team": team, "status": ["!=", "cancelled"]},
+			filters={"team": team, "status": ["!=", "Cancelled"]},
 			order_by="is_default desc, creation asc",
 			pluck="name",
 		)

--- a/central/billing/patches/v07_credit_wallet_balance/backfill_wallet_balance.py
+++ b/central/billing/patches/v07_credit_wallet_balance/backfill_wallet_balance.py
@@ -18,7 +18,7 @@ from frappe.query_builder.functions import Sum
 
 def execute():
 	cle = frappe.qb.DocType("Credit Ledger Entry")
-	signed = Case().when(cle.entry_type == "credit", cle.amount).else_(-cle.amount)
+	signed = Case().when(cle.entry_type == "Credit", cle.amount).else_(-cle.amount)
 	for team in frappe.get_all("Credit Wallet", pluck="name"):
 		balance = (
 			frappe.qb.from_(cle).select(Sum(signed)).where(cle.team == team).run()

--- a/central/billing/patches/v08_titlecase_select_options/titlecase_options.py
+++ b/central/billing/patches/v08_titlecase_select_options/titlecase_options.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Title-case stored Select option values to match the new field options.
+
+Every billing Select field's options moved from lower/snake_case to Title Case
+(e.g. account_standing "past_due" -> "Past Due"). Existing rows still hold the
+old values, so rewrite them in place. Runs post_model_sync, after the DocType
+schema (and its option list) has been migrated. Idempotent: each update only
+touches rows still holding an old value.
+
+Gateway-protocol strings (Stripe/Razorpay/PayPal API casing) are NOT stored in
+these fields and are deliberately untouched.
+"""
+
+import frappe
+
+# {DocType: {fieldname: {old_value: new_value}}}
+RENAMES = {
+	"Add-on": {
+		"resource_type": {"compute": "Compute", "memory": "Memory", "disk": "Disk", "transfer": "Transfer", "ip": "IP", "snapshot": "Snapshot"},
+		"billing_type": {"fixed": "Fixed", "metered": "Metered"},
+		"pricing_mode": {"grandfathered": "Grandfathered", "live": "Live"},
+		"billing_interval": {"hourly": "Hourly", "daily": "Daily", "monthly": "Monthly"},
+	},
+	"Billing Notification Log": {
+		"event_type": {
+			"payment_success": "Payment Success", "payment_failure": "Payment Failure",
+			"payment_retry": "Payment Retry", "invoice_overdue": "Invoice Overdue",
+			"credit_low": "Credit Low", "card_expiry": "Card Expiry",
+			"mandate_reauth": "Mandate Reauth", "trial_expiring": "Trial Expiring",
+		},
+		"status": {"sent": "Sent", "suppressed": "Suppressed"},
+	},
+	"Billing Profile": {
+		"billing_mode": {"postpaid": "Postpaid", "prepaid": "Prepaid"},
+	},
+	"Credit Ledger Entry": {
+		"entry_type": {"credit": "Credit", "debit": "Debit"},
+	},
+	"Invoice": {
+		"invoice_type": {"billable": "Billable", "cost_report": "Cost Report"},
+		"output_tax_type": {"none": "None"},
+		"zero_rating_reason": {"sez_lut": "SEZ LUT", "export": "Export"},
+		"erpnext_sync_status": {"pending": "Pending", "synced": "Synced", "failed": "Failed"},
+	},
+	"Payment Attempt": {
+		"status": {"initiated": "Initiated", "authorised": "Authorised", "captured": "Captured", "failed": "Failed", "refunded": "Refunded"},
+		"resolved_by": {"webhook": "Webhook", "reconciliation": "Reconciliation"},
+	},
+	"Payment Gateway": {
+		"adapter_key": {"stripe": "Stripe", "razorpay": "Razorpay", "paypal": "Paypal"},
+	},
+	"Payment Method": {
+		"method_type": {"card": "Card", "upi_autopay": "UPI Autopay", "prepaid_credits": "Prepaid Credits"},
+		"status": {"pending_validation": "Pending Validation", "active": "Active", "paused": "Paused", "cancelled": "Cancelled", "expired": "Expired", "failed": "Failed"},
+	},
+	"Plan": {
+		"billing_cycle": {"monthly": "Monthly", "annual": "Annual"},
+	},
+	"Plan Includes": {
+		"resource_type": {"compute": "Compute", "memory": "Memory", "disk": "Disk", "transfer": "Transfer", "ip": "IP", "snapshot": "Snapshot"},
+	},
+	"Refund": {
+		"destination": {"source": "Source", "wallet": "Wallet"},
+		"status": {"initiated": "Initiated", "completed": "Completed", "failed": "Failed"},
+	},
+	"Subscription": {
+		"billing_cycle": {"monthly": "Monthly", "annual": "Annual"},
+		"account_standing": {"current": "Current", "past_due": "Past Due", "suspended": "Suspended"},
+	},
+	"Subscription Change": {
+		"change_type": {
+			"created": "Created", "plan_changed": "Plan Changed",
+			"payment_method_changed": "Payment Method Changed", "past_due": "Past Due",
+			"suspended": "Suspended", "reactivated": "Reactivated", "cancelled": "Cancelled",
+		},
+	},
+	"Tax Profile": {
+		"output_tax_type": {"none": "None"},
+		"zero_rating_reason": {"sez_lut": "SEZ LUT", "export": "Export"},
+	},
+	"Usage Rollup": {
+		"meter_type": {"counter": "Counter", "gauge": "Gauge"},
+	},
+	"Webhook Event": {
+		"status": {"received": "Received", "processed": "Processed", "failed": "Failed", "ignored": "Ignored"},
+	},
+}
+
+
+def execute():
+	for doctype, fields in RENAMES.items():
+		if not frappe.db.table_exists(doctype):
+			continue
+		t = frappe.qb.DocType(doctype)
+		for field, value_map in fields.items():
+			if not frappe.db.has_column(doctype, field):
+				continue
+			column = getattr(t, field)
+			for old, new in value_map.items():
+				frappe.qb.update(t).set(column, new).where(column == old).run()

--- a/central/billing/payments/charges.py
+++ b/central/billing/payments/charges.py
@@ -15,7 +15,7 @@ import frappe
 from central.billing.gateways.base import GatewayTimeout
 
 # An attempt occupying the invoice — a second charge must not start beside it.
-_IN_FLIGHT = ("initiated", "authorised", "captured")
+_IN_FLIGHT = ("Initiated", "Authorised", "Captured")
 
 # Gateway event types the Payment Attempt listens to. An attempt's status is
 # advanced ONLY by the respective callback for its transaction:
@@ -33,7 +33,7 @@ _FAILURE_EVENTS = {"payment_intent.payment_failed", "charge.failed", "payment.fa
 # Logs (Payment Attempt + Webhook Event) are kept on a rolling window and pruned
 # daily; site-config `payment_log_retention_days` overrides the default.
 LOG_RETENTION_DEFAULT_DAYS = 90  # ~3 months
-_TERMINAL_ATTEMPT = ("captured", "failed", "refunded")
+_TERMINAL_ATTEMPT = ("Captured", "Failed", "Refunded")
 _UNSETTLED_INVOICE = ("Open", "Overdue")
 
 
@@ -81,7 +81,7 @@ def pay_invoice(invoice: str, payment_method: str | None = None, gateway: str | 
 			"payment_method": method_name,
 			"amount": inv.expected_collection,
 			"currency": inv.currency,
-			"status": "initiated",
+			"status": "Initiated",
 			"initiated_at": frappe.utils.now_datetime(),
 			"retry_number": frappe.db.count("Payment Attempt", {"invoice": invoice}),
 		}
@@ -103,9 +103,9 @@ def pay_invoice(invoice: str, payment_method: str | None = None, gateway: str | 
 
 	attempt.gateway_transaction_id = result.gateway_transaction_id
 	if result.success:
-		attempt.status = "captured"  # gateway captured; invoice Paid waits on webhook
+		attempt.status = "Captured"  # gateway captured; invoice Paid waits on webhook
 	else:
-		attempt.status = "failed"
+		attempt.status = "Failed"
 		attempt.failure_code = result.failure_code
 		attempt.failure_reason = result.failure_reason
 		attempt.completed_at = frappe.utils.now_datetime()
@@ -156,23 +156,23 @@ def apply_webhook(event_name: str) -> dict:
 	is_failure = event.event_type in _FAILURE_EVENTS
 
 	if not txn_id or not (is_authorised or is_success or is_failure):
-		_mark_event(event, "ignored")
+		_mark_event(event, "Ignored")
 		return {"handled": False, "reason": "not_a_charge_event"}
 
 	attempt_name = frappe.db.get_value("Payment Attempt", {"gateway_transaction_id": txn_id}, "name")
 	if not attempt_name:
-		_mark_event(event, "ignored")
+		_mark_event(event, "Ignored")
 		return {"handled": False, "reason": "no_matching_attempt"}
 
 	attempt = frappe.get_doc("Payment Attempt", attempt_name)
 	if is_authorised:
 		# Funds held, capture pending. Advance only from initiated — never walk a
 		# terminal attempt backwards if the capture/fail webhook arrived first.
-		if attempt.status == "initiated":
-			attempt.status = "authorised"
+		if attempt.status == "Initiated":
+			attempt.status = "Authorised"
 			attempt.save(ignore_permissions=True)
-		_mark_event(event, "processed")
-		return {"handled": True, "result": "authorised", "attempt": attempt_name}
+		_mark_event(event, "Processed")
+		return {"handled": True, "result": "Authorised", "attempt": attempt_name}
 
 	if is_failure:
 		fell_back = None
@@ -180,14 +180,14 @@ def apply_webhook(event_name: str) -> dict:
 		# invoice (a sync `captured` attempt isn't final: Paid lands on the success
 		# webhook). Gate on invoice status, not attempt status, and act once.
 		inv_status = frappe.db.get_value("Invoice", attempt.invoice, "status")
-		if inv_status != "Paid" and attempt.status not in ("failed", "refunded"):
-			attempt.status = "failed"
+		if inv_status != "Paid" and attempt.status not in ("Failed", "Refunded"):
+			attempt.status = "Failed"
 			attempt.completed_at = frappe.utils.now_datetime()
 			attempt.save(ignore_permissions=True)
 			from central.billing.platform import notifications
 
 			notifications.notify(
-				attempt.team, "payment_failure",
+				attempt.team, "Payment Failure",
 				context={"invoice": attempt.invoice, "reason": attempt.failure_reason or "declined"},
 				reference_doctype="Invoice", reference_name=attempt.invoice,
 			)
@@ -197,15 +197,15 @@ def apply_webhook(event_name: str) -> dict:
 				from central.billing.payments import collection
 
 				fell_back = collection.collect_invoice(attempt.invoice)
-		_mark_event(event, "processed")
-		return {"handled": True, "result": "failed", "attempt": attempt_name, "fell_back": fell_back}
+		_mark_event(event, "Processed")
+		return {"handled": True, "result": "Failed", "attempt": attempt_name, "fell_back": fell_back}
 
 	settled = _settle_invoice(attempt)
-	attempt.status = "captured"
+	attempt.status = "Captured"
 	attempt.completed_at = frappe.utils.now_datetime()
-	attempt.resolved_by = "webhook"
+	attempt.resolved_by = "Webhook"
 	attempt.save(ignore_permissions=True)
-	_mark_event(event, "processed")
+	_mark_event(event, "Processed")
 	return {"handled": True, "result": "paid", "invoice": attempt.invoice, "settled": settled}
 
 
@@ -225,7 +225,7 @@ def _settle_invoice(attempt) -> bool:
 	from central.billing.platform import notifications
 
 	notifications.notify(
-		inv.team, "payment_success",
+		inv.team, "Payment Success",
 		message=f"Invoice {inv.name} paid ({inv.amount_paid} {inv.currency or ''}).",
 		reference_doctype="Invoice", reference_name=inv.name,
 	)
@@ -287,7 +287,7 @@ def _prune_webhook_events(cutoff) -> int:
 	yet handled (received/failed) so a stuck event stays visible for triage."""
 	stale = frappe.get_all(
 		"Webhook Event",
-		filters={"status": ["in", ("processed", "ignored")], "creation": ["<", cutoff]},
+		filters={"status": ["in", ("Processed", "Ignored")], "creation": ["<", cutoff]},
 		pluck="name",
 	)
 	for name in stale:
@@ -297,9 +297,9 @@ def _prune_webhook_events(cutoff) -> int:
 
 def _extract_transaction_id(adapter_key: str, payload: dict):
 	"""Pull the gateway transaction id out of a parsed webhook body."""
-	if adapter_key == "stripe":
+	if adapter_key == "Stripe":
 		return ((payload.get("data") or {}).get("object") or {}).get("id")
-	if adapter_key == "razorpay":
+	if adapter_key == "Razorpay":
 		payment = (((payload.get("payload") or {}).get("payment") or {}).get("entity")) or {}
 		return payment.get("id")
 	return None

--- a/central/billing/payments/collection.py
+++ b/central/billing/payments/collection.py
@@ -30,7 +30,7 @@ def ordered_methods(team: str) -> list:
 	whose mandate needs re-authorisation."""
 	return frappe.get_all(
 		"Payment Method",
-		filters={"team": team, "status": "active", "reauth_required": 0},
+		filters={"team": team, "status": "Active", "reauth_required": 0},
 		order_by="priority asc, creation asc",
 		fields=["name", "gateway", "priority"],
 	)
@@ -41,7 +41,7 @@ def _failed_methods_for(invoice: str) -> set:
 	return set(
 		frappe.get_all(
 			"Payment Attempt",
-			filters={"invoice": invoice, "status": "failed"},
+			filters={"invoice": invoice, "status": "Failed"},
 			pluck="payment_method",
 		)
 	)
@@ -83,7 +83,7 @@ def collect_invoice(invoice: str) -> dict:
 		result = charges.pay_invoice(invoice, method.name, method.gateway)
 
 		# A synchronous decline: rotate to the next method now (immediate fallback).
-		if result.get("status") == "failed":
+		if result.get("status") == "Failed":
 			continue
 		# Captured (awaiting webhook), in-flight, or a transient timeout: stop here.
 		return result

--- a/central/billing/payments/mandates.py
+++ b/central/billing/payments/mandates.py
@@ -14,8 +14,8 @@ through the registry, keeping the gateway seam intact (see gateways/base.py).
 
 import frappe
 
-MANDATE_METHOD = "upi_autopay"
-CARD_METHOD = "card"
+MANDATE_METHOD = "UPI Autopay"
+CARD_METHOD = "Card"
 
 # UPI Autopay recurring ceiling (merchant-category-code limit): a recurring UPI
 # payment for this MCC cannot exceed Rs. 1,00,000. Above this the mandate would
@@ -91,7 +91,7 @@ def setup_mandate(team: str, gateway: str, customer_id: str | None = None, is_de
 			"team": team,
 			"gateway": gateway,
 			"method_type": MANDATE_METHOD,
-			"status": "pending_validation",
+			"status": "Pending Validation",
 			"mandate_max_amount": cap,
 			"mandate_currency": "INR",
 			"gateway_customer_id": customer_id,
@@ -119,7 +119,7 @@ def setup_card(team: str, gateway: str, customer_id: str | None = None) -> dict:
 			"team": team,
 			"gateway": gateway,
 			"method_type": CARD_METHOD,
-			"status": "pending_validation",
+			"status": "Pending Validation",
 			"mandate_currency": "INR",
 			"gateway_customer_id": customer_id,
 		}
@@ -140,12 +140,12 @@ def confirm_mandate(payment_method: str, callback: dict):
 	adapter = _adapter(method.gateway)
 
 	if not adapter.verify_payment_signature(callback):
-		method.status = "failed"
+		method.status = "Failed"
 		method.save(ignore_permissions=True)
 		frappe.throw("Mandate authorisation signature invalid", frappe.ValidationError)
 
 	method.gateway_method_id = callback.get("razorpay_token_id") or callback.get("token_id")
-	method.status = "active"
+	method.status = "Active"
 	method.validated_at = frappe.utils.now_datetime()
 	method.reauth_required = 0
 	method.save(ignore_permissions=True)
@@ -169,7 +169,7 @@ def cancel_mandate(payment_method: str):
 		_adapter(method.gateway).cancel_mandate(
 			method.gateway_method_id, customer_reference=method.gateway_customer_id
 		)
-	method.status = "cancelled"
+	method.status = "Cancelled"
 	method.save(ignore_permissions=True)
 	return method
 
@@ -191,7 +191,7 @@ def active_mandate_ceiling(team: str):
 	"""Highest ceiling among a team's active mandates (None if none active)."""
 	ceilings = frappe.get_all(
 		"Payment Method",
-		filters={"team": team, "method_type": MANDATE_METHOD, "status": "active"},
+		filters={"team": team, "method_type": MANDATE_METHOD, "status": "Active"},
 		pluck="mandate_max_amount",
 	)
 	return max(ceilings) if ceilings else None
@@ -217,7 +217,7 @@ def reauth_pending(team: str) -> bool:
 			filters={
 				"team": team,
 				"method_type": MANDATE_METHOD,
-				"status": "active",
+				"status": "Active",
 				"reauth_required": 1,
 			},
 			limit=1,
@@ -237,7 +237,7 @@ def reconcile_mandates_to_cap(team: str):
 	flagged = []
 	for method in frappe.get_all(
 		"Payment Method",
-		filters={"team": team, "method_type": MANDATE_METHOD, "status": "active"},
+		filters={"team": team, "method_type": MANDATE_METHOD, "status": "Active"},
 		fields=["name", "mandate_max_amount"],
 	):
 		needs = cap > (method.mandate_max_amount or 0)
@@ -256,7 +256,7 @@ def _retire_superseded_mandates(new_method):
 			"team": new_method.team,
 			"gateway": new_method.gateway,
 			"method_type": MANDATE_METHOD,
-			"status": "active",
+			"status": "Active",
 			"name": ["!=", new_method.name],
 		},
 		pluck="name",

--- a/central/billing/payments/payments.py
+++ b/central/billing/payments/payments.py
@@ -19,7 +19,7 @@ adapter through the registry, keeping the gateway seam intact.
 import frappe
 from frappe.model.document import Document
 
-CARD_METHOD = "card"
+CARD_METHOD = "Card"
 
 
 def _adapter(gateway: str):
@@ -43,7 +43,7 @@ def initiate_payment_method_setup(team: str, gateway: str, gateway_customer_id: 
 			"team": team,
 			"gateway": gateway,
 			"method_type": CARD_METHOD,
-			"status": "pending_validation",
+			"status": "Pending Validation",
 			"gateway_customer_id": gateway_customer_id,
 			"setup_reference": handles.get("setup_intent_id"),
 		}
@@ -81,11 +81,11 @@ def confirm_payment_method(
 	method.save(ignore_permissions=True)
 
 	if not _adapter(method.gateway).validate_payment_method(method):
-		method.status = "failed"
+		method.status = "Failed"
 		method.save(ignore_permissions=True)
 		return method
 
-	method.status = "active"
+	method.status = "Active"
 	method.validated_at = frappe.utils.now_datetime()
 	method.save(ignore_permissions=True)
 	densify_priorities(method.team)
@@ -99,7 +99,7 @@ def densify_priorities(team: str):
 	fallback order; idempotent."""
 	names = frappe.get_all(
 		"Payment Method",
-		filters={"team": team, "status": ["!=", "cancelled"]},
+		filters={"team": team, "status": ["!=", "Cancelled"]},
 		order_by="priority asc, creation asc",
 		pluck="name",
 	)
@@ -116,7 +116,7 @@ def densify_priorities(team: str):
 def set_default_payment_method(payment_method: str) -> Document:
 	"""Make this the team's primary (priority 0). Only an active method can be."""
 	method = frappe.get_doc("Payment Method", payment_method)
-	if method.status != "active":
+	if method.status != "Active":
 		frappe.throw("Only an active payment method can be the primary.", frappe.ValidationError)
 	# Sort it ahead of everyone, then re-densify resolves the rest.
 	frappe.db.set_value("Payment Method", method.name, "priority", -1, update_modified=False)
@@ -146,7 +146,7 @@ def delete_payment_method(payment_method: str) -> dict:
 	frappe.delete_doc("Payment Method", method.name, ignore_permissions=True)
 	densify_priorities(team)
 	new_default = frappe.db.get_value(
-		"Payment Method", {"team": team, "priority": 0, "status": "active"}, "name"
+		"Payment Method", {"team": team, "priority": 0, "status": "Active"}, "name"
 	)
 	return {"deleted": payment_method, "new_default": new_default}
 
@@ -163,17 +163,17 @@ def expire_payment_methods(now=None) -> dict:
 	expired = []
 	for m in frappe.get_all(
 		"Payment Method",
-		filters={"method_type": CARD_METHOD, "status": "active"},
+		filters={"method_type": CARD_METHOD, "status": "Active"},
 		fields=["name", "team", "display_label", "expiry_month", "expiry_year"],
 	):
 		if not m.expiry_year or not m.expiry_month:
 			continue
 		month_start = frappe.utils.getdate(f"{int(m.expiry_year):04d}-{int(m.expiry_month):02d}-01")
 		if frappe.utils.get_last_day(month_start) < today:
-			frappe.db.set_value("Payment Method", m.name, "status", "expired")
+			frappe.db.set_value("Payment Method", m.name, "status", "Expired")
 			expired.append(m.name)
 			notifications.notify(
-				m.team, "card_expiry", context={"label": m.display_label or "card"},
+				m.team, "Card Expiry", context={"label": m.display_label or "Card"},
 				reference_doctype="Payment Method", reference_name=m.name,
 			)
 	return {"expired": expired}

--- a/central/billing/payments/reconciliation.py
+++ b/central/billing/payments/reconciliation.py
@@ -20,7 +20,7 @@ Terminal-state model (the resolved HITL decision — see issue #21):
 
 import frappe
 
-_AMBIGUOUS = ("initiated", "authorised")
+_AMBIGUOUS = ("Initiated", "Authorised")
 _GATEWAY_SUCCESS = {"succeeded", "captured", "paid", "completed"}
 _GATEWAY_FAILED = {"failed", "canceled", "cancelled", "declined", "expired", "voided"}
 
@@ -44,7 +44,7 @@ def reconcile_attempt(attempt_name: str, now=None) -> dict:
 		# The charge never reached the gateway — fail it safely (retryable), never
 		# leave it dangling.
 		_resolve_failed(attempt, "no gateway transaction id")
-		return {"attempt": attempt_name, "resolved": "failed", "reason": "no_txn"}
+		return {"attempt": attempt_name, "resolved": "Failed", "reason": "no_txn"}
 
 	status = (_adapter(attempt.gateway).get_transaction_status(attempt.gateway_transaction_id) or "").lower()
 
@@ -53,7 +53,7 @@ def reconcile_attempt(attempt_name: str, now=None) -> dict:
 		return {"attempt": attempt_name, "resolved": "paid", "gateway_status": status}
 	if status in _GATEWAY_FAILED:
 		_resolve_failed(attempt, f"gateway:{status}")
-		return {"attempt": attempt_name, "resolved": "failed", "gateway_status": status}
+		return {"attempt": attempt_name, "resolved": "Failed", "gateway_status": status}
 
 	# Still pending/unknown at the gateway — escalate if it has aged out.
 	now = frappe.utils.get_datetime(now or frappe.utils.now_datetime())
@@ -81,17 +81,17 @@ def _resolve_paid(attempt):
 	"""Settle through the same idempotent path a webhook uses; tag provenance."""
 	from central.billing.payments import charges
 
-	attempt.status = "captured"
+	attempt.status = "Captured"
 	attempt.completed_at = frappe.utils.now_datetime()
-	attempt.resolved_by = "reconciliation"
+	attempt.resolved_by = "Reconciliation"
 	attempt.save(ignore_permissions=True)
 	charges._settle_invoice(attempt)  # idempotent: a duplicate webhook would no-op too
 
 
 def _resolve_failed(attempt, reason: str):
-	attempt.status = "failed"
+	attempt.status = "Failed"
 	attempt.completed_at = frappe.utils.now_datetime()
-	attempt.resolved_by = "reconciliation"
+	attempt.resolved_by = "Reconciliation"
 	attempt.failure_reason = reason[:140]
 	attempt.save(ignore_permissions=True)
 

--- a/central/billing/payments/refunds.py
+++ b/central/billing/payments/refunds.py
@@ -6,7 +6,7 @@ Two destinations, two mechanics:
 
   - **Full dispute -> source.** Refund the captured amount through the gateway
     (`adapter.refund`, symmetric across Stripe/Razorpay). The invoice **stays
-    Paid** with a linked Refund — there is no "refunded" state, which preserves
+    Paid** with a linked Refund — there is no "Refunded" state, which preserves
     GST immutability; the statutory credit note is issued in ERPNext (#17).
   - **Partial overcharge -> wallet.** Add the difference to the customer's
     wallet as a credit ledger entry, applied on the next invoice. No gateway
@@ -27,14 +27,14 @@ def _adapter(gateway: str):
 	return get_adapter(frappe.get_doc("Payment Gateway", gateway))
 
 
-def issue_refund(payment_attempt: str, amount=None, destination: str = "source", reason: str | None = None):
+def issue_refund(payment_attempt: str, amount=None, destination: str = "Source", reason: str | None = None):
 	"""Refund (part of) a captured Payment Attempt to source or to the wallet.
 
 	`amount` defaults to the full captured amount (a full dispute). The invoice
 	is never moved off Paid.
 	"""
 	attempt = frappe.get_doc("Payment Attempt", payment_attempt)
-	if attempt.status not in ("captured", "refunded"):
+	if attempt.status not in ("Captured", "Refunded"):
 		frappe.throw(
 			f"Only a captured charge can be refunded (attempt is {attempt.status}).",
 			frappe.ValidationError,
@@ -54,12 +54,12 @@ def issue_refund(payment_attempt: str, amount=None, destination: str = "source",
 			"currency": attempt.currency,
 			"destination": destination,
 			"reason": reason,
-			"status": "initiated",
+			"status": "Initiated",
 			"created_at": frappe.utils.now_datetime(),
 		}
 	).insert(ignore_permissions=True)
 
-	if destination == "wallet":
+	if destination == "Wallet":
 		_to_wallet(refund, attempt)
 	else:
 		_to_source(refund, attempt, reason)
@@ -69,14 +69,14 @@ def issue_refund(payment_attempt: str, amount=None, destination: str = "source",
 
 def full_dispute(payment_attempt: str, reason: str | None = None):
 	"""Refund the whole charge to source; the invoice stays Paid + linked Refund."""
-	return issue_refund(payment_attempt, amount=None, destination="source", reason=reason)
+	return issue_refund(payment_attempt, amount=None, destination="Source", reason=reason)
 
 
 def partial_overcharge(payment_attempt: str, amount, reason: str | None = None, to_source: bool = False):
 	"""Correct a partial overcharge: to the wallet by default (active customers),
 	to source for churning customers (`to_source=True`)."""
 	return issue_refund(
-		payment_attempt, amount=amount, destination="source" if to_source else "wallet", reason=reason
+		payment_attempt, amount=amount, destination="Source" if to_source else "Wallet", reason=reason
 	)
 
 
@@ -90,7 +90,7 @@ def _to_wallet(refund, attempt):
 		reference_name=refund.name,
 		note=refund.reason or f"Overcharge refund for {attempt.invoice}",
 	)
-	refund.status = "completed"
+	refund.status = "Completed"
 	refund.completed_at = frappe.utils.now_datetime()
 	refund.save(ignore_permissions=True)
 	return refund
@@ -100,11 +100,11 @@ def _to_source(refund, attempt, reason):
 	"""Refund to the gateway via the adapter (symmetric across gateways)."""
 	result = _adapter(attempt.gateway).refund(attempt, refund.amount, reason or "")
 	refund.gateway_refund_id = result.gateway_refund_id
-	refund.status = "completed" if result.success else "failed"
+	refund.status = "Completed" if result.success else "Failed"
 	if result.success:
 		refund.completed_at = frappe.utils.now_datetime()
 		# A full refund marks the attempt refunded (the invoice still stays Paid).
 		if frappe.utils.flt(refund.amount) >= frappe.utils.flt(attempt.amount):
-			frappe.db.set_value("Payment Attempt", attempt.name, "status", "refunded")
+			frappe.db.set_value("Payment Attempt", attempt.name, "status", "Refunded")
 	refund.save(ignore_permissions=True)
 	return refund

--- a/central/billing/payments/settlement.py
+++ b/central/billing/payments/settlement.py
@@ -18,7 +18,7 @@ import frappe
 
 from central.billing.revenue import credits
 
-AUTOPAY_METHODS = ("card", "upi_autopay")
+AUTOPAY_METHODS = ("Card", "UPI Autopay")
 FORECAST_NOTIFY_RATIO = 0.8
 
 
@@ -27,7 +27,7 @@ def settlement_sources(team: str) -> dict:
 	has_autopay = bool(
 		frappe.get_all(
 			"Payment Method",
-			filters={"team": team, "method_type": ["in", AUTOPAY_METHODS], "status": "active"},
+			filters={"team": team, "method_type": ["in", AUTOPAY_METHODS], "status": "Active"},
 			limit=1,
 		)
 	)
@@ -105,7 +105,7 @@ def _notify_top_up(team: str, balance, projected, utilisation):
 	"""Emit the credit-low top-up prompt through the notification suite (#20)."""
 	from central.billing.platform import notifications
 
-	notifications.notify(team, "credit_low", context={"utilisation": f"{utilisation:.0%}"})
+	notifications.notify(team, "Credit Low", context={"utilisation": f"{utilisation:.0%}"})
 	frappe.publish_realtime(
 		"billing_top_up_prompt",
 		{"team": team, "balance": balance, "projected_spend": projected, "utilisation": utilisation},

--- a/central/billing/payments/webhooks.py
+++ b/central/billing/payments/webhooks.py
@@ -15,7 +15,7 @@ import frappe
 @frappe.whitelist(allow_guest=True)
 def stripe() -> dict:
 	return process_webhook(
-		"stripe",
+		"Stripe",
 		frappe.request.get_data(),
 		dict(frappe.request.headers),
 	)
@@ -24,7 +24,7 @@ def stripe() -> dict:
 @frappe.whitelist(allow_guest=True)
 def razorpay() -> dict:
 	return process_webhook(
-		"razorpay",
+		"Razorpay",
 		frappe.request.get_data(),
 		dict(frappe.request.headers),
 	)
@@ -74,7 +74,7 @@ def _store_and_enqueue(gateway, event, payload: bytes):
 				"gateway_event_id": event.gateway_event_id,
 				"event_type": event.event_type,
 				"raw_payload": payload.decode() if isinstance(payload, bytes) else payload,
-				"status": "received",
+				"status": "Received",
 			}
 		).insert(ignore_permissions=True)
 	except frappe.DuplicateEntryError:

--- a/central/billing/platform/notifications.py
+++ b/central/billing/platform/notifications.py
@@ -16,14 +16,14 @@ import frappe
 
 # event_type -> default (subject, body template). Body is .format(**context)-ed.
 _TEMPLATES = {
-	"payment_success": ("Payment received", "Payment received for invoice {invoice}."),
-	"payment_failure": ("Payment failed", "Payment for invoice {invoice} failed: {reason}."),
-	"payment_retry": ("Payment retry failed", "Payment retry for invoice {invoice} failed: {reason}."),
-	"invoice_overdue": ("Invoice overdue", "Invoice {invoice} is overdue. Please settle it to avoid suspension."),
-	"credit_low": ("Credit balance low", "Your credit balance is low (projected use {utilisation}). Top up to avoid interruption."),
-	"card_expiry": ("Card expired", "Your card {label} has expired. Please add a new payment method."),
-	"mandate_reauth": ("Mandate re-authorisation needed", "Your UPI Autopay mandate needs re-authorisation for the new limit."),
-	"trial_expiring": ("Trial ending", "Your trial is ending. Add a payment method to keep your resources running."),
+	"Payment Success": ("Payment received", "Payment received for invoice {invoice}."),
+	"Payment Failure": ("Payment failed", "Payment for invoice {invoice} failed: {reason}."),
+	"Payment Retry": ("Payment retry failed", "Payment retry for invoice {invoice} failed: {reason}."),
+	"Invoice Overdue": ("Invoice overdue", "Invoice {invoice} is overdue. Please settle it to avoid suspension."),
+	"Credit Low": ("Credit balance low", "Your credit balance is low (projected use {utilisation}). Top up to avoid interruption."),
+	"Card Expiry": ("Card expired", "Your card {label} has expired. Please add a new payment method."),
+	"Mandate Reauth": ("Mandate re-authorisation needed", "Your UPI Autopay mandate needs re-authorisation for the new limit."),
+	"Trial Expiring": ("Trial ending", "Your trial is ending. Add a payment method to keep your resources running."),
 }
 
 
@@ -31,7 +31,8 @@ def _preference_enabled(team: str, event_type: str) -> bool:
 	"""A team's opt-out for an event; absent preference doc = all enabled."""
 	if not frappe.db.exists("Notification Preference", team):
 		return True
-	value = frappe.db.get_value("Notification Preference", team, f"notify_{event_type}")
+	fieldname = "notify_" + event_type.lower().replace(" ", "_")
+	value = frappe.db.get_value("Notification Preference", team, fieldname)
 	return value is None or bool(value)
 
 
@@ -59,7 +60,7 @@ def notify(
 			"team": team,
 			"event_type": event_type,
 			"channel": "email",
-			"status": "sent" if enabled else "suppressed",
+			"status": "Sent" if enabled else "Suppressed",
 			"subject": subject,
 			"message": body,
 			"reference_doctype": reference_doctype,

--- a/central/billing/revenue/credits.py
+++ b/central/billing/revenue/credits.py
@@ -124,7 +124,7 @@ def _book_entry_once(
 	"""One booking attempt under the per-team lock; returns (doc, new_balance)."""
 	_ensure_wallet(team, currency)
 	balance = _lock_and_read_balance(team)
-	new_balance = balance + (amount if entry_type == "credit" else -amount)
+	new_balance = balance + (amount if entry_type == "Credit" else -amount)
 	if new_balance < 0:
 		raise InsufficientCredits(
 			f"Debit of {amount} exceeds wallet balance {balance} for {team}."
@@ -160,7 +160,7 @@ def purchase(team: str, amount: float, currency: str = "INR", payment_method: st
 	"""
 	entry, new_balance = _book_entry(
 		team,
-		"credit",
+		"Credit",
 		amount,
 		currency,
 		reference_type="Payment Method" if payment_method else "Top-up",
@@ -180,7 +180,7 @@ def apply_credit(
 	is the locked primitive it builds on.
 	"""
 	entry, new_balance = _book_entry(
-		team, "debit", amount, currency, reference_type, reference_name, note
+		team, "Debit", amount, currency, reference_type, reference_name, note
 	)
 	return {"ledger_entry": entry.name, "new_balance": new_balance}
 
@@ -188,7 +188,7 @@ def apply_credit(
 def refund_to_wallet(team, amount, currency="INR", reference_type=None, reference_name=None, note=None) -> dict:
 	"""Book a credit entry for a partial-overcharge / gateway refund to wallet."""
 	entry, new_balance = _book_entry(
-		team, "credit", amount, currency, reference_type, reference_name, note or "Refund to wallet"
+		team, "Credit", amount, currency, reference_type, reference_name, note or "Refund to wallet"
 	)
 	return {"ledger_entry": entry.name, "new_balance": new_balance}
 
@@ -197,8 +197,8 @@ def refund_to_wallet(team, amount, currency="INR", reference_type=None, referenc
 def adjust_credits(team: str, amount: float, entry_type: str, currency: str = "INR",
 				   note: str | None = None) -> dict:
 	"""Admin manual correction — a credit or debit entry with an audit note."""
-	if entry_type not in ("credit", "debit"):
-		frappe.throw("entry_type must be 'credit' or 'debit'.", frappe.ValidationError)
+	if entry_type not in ("Credit", "Debit"):
+		frappe.throw("entry_type must be 'Credit' or 'Debit'.", frappe.ValidationError)
 	entry, new_balance = _book_entry(
 		team, entry_type, amount, currency, reference_type="Admin", note=note or "Admin adjustment"
 	)
@@ -219,7 +219,7 @@ def get_balance(team: str, currency: str | None = None) -> dict:
 	"""
 	if currency:
 		cle = frappe.qb.DocType("Credit Ledger Entry")
-		signed = Case().when(cle.entry_type == "credit", cle.amount).else_(-cle.amount)
+		signed = Case().when(cle.entry_type == "Credit", cle.amount).else_(-cle.amount)
 		balance = (
 			frappe.qb.from_(cle)
 			.select(Sum(signed))

--- a/central/billing/revenue/dunning.py
+++ b/central/billing/revenue/dunning.py
@@ -44,11 +44,11 @@ def retry_payment(invoice_name: str) -> dict:
 	)
 	if last:
 		attempt = frappe.get_doc("Payment Attempt", last[0])
-		if attempt.status == "failed":
+		if attempt.status == "Failed":
 			n = frappe.db.count("Payment Attempt", {"invoice": invoice_name})
 			reason = attempt.failure_reason or attempt.failure_code or "declined"
 			notifications.notify(
-				attempt.team, "payment_retry",
+				attempt.team, "Payment Retry",
 				message=f"Payment retry {n} for invoice {invoice_name} failed: {reason}",
 				reference_doctype="Invoice", reference_name=invoice_name,
 			)
@@ -83,8 +83,8 @@ def process_invoice_dunning(invoice_name: str, now=None) -> dict:
 	re-issue a directive already in force.
 	"""
 	inv = frappe.get_doc("Invoice", invoice_name)
-	if inv.invoice_type != "billable":
-		return {"invoice": invoice_name, "skipped": "cost_report"}
+	if inv.invoice_type != "Billable":
+		return {"invoice": invoice_name, "skipped": "Cost Report"}
 	if inv.status not in ("Open", "Overdue") or frappe.utils.flt(inv.expected_collection) <= 0:
 		return {"invoice": invoice_name, "skipped": "nothing_due"}
 	if not inv.due_date:
@@ -119,16 +119,16 @@ def process_invoice_dunning(invoice_name: str, now=None) -> dict:
 			from central.billing.platform import notifications
 
 			notifications.notify(
-				inv.team, "invoice_overdue", context={"invoice": invoice_name},
+				inv.team, "Invoice Overdue", context={"invoice": invoice_name},
 				reference_doctype="Invoice", reference_name=invoice_name,
 			)
 		if sub:
-			standing = _advance_standing(inv.subscription, "past_due")
+			standing = _advance_standing(inv.subscription, "Past Due")
 
 	# --- Day 14: suspend directive -> Agent stops --------------------------
 	if days >= SUSPEND_AFTER_DAYS and sub:
-		standing = _advance_standing(inv.subscription, "suspended")
-		if standing == "suspended" and not _active_directive(sub.team, "suspend"):
+		standing = _advance_standing(inv.subscription, "Suspended")
+		if standing == "Suspended" and not _active_directive(sub.team, "suspend"):
 			issue_token(sub.team, {}, suspend=True)
 			_notify(inv, f"Suspended for non-payment (day {days}); resource stopped, data preserved.")
 			actions.append("suspend")
@@ -147,7 +147,7 @@ def run_dunning(now=None) -> list[dict]:
 	invoices = frappe.get_all(
 		"Invoice",
 		filters=[
-			["invoice_type", "=", "billable"],
+			["invoice_type", "=", "Billable"],
 			["status", "in", ["Open", "Overdue"]],
 			["expected_collection", ">", 0],
 		],

--- a/central/billing/revenue/erpnext_sync.py
+++ b/central/billing/revenue/erpnext_sync.py
@@ -38,7 +38,7 @@ def sync_invoice(invoice: str) -> dict:
 	status — the sync state lives in its own fields.
 	"""
 	inv = frappe.get_doc("Invoice", invoice)
-	if inv.invoice_type != "billable":
+	if inv.invoice_type != "Billable":
 		return {"skipped": "not_billable"}  # cost_report is not a statutory sale
 	if inv.status != "Paid":
 		return {"skipped": "not_paid"}
@@ -56,7 +56,7 @@ def sync_invoice(invoice: str) -> dict:
 		invoice,
 		{
 			"erpnext_invoice": erpnext_name,
-			"erpnext_sync_status": "synced",
+			"erpnext_sync_status": "Synced",
 			"erpnext_sync_attempts": attempt,
 			"erpnext_sync_error": None,
 			"erpnext_next_retry_at": None,
@@ -70,14 +70,14 @@ def _handle_failure(invoice: str, attempt: int, error: str) -> dict:
 	customer invoice is never rolled back — it stays Paid."""
 	values = {"erpnext_sync_attempts": attempt, "erpnext_sync_error": error[:140]}
 	if attempt >= MAX_ATTEMPTS:
-		values["erpnext_sync_status"] = "failed"
+		values["erpnext_sync_status"] = "Failed"
 		values["erpnext_next_retry_at"] = None
 		frappe.db.set_value("Invoice", invoice, values)
 		_alert_ops(invoice, error)
 		return {"failed": error, "attempts": attempt}
 
 	backoff = BACKOFF_BASE_SECONDS * (2 ** (attempt - 1))
-	values["erpnext_sync_status"] = "pending"
+	values["erpnext_sync_status"] = "Pending"
 	values["erpnext_next_retry_at"] = frappe.utils.add_to_date(
 		frappe.utils.now_datetime(), seconds=backoff
 	)
@@ -91,7 +91,7 @@ def retry_failed_syncs(now=None) -> list:
 	due = frappe.get_all(
 		"Invoice",
 		filters=[
-			["erpnext_sync_status", "=", "pending"],
+			["erpnext_sync_status", "=", "Pending"],
 			["erpnext_next_retry_at", "is", "set"],
 			["erpnext_next_retry_at", "<=", now],
 		],

--- a/central/billing/revenue/invoicing/lifecycle.py
+++ b/central/billing/revenue/invoicing/lifecycle.py
@@ -46,7 +46,7 @@ def open_and_collect(invoice: str, collect: bool = True) -> dict:
 
 	# Free/trial: a cost_report is computed, never collected — no credits, no
 	# charge. It is opened as a record of the subsidy cost.
-	if doc.invoice_type == "cost_report":
+	if doc.invoice_type == "Cost Report":
 		doc.credit_applied = 0
 		doc.expected_collection = 0
 		doc.status = "Open"

--- a/central/billing/revenue/invoicing/lines.py
+++ b/central/billing/revenue/invoicing/lines.py
@@ -30,7 +30,7 @@ def compute_line_items(team: str, cluster: str, period_start, period_end) -> lis
 		filters={
 			"team": team,
 			"cluster": cluster,
-			"event_type": ["!=", "cancelled"],
+			"event_type": ["!=", "Cancelled"],
 		},
 		fields=["name", "resource_id", "plan", "locked_rate", "started_at", "ended_at"],
 		order_by="started_at asc",

--- a/central/billing/revenue/metering.py
+++ b/central/billing/revenue/metering.py
@@ -38,7 +38,7 @@ def _resolve_terms(meter: dict):
 	  active price-lock (skipped when there is no active lock).
 	"""
 	addon = _addon_for(meter.get("resource_type"))
-	if addon and addon.pricing_mode == "live":
+	if addon and addon.pricing_mode == "Live":
 		return {
 			"team": meter.get("team"),
 			"cluster": meter.get("cluster"),
@@ -162,7 +162,7 @@ def metered_line_items(team: str, cluster: str, period_start, period_end) -> lis
 		# A live add-on (e.g. snapshot) reads the CURRENT catalog rate and has no
 		# allowance; a grandfathered add-on uses the terms locked at ingest.
 		addon = _addon_for(r.resource_type)
-		if addon and addon.pricing_mode == "live":
+		if addon and addon.pricing_mode == "Live":
 			rate = frappe.utils.flt(resolve_rate(get_catalog_rates("Add-on", addon.name), r.currency, cluster))
 			allowance = 0.0
 		else:

--- a/central/billing/revenue/pricelock.py
+++ b/central/billing/revenue/pricelock.py
@@ -50,7 +50,7 @@ def lock_from_event(event: dict) -> str | None:
 	effective = event.get("effective_from")
 
 	# A plan change or cancellation closes the resource's current open lock.
-	if event_type in ("changed", "cancelled"):
+	if event_type in ("changed", "Cancelled"):
 		prior = _open_lock(resource_id)
 		if prior:
 			frappe.db.set_value("Price Lock", prior, "ended_at", event.get("effective_to") or effective)
@@ -79,7 +79,7 @@ def lock_from_event(event: dict) -> str | None:
 			"cluster": cluster,
 			"started_at": effective,
 			# A cancellation opens no live lock — it is a closed terminal marker.
-			"ended_at": (event.get("effective_to") or effective) if event_type == "cancelled" else None,
+			"ended_at": (event.get("effective_to") or effective) if event_type == "Cancelled" else None,
 			"source_event_id": event_id,
 			"event_type": event_type,
 			"discrepancy": 1 if discrepancy else 0,

--- a/central/billing/revenue/tax.py
+++ b/central/billing/revenue/tax.py
@@ -4,7 +4,7 @@
 
   - Additive output tax (GST/VAT) — added to `total`; the customer pays more.
   - Zero-rating with reason (SEZ-LUT/export) — tax 0 *plus* a compliance reason
-    code (never a bare "none" — an auditor will ask).
+    code (never a bare "None" — an auditor will ask).
   - Withholding (TDS) — reduces what is *collected*, not `total`; the customer
     pays less and supplies a certificate.
 
@@ -20,7 +20,7 @@ is 0 at launch (no team self-declares yet).
 import frappe
 
 _ZERO_BLOCK = {
-	"output_tax_type": "none",
+	"output_tax_type": "None",
 	"output_tax_rate": 0,
 	"output_tax_amount": 0,
 	"zero_rating_reason": None,
@@ -42,7 +42,7 @@ def resolve_tax(team: str, subtotal) -> dict:
 
 	p = frappe.get_doc("Tax Profile", team)
 	block = dict(_ZERO_BLOCK)
-	block["output_tax_type"] = p.output_tax_type or "none"
+	block["output_tax_type"] = p.output_tax_type or "None"
 	block["output_tax_rate"] = frappe.utils.flt(p.output_tax_rate)
 
 	if p.zero_rated:

--- a/central/billing/tests/gateway_contract.py
+++ b/central/billing/tests/gateway_contract.py
@@ -121,7 +121,7 @@ class GatewayAdapterContract:
 		with self.charge_succeeds(txn_id="txn_ok"):
 			result = adapter.charge(invoice, method, key)
 		self.assertTrue(result.success)
-		self.assertEqual(result.status, "captured")
+		self.assertEqual(result.status, "Captured")
 		self.assertEqual(result.gateway_transaction_id, "txn_ok")
 
 	def test_declined_charge_is_a_failure_not_an_exception(self):
@@ -130,7 +130,7 @@ class GatewayAdapterContract:
 		with self.charge_declines(code="card_declined"):
 			result = adapter.charge(invoice, method, key)
 		self.assertFalse(result.success)
-		self.assertEqual(result.status, "failed")
+		self.assertEqual(result.status, "Failed")
 		self.assertEqual(result.failure_code, "card_declined")
 
 	def test_timeout_raises_gateway_timeout_and_forwards_idempotency_key(self):
@@ -150,7 +150,7 @@ class GatewayAdapterContract:
 		with self.refund_succeeds(refund_id="rfnd_ok"):
 			result = adapter.refund(payment_attempt, amount, reason)
 		self.assertTrue(result.success)
-		self.assertEqual(result.status, "completed")
+		self.assertEqual(result.status, "Completed")
 		self.assertEqual(result.gateway_refund_id, "rfnd_ok")
 
 	def test_parse_webhook_event_normalises_id_and_type(self):

--- a/central/billing/tests/test_admin.py
+++ b/central/billing/tests/test_admin.py
@@ -31,7 +31,7 @@ class AdminTestBase(IntegrationTestCase):
 			frappe.db.delete("Credit Wallet", {"team": team})
 		frappe.db.commit()
 
-	def _invoice(self, team, total, status="Paid", itype="billable", cluster="ap-south-1",
+	def _invoice(self, team, total, status="Paid", itype="Billable", cluster="ap-south-1",
 				 due_date=None, paid=None):
 		return frappe.get_doc(
 			{"doctype": "Invoice", "team": team, "invoice_type": itype, "status": status,
@@ -70,7 +70,7 @@ class TestAggregates(AdminTestBase):
 		self.assertEqual(teams[TEAM_A], 1000)
 
 	def test_free_trial_subsidy_by_cluster_and_plan(self):
-		self._invoice(TEAM_A, 800, itype="cost_report", cluster="ap-south-1")
+		self._invoice(TEAM_A, 800, itype="Cost Report", cluster="ap-south-1")
 		out = admin.get_free_trial_costs("2099-01-01", "2099-01-31")
 		self.assertEqual(out["total_subsidy"], 800)
 		self.assertEqual(out["by_cluster"]["ap-south-1"], 800)
@@ -80,7 +80,7 @@ class TestAggregates(AdminTestBase):
 class TestPanels(AdminTestBase):
 	def test_payment_analytics_success_rate_and_reasons(self):
 		inv = self._invoice(TEAM_A, 100, status="Open", paid=0)
-		for status, code in [("captured", None), ("captured", None), ("failed", "card_declined")]:
+		for status, code in [("Captured", None), ("Captured", None), ("Failed", "card_declined")]:
 			frappe.get_doc(
 				{"doctype": "Payment Attempt", "team": TEAM_A, "invoice": inv, "gateway": None,
 				 "amount": 100, "status": status, "failure_code": code,
@@ -130,9 +130,9 @@ class TestMetricsReports(AdminTestBase):
 	def test_metrics_counts_and_mrr(self):
 		from central.billing.catalog import subscriptions
 
-		subscriptions.create_subscription(team=TEAM_A, cluster="ap-south-1", plan=PLAN, billing_cycle="monthly")
-		sub_b = subscriptions.create_subscription(team=TEAM_B, cluster="ap-south-1", plan=PLAN, billing_cycle="monthly")
-		subscriptions.set_standing(sub_b.name, "past_due")
+		subscriptions.create_subscription(team=TEAM_A, cluster="ap-south-1", plan=PLAN, billing_cycle="Monthly")
+		sub_b = subscriptions.create_subscription(team=TEAM_B, cluster="ap-south-1", plan=PLAN, billing_cycle="Monthly")
+		subscriptions.set_standing(sub_b.name, "Past Due")
 
 		m = admin.get_metrics()
 		self.assertGreaterEqual(m["team_count"], 2)
@@ -141,7 +141,7 @@ class TestMetricsReports(AdminTestBase):
 		self.assertIn("payment_failures", m)
 
 		teams = {t["team"]: t for t in admin.list_teams()}
-		self.assertEqual(teams[TEAM_B]["standing"], "past_due")
+		self.assertEqual(teams[TEAM_B]["standing"], "Past Due")
 		self.assertGreater(teams[TEAM_A]["mrr"], 0)
 		for team in (TEAM_A, TEAM_B):
 			for sub in frappe.get_all("Subscription", {"team": team}, pluck="name"):

--- a/central/billing/tests/test_billing.py
+++ b/central/billing/tests/test_billing.py
@@ -67,7 +67,7 @@ class BillingTestBase(IntegrationTestCase):
 		make_plan(PLAN)
 		self._purge()
 		self.sub = subscriptions.create_subscription(
-			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="monthly"
+			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="Monthly"
 		).name
 
 	def tearDown(self):
@@ -106,7 +106,7 @@ class TestDraftGeneration(BillingTestBase):
 	def test_same_day_provision_destroy_floors_to_one_day(self):
 		# Provisioned and cancelled on the same day → 1 day, not 0.
 		push_event("e1", "R2", 1000, "2026-06-05 00:00:00", "subscribed")
-		push_event("e2", "R2", 1000, "2026-06-05 00:00:00", "cancelled")
+		push_event("e2", "R2", 1000, "2026-06-05 00:00:00", "Cancelled")
 
 		name = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
 		inv = frappe.get_doc("Invoice", name)
@@ -173,6 +173,6 @@ class TestOpenAndCollect(BillingTestBase):
 		# One debit entry for the invoice — no duplicate debit.
 		debits = frappe.get_all(
 			"Credit Ledger Entry",
-			{"team": TEAM, "entry_type": "debit", "reference_name": name},
+			{"team": TEAM, "entry_type": "Debit", "reference_name": name},
 		)
 		self.assertEqual(len(debits), 1)

--- a/central/billing/tests/test_charges.py
+++ b/central/billing/tests/test_charges.py
@@ -52,7 +52,7 @@ def stub_adapter(success=True, txn_id="pi_x"):
 	adapter = MagicMock()
 	adapter.charge.return_value = PaymentResult(
 		success=success,
-		status="captured" if success else "failed",
+		status="Captured" if success else "Failed",
 		gateway_transaction_id=txn_id if success else None,
 		failure_code=None if success else "card_declined",
 		failure_reason=None if success else "declined",
@@ -72,7 +72,7 @@ class ChargeTestBase(IntegrationTestCase):
 			team=TEAM,
 			cluster=CLUSTER,
 			plan=PLAN,
-			billing_cycle="monthly",
+			billing_cycle="Monthly",
 			default_payment_method=self.method,
 			gateway=GATEWAY,
 		).name
@@ -98,8 +98,8 @@ class ChargeTestBase(IntegrationTestCase):
 				"doctype": "Payment Method",
 				"team": TEAM,
 				"gateway": GATEWAY,
-				"method_type": "card",
-				"status": "active",
+				"method_type": "Card",
+				"status": "Active",
 				"gateway_method_id": "pm_card",
 				"gateway_customer_id": "cus_1",
 				"is_default": 1,
@@ -133,7 +133,7 @@ class ChargeTestBase(IntegrationTestCase):
 				"gateway_event_id": gateway_event_id,
 				"event_type": event_type,
 				"raw_payload": json.dumps(payload),
-				"status": "received",
+				"status": "Received",
 			}
 		).insert(ignore_permissions=True).name
 
@@ -149,7 +149,7 @@ class TestChargeInvoice(ChargeTestBase):
 		attempt = frappe.get_doc("Payment Attempt", result["attempt"])
 		self.assertEqual(adapter.charge.call_args.args[2], attempt.idempotency_key)
 		self.assertEqual(attempt.idempotency_key, attempt.name)
-		self.assertEqual(attempt.status, "captured")
+		self.assertEqual(attempt.status, "Captured")
 		self.assertEqual(attempt.gateway_transaction_id, "pi_1")
 		# Crucially: invoice is NOT Paid on the charge response.
 		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Open")
@@ -160,7 +160,7 @@ class TestChargeInvoice(ChargeTestBase):
 			result = charges.pay_invoice(inv)
 		self.assertFalse(result["charged"])
 		attempt = frappe.get_doc("Payment Attempt", result["attempt"])
-		self.assertEqual(attempt.status, "failed")
+		self.assertEqual(attempt.status, "Failed")
 		self.assertEqual(attempt.failure_code, "card_declined")
 		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Open")
 
@@ -207,18 +207,18 @@ class TestChargeInvoice(ChargeTestBase):
 		# An authorise-only charge: the sync response holds funds, attempt initiated.
 		with stub_adapter(success=False, txn_id="pi_auth") as adapter:
 			adapter.charge.return_value = PaymentResult(
-				success=False, status="authorised", gateway_transaction_id="pi_auth",
+				success=False, status="Authorised", gateway_transaction_id="pi_auth",
 				failure_code=None, failure_reason=None,
 			)
 			attempt_name = charges.pay_invoice(inv)["attempt"]
 		# Manually leave the attempt at initiated (charge didn't capture).
-		frappe.db.set_value("Payment Attempt", attempt_name, {"status": "initiated", "gateway_transaction_id": "pi_auth"})
+		frappe.db.set_value("Payment Attempt", attempt_name, {"status": "Initiated", "gateway_transaction_id": "pi_auth"})
 
 		event = self._stripe_event("evt_auth", "payment_intent.amount_capturable_updated", "pi_auth")
 		out = charges.apply_webhook(event)
 
-		self.assertEqual(out["result"], "authorised")
-		self.assertEqual(frappe.db.get_value("Payment Attempt", attempt_name, "status"), "authorised")
+		self.assertEqual(out["result"], "Authorised")
+		self.assertEqual(frappe.db.get_value("Payment Attempt", attempt_name, "status"), "Authorised")
 		# Funds only held — invoice not settled.
 		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Open")
 
@@ -230,7 +230,7 @@ class TestChargeInvoice(ChargeTestBase):
 		charges.apply_webhook(self._stripe_event("evt_cap", "payment_intent.succeeded", "pi_race"))
 		# A late authorise webhook for the same txn must not regress it.
 		charges.apply_webhook(self._stripe_event("evt_late", "payment_intent.amount_capturable_updated", "pi_race"))
-		self.assertEqual(frappe.db.get_value("Payment Attempt", attempt_name, "status"), "captured")
+		self.assertEqual(frappe.db.get_value("Payment Attempt", attempt_name, "status"), "Captured")
 		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Paid")
 
 
@@ -245,7 +245,7 @@ class TestConcurrentPay(ChargeTestBase):
 		frappe.db.rollback()
 		attempts = frappe.get_all("Payment Attempt", {"invoice": inv}, ["name", "status"])
 		self.assertEqual(len(attempts), 1)  # exactly one attempt created
-		self.assertEqual(attempts[0].status, "captured")  # and only it reaches captured
+		self.assertEqual(attempts[0].status, "Captured")  # and only it reaches captured
 
 
 class TestFullStripeCycle(ChargeTestBase):
@@ -268,7 +268,7 @@ class TestFullStripeCycle(ChargeTestBase):
 			{"id": "evt_cycle", "type": "payment_intent.succeeded", "data": {"object": {"id": "pi_cycle"}}}
 		).encode()
 		with patch.object(StripeAdapter, "verify_webhook_signature", return_value=True):
-			webhooks.process_webhook("stripe", body, {"Stripe-Signature": "x"})
+			webhooks.process_webhook("Stripe", body, {"Stripe-Signature": "x"})
 
 		event_name = frappe.get_all("Webhook Event", {"gateway_event_id": "evt_cycle"}, pluck="name")[0]
 		webhooks.handle_webhook_event(event_name)
@@ -300,37 +300,37 @@ class TestLogRetention(ChargeTestBase):
 		return frappe.utils.add_to_date(frappe.utils.now_datetime(), days=200)
 
 	def test_prunes_terminal_attempt_on_settled_invoice(self):
-		captured = self._attempt(self._paid_invoice(), "captured")
+		captured = self._attempt(self._paid_invoice(), "Captured")
 		out = charges.cleanup_payment_logs(now=self._far_future())
 		self.assertGreaterEqual(out["payment_attempts"], 1)
 		self.assertFalse(frappe.db.exists("Payment Attempt", captured))
 
 	def test_keeps_attempt_on_unsettled_invoice(self):
-		live = self._attempt(self._open_invoice(1000), "failed")  # invoice still Open
+		live = self._attempt(self._open_invoice(1000), "Failed")  # invoice still Open
 		charges.cleanup_payment_logs(now=self._far_future())
 		self.assertTrue(frappe.db.exists("Payment Attempt", live))
 
 	def test_keeps_non_terminal_attempt(self):
-		initiated = self._attempt(self._paid_invoice(), "initiated")
+		initiated = self._attempt(self._paid_invoice(), "Initiated")
 		charges.cleanup_payment_logs(now=self._far_future())
 		self.assertTrue(frappe.db.exists("Payment Attempt", initiated))
 
 	def test_keeps_attempt_referenced_by_refund(self):
-		refunded = self._attempt(self._paid_invoice(), "refunded")
+		refunded = self._attempt(self._paid_invoice(), "Refunded")
 		frappe.get_doc({"doctype": "Refund", "payment_attempt": refunded}).insert(ignore_permissions=True)
 		charges.cleanup_payment_logs(now=self._far_future())
 		self.assertTrue(frappe.db.exists("Payment Attempt", refunded))
 
 	def test_prunes_processed_event_keeps_unhandled(self):
 		processed = self._stripe_event("evt_old_done", "payment_intent.succeeded", "pi_x")
-		frappe.db.set_value("Webhook Event", processed, "status", "processed")
+		frappe.db.set_value("Webhook Event", processed, "status", "Processed")
 		pending = self._stripe_event("evt_old_recv", "payment_intent.succeeded", "pi_y")  # still received
 		charges.cleanup_payment_logs(now=self._far_future())
 		self.assertFalse(frappe.db.exists("Webhook Event", processed))
 		self.assertTrue(frappe.db.exists("Webhook Event", pending))
 
 	def test_respects_config_window(self):
-		captured = self._attempt(self._paid_invoice(), "captured")
+		captured = self._attempt(self._paid_invoice(), "Captured")
 		# Wide window (1 year) with 'now' = real now: a fresh row is NOT old enough.
 		with patch.dict(frappe.conf, {"payment_log_retention_days": 365}):
 			charges.cleanup_payment_logs()

--- a/central/billing/tests/test_collection.py
+++ b/central/billing/tests/test_collection.py
@@ -22,7 +22,7 @@ GATEWAY = "GW-Fallback-Stripe"
 def _result(success, txn_id):
 	return PaymentResult(
 		success=success,
-		status="captured" if success else "failed",
+		status="Captured" if success else "Failed",
 		gateway_transaction_id=txn_id if success else None,
 		failure_code=None if success else "card_declined",
 		failure_reason=None if success else "declined",
@@ -63,7 +63,7 @@ class FallbackTestBase(IntegrationTestCase):
 		return frappe.get_doc(
 			{
 				"doctype": "Payment Method", "team": TEAM, "gateway": GATEWAY,
-				"method_type": "card", "status": "active", "display_label": label,
+				"method_type": "Card", "status": "Active", "display_label": label,
 				"gateway_method_id": gw_id, "gateway_customer_id": "cus_1",
 				"priority": priority, "is_default": 1 if priority == 0 else 0,
 				"reauth_required": reauth,
@@ -87,7 +87,7 @@ class FallbackTestBase(IntegrationTestCase):
 			{
 				"doctype": "Webhook Event", "gateway": GATEWAY, "gateway_event_id": f"evt_{txn_id}",
 				"event_type": "payment_intent.payment_failed", "raw_payload": json.dumps(payload),
-				"status": "received",
+				"status": "Received",
 			}
 		).insert(ignore_permissions=True).name
 
@@ -109,8 +109,8 @@ class TestSyncFallback(FallbackTestBase):
 		self.assertEqual(adapter.charge.call_count, 2)  # primary then backup
 		attempts = self._attempts()
 		self.assertEqual([a.payment_method for a in attempts], [self.primary, self.backup])
-		self.assertEqual(attempts[0].status, "failed")
-		self.assertEqual(attempts[1].status, "captured")  # awaiting webhook, but charged
+		self.assertEqual(attempts[0].status, "Failed")
+		self.assertEqual(attempts[1].status, "Captured")  # awaiting webhook, but charged
 
 	def test_all_methods_fail_leaves_invoice_open_without_repeat(self):
 		inv = self._open_invoice()
@@ -147,7 +147,7 @@ class TestWebhookFallback(FallbackTestBase):
 		self.assertIn("pi_backup", attempts)
 		self.assertEqual(attempts["pi_backup"].payment_method, self.backup)
 		primary_attempt = next(a for a in self._attempts() if a.payment_method == self.primary)
-		self.assertEqual(primary_attempt.status, "failed")
+		self.assertEqual(primary_attempt.status, "Failed")
 
 
 class TestMethodOrdering(FallbackTestBase):

--- a/central/billing/tests/test_commitments.py
+++ b/central/billing/tests/test_commitments.py
@@ -62,7 +62,7 @@ class CommitmentTestBase(IntegrationTestCase):
 		make_plan(PLAN)
 		self._purge()
 		self.sub = subscriptions.create_subscription(
-			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="monthly"
+			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="Monthly"
 		).name
 
 	def tearDown(self):
@@ -111,7 +111,7 @@ class TestCommitmentDiscount(CommitmentTestBase):
 				"team": TEAM,
 				"cluster": CLUSTER,
 				"resource_type": resource_type,
-				"meter_type": "counter",
+				"meter_type": "Counter",
 				"period_start": "2026-06-01",
 				"period_end": "2026-06-30",
 				"quantity": quantity,
@@ -126,7 +126,7 @@ class TestCommitmentDiscount(CommitmentTestBase):
 	def test_discount_base_is_fixed_bundle_only(self):
 		# Bundle 1000 (discountable) + metered transfer 300 (billed at list).
 		push_event("e1", "R1", 1000, "2026-06-01 00:00:00", "subscribed")
-		self._metered_rollup("R-transfer", "transfer", quantity=300, rate=1)
+		self._metered_rollup("R-transfer", "Transfer", quantity=300, rate=1)
 		make_commitment(TEAM, floor=800, discount_pct=20)
 
 		name = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
@@ -157,7 +157,7 @@ class TestCommitmentClawback(CommitmentTestBase):
 		self.assertEqual(frappe.get_doc("Invoice", june).commitment_discount, 200.0)
 
 		# July: resource terminated Jul16 -> 15 days, spend < 800 floor -> breach.
-		push_event("e2", "R1", 1000, "2026-07-16 00:00:00", "cancelled")
+		push_event("e2", "R1", 1000, "2026-07-16 00:00:00", "Cancelled")
 		july = invoicing.generate_draft_invoice(self.sub, "2026-07-01", "2026-07-31")
 		inv = frappe.get_doc("Invoice", july)
 
@@ -184,7 +184,7 @@ class TestCommitmentClawback(CommitmentTestBase):
 		commitment = make_commitment(TEAM, floor=800, discount_pct=20, started_at="2026-06-01")
 		push_event("e1", "R1", 1000, "2026-06-01 00:00:00", "subscribed")
 		invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
-		push_event("e2", "R1", 1000, "2026-07-16 00:00:00", "cancelled")
+		push_event("e2", "R1", 1000, "2026-07-16 00:00:00", "Cancelled")
 
 		first = invoicing.generate_draft_invoice(self.sub, "2026-07-01", "2026-07-31")
 		second = invoicing.generate_draft_invoice(self.sub, "2026-07-01", "2026-07-31")

--- a/central/billing/tests/test_credits.py
+++ b/central/billing/tests/test_credits.py
@@ -76,7 +76,7 @@ class TestLedgerBasics(CreditTestBase):
 		entries = frappe.get_all(
 			"Credit Ledger Entry", {"team": TEAM}, ["entry_type", "amount"]
 		)
-		signed = sum((e.amount if e.entry_type == "credit" else -e.amount) for e in entries)
+		signed = sum((e.amount if e.entry_type == "Credit" else -e.amount) for e in entries)
 		self.assertEqual(signed, 410)
 		# Balance read equals the ledger sum — it is never a stored scalar.
 		self.assertEqual(credits.get_balance(TEAM)["balance"], signed)
@@ -87,7 +87,7 @@ class TestLedgerBasics(CreditTestBase):
 		self.assertEqual(res["new_balance"], 300)
 		latest = frappe.get_all(
 			"Credit Ledger Entry",
-			{"team": TEAM, "entry_type": "debit"},
+			{"team": TEAM, "entry_type": "Debit"},
 			pluck="running_balance",
 		)
 		self.assertEqual(latest, [300])
@@ -114,7 +114,7 @@ class TestLedgerBasics(CreditTestBase):
 
 	def test_admin_adjustment_books_an_entry(self):
 		credits.purchase(TEAM, 100)
-		res = credits.adjust_credits(TEAM, 25, "debit", note="dispute clawback")
+		res = credits.adjust_credits(TEAM, 25, "Debit", note="dispute clawback")
 		self.assertEqual(res["new_balance"], 75)
 
 	def test_get_balance_filtered_by_currency(self):
@@ -155,7 +155,7 @@ class TestConcurrency(CreditTestBase):
 		# running_balance is the exact cumulative ladder — no gaps, no negatives.
 		debit_balances = sorted(
 			frappe.get_all(
-				"Credit Ledger Entry", {"team": TEAM, "entry_type": "debit"}, pluck="running_balance"
+				"Credit Ledger Entry", {"team": TEAM, "entry_type": "Debit"}, pluck="running_balance"
 			)
 		)
 		self.assertEqual(debit_balances, [0, 10, 20, 30, 40, 50, 60, 70, 80, 90])

--- a/central/billing/tests/test_dashboard.py
+++ b/central/billing/tests/test_dashboard.py
@@ -78,7 +78,7 @@ class TestForecast(CustomerDataBase):
 class TestCustomerReads(CustomerDataBase):
 	def _invoice(self):
 		return frappe.get_doc(
-			{"doctype": "Invoice", "team": TEAM, "invoice_type": "billable", "status": "Paid",
+			{"doctype": "Invoice", "team": TEAM, "invoice_type": "Billable", "status": "Paid",
 			 "period_start": "2026-05-01", "period_end": "2026-05-31", "currency": "INR",
 			 "subtotal": 1000, "output_tax_type": "GST", "output_tax_amount": 180, "total": 1180,
 			 "amount_paid": 1180,
@@ -104,8 +104,8 @@ class TestCustomerReads(CustomerDataBase):
 
 		gw = make_stripe_gateway("GW-Cust-Stripe").name
 		frappe.get_doc(
-			{"doctype": "Payment Method", "team": TEAM, "gateway": gw, "method_type": "card",
-			 "status": "active", "display_label": "Visa ····4242", "gateway_method_id": "pm_secret",
+			{"doctype": "Payment Method", "team": TEAM, "gateway": gw, "method_type": "Card",
+			 "status": "Active", "display_label": "Visa ····4242", "gateway_method_id": "pm_secret",
 			 "is_default": 1}
 		).insert(ignore_permissions=True)
 		rows = dashboard.list_payment_methods(TEAM)
@@ -119,7 +119,7 @@ class TestCustomerReads(CustomerDataBase):
 		credits.purchase(TEAM, 500, "INR")
 		self.assertEqual(dashboard.get_credit_balance(TEAM)["balance"], 500)
 		ledger = dashboard.credit_ledger(TEAM)
-		self.assertEqual(ledger[0]["entry_type"], "credit")
+		self.assertEqual(ledger[0]["entry_type"], "Credit")
 
 
 class TestTeamScoping(CustomerDataBase):
@@ -150,7 +150,7 @@ class TestTeamScoping(CustomerDataBase):
 					with self.assertRaises(frappe.PermissionError):
 						dashboard.list_invoices(team.name)
 					with self.assertRaises(frappe.PermissionError):
-						dashboard.save_billing_settings(team=team.name, billing_mode="prepaid")
+						dashboard.save_billing_settings(team=team.name, billing_mode="Prepaid")
 				finally:
 					frappe.set_user("Administrator")
 
@@ -171,7 +171,7 @@ class TestTeamScoping(CustomerDataBase):
 				frappe.set_user(member)
 				try:
 					dashboard.list_invoices(team_name)  # read ok
-					dashboard.save_billing_settings(team=team_name, billing_mode="prepaid")  # manage ok
+					dashboard.save_billing_settings(team=team_name, billing_mode="Prepaid")  # manage ok
 				finally:
 					frappe.set_user("Administrator")
 					frappe.db.delete("Billing Profile", {"team": team_name})
@@ -187,7 +187,7 @@ class TestTeamScoping(CustomerDataBase):
 			dashboard.list_invoices(team.name)  # read ok
 			dashboard.get_credit_balance(team.name)  # read ok
 			with self.assertRaises(frappe.PermissionError):
-				dashboard.save_billing_settings(team=team.name, billing_mode="prepaid")
+				dashboard.save_billing_settings(team=team.name, billing_mode="Prepaid")
 			with self.assertRaises(frappe.PermissionError):
 				dashboard.purchase_credits(team=team.name, amount=100)
 		finally:
@@ -216,14 +216,14 @@ class TestCustomerActions(CustomerDataBase):
 
 
 	def test_billing_settings_roundtrip(self):
-		dashboard.save_billing_settings(team=TEAM, billing_mode="prepaid", min_balance=5000)
+		dashboard.save_billing_settings(team=TEAM, billing_mode="Prepaid", min_balance=5000)
 		s = dashboard.get_billing_settings(TEAM)
-		self.assertEqual(s["billing_mode"], "prepaid")
+		self.assertEqual(s["billing_mode"], "Prepaid")
 		self.assertEqual(s["min_balance"], 5000)
 
 	def test_admin_without_team_falls_back(self):
 		from central.billing.catalog import subscriptions
-		subscriptions.create_subscription(team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="monthly")
+		subscriptions.create_subscription(team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="Monthly")
 		invoices = dashboard.list_invoices()  # no team arg, as admin
 		self.assertIsInstance(invoices, list)
 
@@ -274,7 +274,7 @@ class TestGatewayTopUp(CustomerDataBase):
 			"payment_status": "paid", "payment_intent": "pi_x", "amount_total": 500000, "currency": "eur"}
 		with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
 			order = dashboard.create_topup_order(team=TEAM, amount=5000, gateway=gw)
-			self.assertEqual(order["adapter_key"], "stripe")
+			self.assertEqual(order["adapter_key"], "Stripe")
 			self.assertEqual(order["checkout_url"], "https://stripe.test/cs")  # redirect, not a Razorpay order
 			adapter.create_checkout_session.assert_called_once()
 			self.assertEqual(dashboard.get_credit_balance(TEAM)["balance"], 0)  # not credited yet

--- a/central/billing/tests/test_dunning.py
+++ b/central/billing/tests/test_dunning.py
@@ -26,7 +26,7 @@ DUE = "2026-06-01"
 def declining_gateway():
 	adapter = MagicMock()
 	adapter.charge.return_value = PaymentResult(
-		success=False, status="failed", failure_code="card_declined", failure_reason="Card declined"
+		success=False, status="Failed", failure_code="card_declined", failure_reason="Card declined"
 	)
 	with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
 		yield adapter
@@ -69,14 +69,14 @@ class DunningTestBase(IntegrationTestCase):
 		return frappe.get_doc(
 			{
 				"doctype": "Payment Method", "team": TEAM, "gateway": GATEWAY,
-				"method_type": "card", "status": "active",
+				"method_type": "Card", "status": "Active",
 				"gateway_method_id": "pm_x", "gateway_customer_id": "cus_x", "is_default": 1,
 			}
 		).insert(ignore_permissions=True).name
 
 	def _subscription(self, with_card=True):
 		return subscriptions.create_subscription(
-			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="monthly",
+			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="Monthly",
 			default_payment_method=self._card() if with_card else None,
 			gateway=GATEWAY if with_card else None,
 		).name
@@ -84,7 +84,7 @@ class DunningTestBase(IntegrationTestCase):
 	def _open_invoice(self, sub, total=1000):
 		return frappe.get_doc(
 			{
-				"doctype": "Invoice", "team": TEAM, "subscription": sub, "invoice_type": "billable",
+				"doctype": "Invoice", "team": TEAM, "subscription": sub, "invoice_type": "Billable",
 				"status": "Open", "period_start": "2026-05-01", "period_end": "2026-05-31",
 				"currency": "INR", "subtotal": total, "total": total,
 				"expected_collection": total, "due_date": DUE,
@@ -129,7 +129,7 @@ class TestRetrySchedule(DunningTestBase):
 		frappe.get_doc(
 			{
 				"doctype": "Payment Method", "team": TEAM, "gateway": GATEWAY,
-				"method_type": "card", "status": "active", "gateway_method_id": "pm_y",
+				"method_type": "Card", "status": "Active", "gateway_method_id": "pm_y",
 				"gateway_customer_id": "cus_x", "priority": 1,
 			}
 		).insert(ignore_permissions=True)
@@ -162,7 +162,7 @@ class TestStagedEscalation(DunningTestBase):
 		self._run_through(inv, sub, last_day=7)
 
 		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Overdue")
-		self.assertEqual(self._standing(sub), "past_due")  # grace
+		self.assertEqual(self._standing(sub), "Past Due")  # grace
 		self.assertFalse(self._has_directive("suspend"))  # not stopped — still running
 
 	def test_day14_suspend_directive_on_token_channel(self):
@@ -170,7 +170,7 @@ class TestStagedEscalation(DunningTestBase):
 		inv = self._open_invoice(sub)
 		self._run_through(inv, sub, last_day=14)
 
-		self.assertEqual(self._standing(sub), "suspended")
+		self.assertEqual(self._standing(sub), "Suspended")
 		self.assertTrue(self._has_directive("suspend"))  # cap-0 + suspend rides the token
 
 	def test_day44_terminate_directive(self):
@@ -183,9 +183,9 @@ class TestStagedEscalation(DunningTestBase):
 	def test_cost_report_invoice_is_not_dunned(self):
 		sub = self._subscription()
 		inv = self._open_invoice(sub)
-		frappe.db.set_value("Invoice", inv, "invoice_type", "cost_report")
+		frappe.db.set_value("Invoice", inv, "invoice_type", "Cost Report")
 		out = dunning.process_invoice_dunning(inv, now=day(14))
-		self.assertEqual(out["skipped"], "cost_report")
+		self.assertEqual(out["skipped"], "Cost Report")
 		self.assertEqual(self._attempts(inv), 0)
 
 
@@ -197,4 +197,4 @@ class TestCreditsOnlyDunning(DunningTestBase):
 			dunning.process_invoice_dunning(inv, now=day(d))
 
 		self.assertEqual(self._attempts(inv), 0)  # nothing to retry against
-		self.assertEqual(self._standing(sub), "suspended")  # but still escalates
+		self.assertEqual(self._standing(sub), "Suspended")  # but still escalates

--- a/central/billing/tests/test_erpnext_sync.py
+++ b/central/billing/tests/test_erpnext_sync.py
@@ -41,7 +41,7 @@ class ErpnextSyncTestBase(IntegrationTestCase):
 		frappe.db.delete("Invoice", {"team": TEAM})
 		frappe.db.commit()
 
-	def _paid_invoice(self, status="Paid", invoice_type="billable"):
+	def _paid_invoice(self, status="Paid", invoice_type="Billable"):
 		return frappe.get_doc(
 			{
 				"doctype": "Invoice", "team": TEAM, "invoice_type": invoice_type, "status": status,
@@ -64,7 +64,7 @@ class TestSyncSuccess(ErpnextSyncTestBase):
 		self.assertEqual(out["synced"], "SINV-9")
 		doc = frappe.get_doc("Invoice", inv)
 		self.assertEqual(doc.erpnext_invoice, "SINV-9")
-		self.assertEqual(doc.erpnext_sync_status, "synced")
+		self.assertEqual(doc.erpnext_sync_status, "Synced")
 		# Payload carries the Sales Invoice shape + a back-reference.
 		payload = post.call_args.kwargs["json"]
 		self.assertEqual(payload["doctype"], "Sales Invoice")
@@ -73,14 +73,14 @@ class TestSyncSuccess(ErpnextSyncTestBase):
 
 	def test_already_synced_is_idempotent(self):
 		inv = self._paid_invoice()
-		frappe.db.set_value("Invoice", inv, {"erpnext_invoice": "SINV-1", "erpnext_sync_status": "synced"})
+		frappe.db.set_value("Invoice", inv, {"erpnext_invoice": "SINV-1", "erpnext_sync_status": "Synced"})
 		with patch("central.billing.revenue.erpnext_sync.requests.post") as post:
 			out = erpnext_sync.sync_invoice(inv)
 			post.assert_not_called()
 		self.assertEqual(out["skipped"], "already_synced")
 
 	def test_cost_report_and_unpaid_are_skipped(self):
-		cost = self._paid_invoice(invoice_type="cost_report")
+		cost = self._paid_invoice(invoice_type="Cost Report")
 		draft = self._paid_invoice(status="Open")
 		with patch("central.billing.revenue.erpnext_sync.requests.post") as post:
 			self.assertEqual(erpnext_sync.sync_invoice(cost)["skipped"], "not_billable")
@@ -97,7 +97,7 @@ class TestFailureIsolation(ErpnextSyncTestBase):
 		self.assertTrue(out["retry_scheduled"])
 		doc = frappe.get_doc("Invoice", inv)
 		self.assertEqual(doc.status, "Paid")  # never rolled back
-		self.assertEqual(doc.erpnext_sync_status, "pending")
+		self.assertEqual(doc.erpnext_sync_status, "Pending")
 		self.assertEqual(doc.erpnext_sync_attempts, 1)
 		self.assertTrue(doc.erpnext_next_retry_at)  # backoff scheduled
 		self.assertFalse(doc.erpnext_invoice)
@@ -114,7 +114,7 @@ class TestFailureIsolation(ErpnextSyncTestBase):
 		self.assertEqual(a3.get("failed") is not None, True)
 		doc = frappe.get_doc("Invoice", inv)
 		self.assertEqual(doc.status, "Paid")
-		self.assertEqual(doc.erpnext_sync_status, "failed")
+		self.assertEqual(doc.erpnext_sync_status, "Failed")
 		self.assertEqual(doc.erpnext_sync_attempts, 3)
 		# Ops alerted (not the customer).
 		comments = frappe.get_all(
@@ -133,7 +133,7 @@ class TestFailureIsolation(ErpnextSyncTestBase):
 			erpnext_sync.retry_failed_syncs(now=future)
 
 		doc = frappe.get_doc("Invoice", inv)
-		self.assertEqual(doc.erpnext_sync_status, "synced")
+		self.assertEqual(doc.erpnext_sync_status, "Synced")
 		self.assertEqual(doc.erpnext_invoice, "SINV-RETRY")
 
 

--- a/central/billing/tests/test_gateway_currency.py
+++ b/central/billing/tests/test_gateway_currency.py
@@ -45,7 +45,7 @@ class TestResolveGatewayForCurrency(IntegrationTestCase):
 				frappe.delete_doc("Payment Gateway", name, force=True)
 
 	def test_returns_gateway_with_is_default_for_currency(self):
-		_make_gateway("GW-USD-A", "stripe", [("USD", 1)])
+		_make_gateway("GW-USD-A", "Stripe", [("USD", 1)])
 		self.assertEqual(resolve_gateway_for_currency("USD"), "GW-USD-A")
 
 	def test_raises_gateway_not_found_when_none_configured(self):
@@ -53,17 +53,17 @@ class TestResolveGatewayForCurrency(IntegrationTestCase):
 			resolve_gateway_for_currency("JPY")
 
 	def test_raises_gateway_not_found_when_gateway_disabled(self):
-		_make_gateway("GW-USD-A", "stripe", [("USD", 1)], is_enabled=0)
+		_make_gateway("GW-USD-A", "Stripe", [("USD", 1)], is_enabled=0)
 		with self.assertRaises(GatewayNotFound):
 			resolve_gateway_for_currency("USD")
 
 	def test_raises_gateway_not_found_when_no_is_default_row(self):
-		_make_gateway("GW-USD-A", "stripe", [("USD", 0)])
+		_make_gateway("GW-USD-A", "Stripe", [("USD", 0)])
 		with self.assertRaises(GatewayNotFound):
 			resolve_gateway_for_currency("USD")
 
 	def test_gateway_with_multiple_currencies(self):
-		_make_gateway("GW-EUR-A", "stripe", [("EUR", 1), ("USD", 1)])
+		_make_gateway("GW-EUR-A", "Stripe", [("EUR", 1), ("USD", 1)])
 		self.assertEqual(resolve_gateway_for_currency("EUR"), "GW-EUR-A")
 		self.assertEqual(resolve_gateway_for_currency("USD"), "GW-EUR-A")
 
@@ -82,11 +82,11 @@ class TestIsDefaultInvariant(IntegrationTestCase):
 				frappe.delete_doc("Payment Gateway", name, force=True)
 
 	def test_setting_is_default_clears_previous_default(self):
-		_make_gateway("GW-USD-A", "stripe", [("USD", 1)])
+		_make_gateway("GW-USD-A", "Stripe", [("USD", 1)])
 		self.assertEqual(resolve_gateway_for_currency("USD"), "GW-USD-A")
 
 		# GW-USD-B now claims the USD default.
-		_make_gateway("GW-USD-B", "stripe", [("USD", 1)])
+		_make_gateway("GW-USD-B", "Stripe", [("USD", 1)])
 		self.assertEqual(resolve_gateway_for_currency("USD"), "GW-USD-B")
 
 		# GW-USD-A's row should have been cleared.
@@ -98,8 +98,8 @@ class TestIsDefaultInvariant(IntegrationTestCase):
 		self.assertEqual(row, 0)
 
 	def test_different_currencies_do_not_interfere(self):
-		_make_gateway("GW-USD-A", "stripe", [("USD", 1)])
-		_make_gateway("GW-INR-A", "razorpay", [("INR", 1)])
+		_make_gateway("GW-USD-A", "Stripe", [("USD", 1)])
+		_make_gateway("GW-INR-A", "Razorpay", [("INR", 1)])
 
 		# Each owns its currency independently.
 		self.assertEqual(resolve_gateway_for_currency("USD"), "GW-USD-A")

--- a/central/billing/tests/test_hardening.py
+++ b/central/billing/tests/test_hardening.py
@@ -147,15 +147,15 @@ class TestWebhookHardening(IntegrationTestCase):
 
 	def test_replay_is_idempotent_no_second_job(self):
 		with valid_signature(), patch("frappe.enqueue") as enqueue:
-			process_webhook("stripe", FLOOD_PAYLOAD, dict({"Stripe-Signature": "x"}))
-			process_webhook("stripe", FLOOD_PAYLOAD, dict({"Stripe-Signature": "x"}))  # replay
+			process_webhook("Stripe", FLOOD_PAYLOAD, dict({"Stripe-Signature": "x"}))
+			process_webhook("Stripe", FLOOD_PAYLOAD, dict({"Stripe-Signature": "x"}))  # replay
 		self.assertEqual(self._count(), 1)  # one row
 		self.assertEqual(enqueue.call_count, 1)  # one job — replay had no side effect
 
 	def test_concurrent_flood_stores_exactly_one(self):
 		def deliver(_i):
 			with patch.object(stripe.Webhook, "construct_event", return_value={"id": FLOOD_EVENT}):
-				process_webhook("stripe", FLOOD_PAYLOAD, {"Stripe-Signature": "x"})
+				process_webhook("Stripe", FLOOD_PAYLOAD, {"Stripe-Signature": "x"})
 
 		run_threads(10, deliver)  # 10 simultaneous deliveries of the same event
 		frappe.db.rollback()
@@ -202,7 +202,7 @@ class TestLoadTwoPhase(IntegrationTestCase):
 				  "event_type": "subscribed", "effective_from": "2026-06-01 00:00:00", "effective_to": None}]
 			)
 			subscriptions.create_subscription(
-				team=team, cluster=self.CLUSTER, plan=self.PLAN, billing_cycle="monthly"
+				team=team, cluster=self.CLUSTER, plan=self.PLAN, billing_cycle="Monthly"
 			)
 
 		drafts = invoicing.generate_draft_invoices("2026-06-01", "2026-06-30")

--- a/central/billing/tests/test_live_pricing.py
+++ b/central/billing/tests/test_live_pricing.py
@@ -24,8 +24,8 @@ CLUSTER = "ap-south-1"
 def snapshot_meter(resource_id, qty, currency="INR"):
 	return {
 		"resource_id": resource_id,
-		"resource_type": "snapshot",
-		"meter_type": "gauge",
+		"resource_type": "Snapshot",
+		"meter_type": "Gauge",
 		"period_start": "2026-06-01 00:00:00",
 		"period_end": "2026-06-30 23:59:59",
 		"quantity": qty,
@@ -42,9 +42,9 @@ class LivePricingTestBase(IntegrationTestCase):
 		ensure_team(TEAM)
 		make_addon(
 			"addon-snapshot",
-			resource_type="snapshot",
-			billing_type="metered",
-			pricing_mode="live",
+			resource_type="Snapshot",
+			billing_type="Metered",
+			pricing_mode="Live",
 			rates=[{"cluster": "", "currency": "INR", "rate": 0.10}],
 		)
 		self._purge()

--- a/central/billing/tests/test_mandates.py
+++ b/central/billing/tests/test_mandates.py
@@ -32,7 +32,7 @@ def make_gateway():
 			"doctype": "Payment Gateway",
 			"__newname": GATEWAY,
 			"title": "Razorpay (Mandate Test)",
-			"adapter_key": "razorpay",
+			"adapter_key": "Razorpay",
 			"currency": "INR",
 			"api_key": "rzp_test_key",
 			"api_secret": "rzp_test_secret",
@@ -83,8 +83,8 @@ class TestMandateSetup(MandateTestBase):
 		self.assertEqual(args[1]["max_amount"], 100)
 
 		method = frappe.get_doc("Payment Method", result["payment_method"])
-		self.assertEqual(method.method_type, "upi_autopay")
-		self.assertEqual(method.status, "pending_validation")
+		self.assertEqual(method.method_type, "UPI Autopay")
+		self.assertEqual(method.status, "Pending Validation")
 		self.assertEqual(method.mandate_max_amount, 100)
 		self.assertIn("order_id", result)
 
@@ -95,7 +95,7 @@ class TestMandateSetup(MandateTestBase):
 				result["payment_method"],
 				{"razorpay_token_id": "token_live", "razorpay_signature": "s"},
 			)
-		self.assertEqual(method.status, "active")
+		self.assertEqual(method.status, "Active")
 		self.assertEqual(method.gateway_method_id, "token_live")
 		self.assertTrue(method.validated_at)
 
@@ -105,7 +105,7 @@ class TestMandateSetup(MandateTestBase):
 			with self.assertRaises(frappe.ValidationError):
 				mandates.confirm_mandate(result["payment_method"], {"razorpay_signature": "bad"})
 		method = frappe.get_doc("Payment Method", result["payment_method"])
-		self.assertEqual(method.status, "failed")
+		self.assertEqual(method.status, "Failed")
 
 
 class TestMandateReauthorisation(MandateTestBase):
@@ -145,7 +145,7 @@ class TestMandateReauthorisation(MandateTestBase):
 
 		# Old mandate retired, new ceiling effective, no outstanding re-auth.
 		self.assertEqual(mandates.effective_cap(TEAM), 300)
-		self.assertEqual(frappe.db.get_value("Payment Method", pm, "status"), "cancelled")
+		self.assertEqual(frappe.db.get_value("Payment Method", pm, "status"), "Cancelled")
 		self.assertFalse(mandates.reauth_pending(TEAM))
 
 	def test_demotion_below_ceiling_needs_no_reauth(self):
@@ -172,7 +172,7 @@ class TestMandateCancel(MandateTestBase):
 			)
 		self.assertEqual(
 			frappe.db.get_value("Payment Method", result["payment_method"], "status"),
-			"cancelled",
+			"Cancelled",
 		)
 
 
@@ -187,7 +187,7 @@ class TestUpiRecurringLimit(MandateTestBase):
 	def _invoice(self, total):
 		return frappe.get_doc(
 			{
-				"doctype": "Invoice", "team": TEAM, "invoice_type": "billable", "status": "Open",
+				"doctype": "Invoice", "team": TEAM, "invoice_type": "Billable", "status": "Open",
 				"period_start": "2026-05-01", "period_end": "2026-05-31", "currency": "INR",
 				"subtotal": total, "total": total, "expected_collection": total, "amount_paid": 0,
 			}
@@ -220,15 +220,15 @@ class TestRazorpayCardSetup(MandateTestBase):
 		# Adapter asked for the card rail, not UPI.
 		self.assertEqual(adapter.setup_payment_method.call_args.args[1]["method"], "card")
 		method = frappe.get_doc("Payment Method", result["payment_method"])
-		self.assertEqual(method.method_type, "card")
-		self.assertEqual(method.status, "pending_validation")
+		self.assertEqual(method.method_type, "Card")
+		self.assertEqual(method.status, "Pending Validation")
 
 	def test_card_setup_works_even_when_upi_is_blocked(self):
 		frappe.db.set_value("Trust Tier", TEAM, "max_spend", mandates.UPI_RECURRING_MAX)
 		with stub_adapter():
 			result = mandates.setup_card(TEAM, GATEWAY)  # no exception
 		self.assertEqual(
-			frappe.db.get_value("Payment Method", result["payment_method"], "method_type"), "card"
+			frappe.db.get_value("Payment Method", result["payment_method"], "method_type"), "Card"
 		)
 
 
@@ -244,19 +244,19 @@ class TestAddMethodGatewayResolution(IntegrationTestCase):
 			"doctype": "Payment Gateway", "__newname": name, "title": name,
 			"adapter_key": adapter, "api_key": "k", "api_secret": "s",
 			"webhook_secret": "w", "is_enabled": 1,
-			"supports_mandates": 1 if adapter == "razorpay" else 0,
+			"supports_mandates": 1 if adapter == "Razorpay" else 0,
 			"currencies": [{"currency": currency, "is_default": default}],
 		}).insert(ignore_permissions=True)
 
 	def test_razorpay_wins_over_default_stripe_for_inr(self):
 		from central.billing.api import dashboard
 
-		self._gw("GW-Res-Stripe-INR", "stripe", "INR", default=1)
-		self._gw("GW-Res-RZP-INR", "razorpay", "INR", default=0)
-		self.assertEqual(dashboard._shared._add_method_gateway("INR").adapter_key, "razorpay")
+		self._gw("GW-Res-Stripe-INR", "Stripe", "INR", default=1)
+		self._gw("GW-Res-RZP-INR", "Razorpay", "INR", default=0)
+		self.assertEqual(dashboard._shared._add_method_gateway("INR").adapter_key, "Razorpay")
 
 	def test_stripe_when_no_razorpay_for_currency(self):
 		from central.billing.api import dashboard
 
-		self._gw("GW-Res-Stripe-EUR", "stripe", "EUR", default=1)
-		self.assertEqual(dashboard._shared._add_method_gateway("EUR").adapter_key, "stripe")
+		self._gw("GW-Res-Stripe-EUR", "Stripe", "EUR", default=1)
+		self.assertEqual(dashboard._shared._add_method_gateway("EUR").adapter_key, "Stripe")

--- a/central/billing/tests/test_metering.py
+++ b/central/billing/tests/test_metering.py
@@ -16,7 +16,7 @@ PLAN = "bundle-meter-test"
 RESOURCE = "srv-meter-1"
 
 
-def meter(key_suffix, qty, resource_type="transfer", meter_type="counter"):
+def meter(key_suffix, qty, resource_type="Transfer", meter_type="Counter"):
 	return {
 		"resource_id": RESOURCE,
 		"resource_type": resource_type,
@@ -55,12 +55,12 @@ class MeteringTestBase(IntegrationTestCase):
 		# Plan includes a 100 GB transfer allowance; metered Add-on bills 0.5/GB overage.
 		make_plan(
 			PLAN,
-			includes=[{"resource_type": "transfer", "quantity": 100, "unit": "GB"}],
+			includes=[{"resource_type": "Transfer", "quantity": 100, "unit": "GB"}],
 		)
 		make_addon(
 			"addon-transfer-meter",
-			resource_type="transfer",
-			billing_type="metered",
+			resource_type="Transfer",
+			billing_type="Metered",
 			rates=[{"cluster": "", "currency": "INR", "rate": 0.5}],
 		)
 		self._purge()
@@ -122,13 +122,13 @@ class TestMeteredLineItems(MeteringTestBase):
 	def test_draft_invoice_includes_fixed_and_metered_lines(self):
 		receive_meter_rollups([meter("a", 150)])
 		sub = subscriptions.create_subscription(
-			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="monthly"
+			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="Monthly"
 		).name
 		name = invoicing.generate_draft_invoice(sub, "2026-06-01", "2026-06-30")
 		inv = frappe.get_doc("Invoice", name)
 
 		resource_types = sorted(li.resource_type for li in inv.items)
-		self.assertIn("transfer", resource_types)  # metered line present
+		self.assertIn("Transfer", resource_types)  # metered line present
 		self.assertIn("bundle", resource_types)  # fixed line present
 		# subtotal = fixed (full month 1000) + metered overage (25)
 		self.assertEqual(inv.subtotal, 1025.0)

--- a/central/billing/tests/test_notifications.py
+++ b/central/billing/tests/test_notifications.py
@@ -38,37 +38,37 @@ class NotificationTestBase(IntegrationTestCase):
 
 class TestNotify(NotificationTestBase):
 	def test_default_sends_and_logs(self):
-		out = notifications.notify(TEAM, "payment_success", context={"invoice": "INV-1"})
+		out = notifications.notify(TEAM, "Payment Success", context={"invoice": "INV-1"})
 		self.assertTrue(out["sent"])
-		logs = self._logs("payment_success")
-		self.assertEqual(logs[0]["status"], "sent")
+		logs = self._logs("Payment Success")
+		self.assertEqual(logs[0]["status"], "Sent")
 		self.assertIn("INV-1", logs[0]["message"])
 
 	def test_template_renders_with_context(self):
-		notifications.notify(TEAM, "payment_failure", context={"invoice": "INV-2", "reason": "card_declined"})
-		msg = self._logs("payment_failure")[0]["message"]
+		notifications.notify(TEAM, "Payment Failure", context={"invoice": "INV-2", "reason": "card_declined"})
+		msg = self._logs("Payment Failure")[0]["message"]
 		self.assertIn("INV-2", msg)
 		self.assertIn("card_declined", msg)
 
 	def test_explicit_message_overrides_template(self):
-		notifications.notify(TEAM, "payment_success", message="Custom paid message")
-		self.assertEqual(self._logs("payment_success")[0]["message"], "Custom paid message")
+		notifications.notify(TEAM, "Payment Success", message="Custom paid message")
+		self.assertEqual(self._logs("Payment Success")[0]["message"], "Custom paid message")
 
 	def test_preference_suppresses_but_still_logs(self):
 		frappe.get_doc(
 			{"doctype": "Notification Preference", "team": TEAM, "notify_payment_retry": 0}
 		).insert(ignore_permissions=True)
 
-		out = notifications.notify(TEAM, "payment_retry", context={"invoice": "INV-3", "reason": "x"})
+		out = notifications.notify(TEAM, "Payment Retry", context={"invoice": "INV-3", "reason": "x"})
 		self.assertFalse(out["sent"])
-		log = self._logs("payment_retry")[0]
-		self.assertEqual(log["status"], "suppressed")  # the suppression itself is auditable
+		log = self._logs("Payment Retry")[0]
+		self.assertEqual(log["status"], "Suppressed")  # the suppression itself is auditable
 
 	def test_other_events_unaffected_by_one_opt_out(self):
 		frappe.get_doc(
 			{"doctype": "Notification Preference", "team": TEAM, "notify_payment_retry": 0}
 		).insert(ignore_permissions=True)
-		out = notifications.notify(TEAM, "payment_success", context={"invoice": "INV-4"})
+		out = notifications.notify(TEAM, "Payment Success", context={"invoice": "INV-4"})
 		self.assertTrue(out["sent"])
 
 
@@ -79,11 +79,11 @@ class TestWiredEvents(NotificationTestBase):
 		credits.purchase(TEAM, 100, "INR")
 		# Projected spend at 80% of balance → the credit_low notification fires.
 		settlement.credit_forecast(TEAM, 80, notify=True)
-		self.assertTrue(self._logs("credit_low"))
+		self.assertTrue(self._logs("Credit Low"))
 
 	def test_credit_low_does_not_fire_below_threshold(self):
 		from central.billing.revenue import credits
 
 		credits.purchase(TEAM, 100, "INR")
 		settlement.credit_forecast(TEAM, 50, notify=True)
-		self.assertFalse(self._logs("credit_low"))
+		self.assertFalse(self._logs("Credit Low"))

--- a/central/billing/tests/test_payment_gateway.py
+++ b/central/billing/tests/test_payment_gateway.py
@@ -17,7 +17,7 @@ def _new_gateway(name="GW-Setup-Test", **overrides):
 		frappe.delete_doc("Payment Gateway", name, force=True)
 	values = {
 		"doctype": "Payment Gateway", "__newname": name, "title": "Stripe (Setup)",
-		"adapter_key": "stripe",
+		"adapter_key": "Stripe",
 		"currencies": [{"currency": "USD", "is_default": 1}],
 		"api_secret": "sk_live_xyz",
 		**overrides,

--- a/central/billing/tests/test_payments.py
+++ b/central/billing/tests/test_payments.py
@@ -56,8 +56,8 @@ class TestSetupAndConfirm(CardTestBase):
 			result = payments.initiate_payment_method_setup(TEAM, GATEWAY)
 		self.assertEqual(result["client_secret"], "seti_secret_123")
 		method = frappe.get_doc("Payment Method", result["payment_method"])
-		self.assertEqual(method.method_type, "card")
-		self.assertEqual(method.status, "pending_validation")
+		self.assertEqual(method.method_type, "Card")
+		self.assertEqual(method.status, "Pending Validation")
 		self.assertEqual(method.setup_reference, "seti_123")
 
 	def test_confirm_with_successful_microcharge_activates(self):
@@ -67,7 +67,7 @@ class TestSetupAndConfirm(CardTestBase):
 				setup["payment_method"], gateway_method_id="pm_live", display_label="Visa ····4242"
 			)
 		adapter.validate_payment_method.assert_called_once()  # micro-charge ran
-		self.assertEqual(method.status, "active")
+		self.assertEqual(method.status, "Active")
 		self.assertEqual(method.gateway_method_id, "pm_live")
 		self.assertTrue(method.validated_at)
 		self.assertTrue(method.is_default)  # first active method becomes default
@@ -76,7 +76,7 @@ class TestSetupAndConfirm(CardTestBase):
 		with stub_adapter(validate=False):
 			setup = payments.initiate_payment_method_setup(TEAM, GATEWAY)
 			method = payments.confirm_payment_method(setup["payment_method"], gateway_method_id="pm_bad")
-		self.assertEqual(method.status, "failed")
+		self.assertEqual(method.status, "Failed")
 		self.assertFalse(method.is_default)
 
 
@@ -126,16 +126,16 @@ class TestExpiry(CardTestBase):
 
 		payments.expire_payment_methods(now="2026-06-03")
 
-		self.assertEqual(frappe.db.get_value("Payment Method", stale, "status"), "expired")
-		self.assertEqual(frappe.db.get_value("Payment Method", fresh, "status"), "active")
+		self.assertEqual(frappe.db.get_value("Payment Method", stale, "status"), "Expired")
+		self.assertEqual(frappe.db.get_value("Payment Method", fresh, "status"), "Active")
 
 	def test_card_valid_through_end_of_expiry_month(self):
 		# Expires 06/2026 — still valid on a day within June 2026.
 		card = self.add_active_card(expiry_month=6, expiry_year=2026)
 		payments.expire_payment_methods(now="2026-06-30")
-		self.assertEqual(frappe.db.get_value("Payment Method", card, "status"), "active")
+		self.assertEqual(frappe.db.get_value("Payment Method", card, "status"), "Active")
 		payments.expire_payment_methods(now="2026-07-01")
-		self.assertEqual(frappe.db.get_value("Payment Method", card, "status"), "expired")
+		self.assertEqual(frappe.db.get_value("Payment Method", card, "status"), "Expired")
 
 
 class TestStripeTestModeIntegration(CardTestBase):
@@ -152,7 +152,7 @@ class TestStripeTestModeIntegration(CardTestBase):
 		self.assertEqual(setup["client_secret"], "seti_secret")
 		self.assertEqual(
 			frappe.db.get_value("Payment Method", setup["payment_method"], "status"),
-			"pending_validation",
+			"Pending Validation",
 		)
 
 		# Confirm: the micro-charge succeeds and is auto-refunded -> active.
@@ -168,5 +168,5 @@ class TestStripeTestModeIntegration(CardTestBase):
 			)
 
 		refund_create.assert_called_once()  # micro-charge refunded
-		self.assertEqual(method.status, "active")
+		self.assertEqual(method.status, "Active")
 		self.assertTrue(method.is_default)

--- a/central/billing/tests/test_paypal_adapter.py
+++ b/central/billing/tests/test_paypal_adapter.py
@@ -19,7 +19,7 @@ def make_paypal_gateway(name="GW-Test-PayPal"):
 	return frappe.get_doc(
 		{
 			"doctype": "Payment Gateway", "__newname": name, "title": "PayPal (Test)",
-			"adapter_key": "paypal", "currency": "USD", "api_key": "pp_client",
+			"adapter_key": "Paypal", "currency": "USD", "api_key": "pp_client",
 			"api_secret": "pp_secret", "webhook_secret": "WH-ID-1", "is_enabled": 1,
 		}
 	).insert(ignore_permissions=True)

--- a/central/billing/tests/test_plan_configurator.py
+++ b/central/billing/tests/test_plan_configurator.py
@@ -20,21 +20,21 @@ class TestConfigureIncludes(IntegrationTestCase):
 	def test_ratio_1_2_derives_memory(self):
 		includes = plans.configure_includes(vcpu=0.125, ratio="1:2", disk_gb=10)
 		by_type = {r["resource_type"]: r for r in includes}
-		self.assertEqual(by_type["compute"]["quantity"], 0.125)
-		self.assertEqual(by_type["compute"]["unit"], "vCPU")
-		self.assertEqual(by_type["memory"]["quantity"], 0.25)  # 0.125 * 2
-		self.assertEqual(by_type["memory"]["unit"], "GB")
-		self.assertEqual(by_type["disk"]["quantity"], 10)
+		self.assertEqual(by_type["Compute"]["quantity"], 0.125)
+		self.assertEqual(by_type["Compute"]["unit"], "vCPU")
+		self.assertEqual(by_type["Memory"]["quantity"], 0.25)  # 0.125 * 2
+		self.assertEqual(by_type["Memory"]["unit"], "GB")
+		self.assertEqual(by_type["Disk"]["quantity"], 10)
 
 	def test_ratio_1_4_derives_high_memory(self):
 		includes = plans.configure_includes(vcpu=1, ratio="1:4", disk_gb=40)
-		memory = next(r for r in includes if r["resource_type"] == "memory")
+		memory = next(r for r in includes if r["resource_type"] == "Memory")
 		self.assertEqual(memory["quantity"], 4)  # 1 * 4
 
 	def test_memory_override_is_off_ratio(self):
 		# 1 vCPU + 3 GB is neither 1:2 nor 1:4 — the override must win.
 		includes = plans.configure_includes(vcpu=1, ratio="1:2", disk_gb=20, memory_gb=3)
-		memory = next(r for r in includes if r["resource_type"] == "memory")
+		memory = next(r for r in includes if r["resource_type"] == "Memory")
 		self.assertEqual(memory["quantity"], 3)
 
 
@@ -47,8 +47,8 @@ class TestCreateConfiguredPlan(IntegrationTestCase):
 		plans.create_configured_plan(name=PLAN, title="Configured", vcpu=0.25, ratio="1:2", disk_gb=20)
 		doc = frappe.get_doc("Plan", PLAN)
 		by_type = {r.resource_type: r for r in doc.includes}
-		self.assertEqual(by_type["compute"].quantity, 0.25)
-		self.assertEqual(by_type["memory"].quantity, 0.5)  # 0.25 * 2
-		self.assertEqual(by_type["disk"].quantity, 20)
+		self.assertEqual(by_type["Compute"].quantity, 0.25)
+		self.assertEqual(by_type["Memory"].quantity, 0.5)  # 0.25 * 2
+		self.assertEqual(by_type["Disk"].quantity, 20)
 		# Plain quantity/unit only — no millicores/ratio stored anywhere.
-		self.assertEqual(by_type["compute"].unit, "vCPU")
+		self.assertEqual(by_type["Compute"].unit, "vCPU")

--- a/central/billing/tests/test_plans.py
+++ b/central/billing/tests/test_plans.py
@@ -37,7 +37,7 @@ class TestGetPlanPricing(IntegrationTestCase):
 
 		includes = pricing["includes"]
 		self.assertEqual(len(includes), 3)
-		self.assertEqual(includes[0]["resource_type"], "compute")
+		self.assertEqual(includes[0]["resource_type"], "Compute")
 		# composition rows carry quantity/unit but no price/rate
 		self.assertNotIn("rate", includes[0])
 		self.assertNotIn("price_per_unit", includes[0])

--- a/central/billing/tests/test_pricelock.py
+++ b/central/billing/tests/test_pricelock.py
@@ -92,6 +92,6 @@ class TestReceiveUsageEvents(PriceLockTestBase):
 
 	def test_cancelled_closes_the_active_lock(self):
 		receive_usage_events([event("evt-1", "srv-A", 40)])
-		receive_usage_events([event("evt-2", "srv-A", 40, event_type="cancelled")])
+		receive_usage_events([event("evt-2", "srv-A", 40, event_type="Cancelled")])
 
 		self.assertIsNone(get_locked_rate("srv-A"))  # nothing active

--- a/central/billing/tests/test_razorpay_adapter.py
+++ b/central/billing/tests/test_razorpay_adapter.py
@@ -21,7 +21,7 @@ def make_razorpay_gateway(name="GW-Test-Razorpay"):
 			"doctype": "Payment Gateway",
 			"__newname": name,
 			"title": "Razorpay (Test)",
-			"adapter_key": "razorpay",
+			"adapter_key": "Razorpay",
 			"currencies": [{"currency": "INR", "is_default": 1}],
 			"api_key": "rzp_test_key",
 			"api_secret": "rzp_test_secret",

--- a/central/billing/tests/test_reconciliation.py
+++ b/central/billing/tests/test_reconciliation.py
@@ -42,7 +42,7 @@ class ReconTestBase(IntegrationTestCase):
 	def _open_invoice(self, total=1000):
 		return frappe.get_doc(
 			{
-				"doctype": "Invoice", "team": TEAM, "invoice_type": "billable", "status": "Open",
+				"doctype": "Invoice", "team": TEAM, "invoice_type": "Billable", "status": "Open",
 				"period_start": "2026-05-01", "period_end": "2026-05-31", "currency": "INR",
 				"subtotal": total, "total": total, "expected_collection": total,
 			}
@@ -52,7 +52,7 @@ class ReconTestBase(IntegrationTestCase):
 		name = frappe.get_doc(
 			{
 				"doctype": "Payment Attempt", "invoice": invoice, "team": TEAM, "gateway": GATEWAY,
-				"amount": 1000, "currency": "INR", "status": "initiated",
+				"amount": 1000, "currency": "INR", "status": "Initiated",
 				"gateway_transaction_id": txn,
 			}
 		).insert(ignore_permissions=True).name
@@ -72,15 +72,15 @@ class TestReconcile(ReconTestBase):
 
 		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Paid")
 		a = frappe.get_doc("Payment Attempt", attempt)
-		self.assertEqual(a.status, "captured")
-		self.assertEqual(a.resolved_by, "reconciliation")
+		self.assertEqual(a.status, "Captured")
+		self.assertEqual(a.resolved_by, "Reconciliation")
 
 	def test_gateway_failure_fails_attempt_invoice_stays_open(self):
 		inv = self._open_invoice()
 		attempt = self._ambiguous_attempt(inv)
 		with gateway_status("failed"):
 			reconciliation.reconcile_attempt(attempt)
-		self.assertEqual(frappe.db.get_value("Payment Attempt", attempt, "status"), "failed")
+		self.assertEqual(frappe.db.get_value("Payment Attempt", attempt, "status"), "Failed")
 		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Open")
 
 	def test_missing_gateway_txn_is_failed_safely(self):
@@ -90,7 +90,7 @@ class TestReconcile(ReconTestBase):
 		with gateway_status("succeeded") as adapter:
 			reconciliation.reconcile_attempt(attempt)
 			adapter.get_transaction_status.assert_not_called()
-		self.assertEqual(frappe.db.get_value("Payment Attempt", attempt, "status"), "failed")
+		self.assertEqual(frappe.db.get_value("Payment Attempt", attempt, "status"), "Failed")
 
 	def test_pending_recent_is_left_unresolved(self):
 		inv = self._open_invoice()
@@ -98,13 +98,13 @@ class TestReconcile(ReconTestBase):
 		with gateway_status("requires_action"):
 			out = reconciliation.reconcile_attempt(attempt, now=frappe.utils.now_datetime())
 		self.assertEqual(out["unresolved"], "requires_action")
-		self.assertEqual(frappe.db.get_value("Payment Attempt", attempt, "status"), "initiated")
+		self.assertEqual(frappe.db.get_value("Payment Attempt", attempt, "status"), "Initiated")
 
 	def test_pending_aged_out_alerts_ops(self):
 		inv = self._open_invoice()
 		attempt = self._ambiguous_attempt(inv, minutes_old=60)
 		future = frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=30)
-		with gateway_status("pending"):
+		with gateway_status("Pending"):
 			out = reconciliation.reconcile_attempt(attempt, now=future)
 		self.assertTrue(out["alerted"])
 		comments = frappe.get_all(
@@ -120,11 +120,11 @@ class TestScan(ReconTestBase):
 		with gateway_status("succeeded"):
 			results = reconciliation.run_reconciliation()
 		self.assertNotIn(fresh, [r.get("attempt") for r in results])
-		self.assertEqual(frappe.db.get_value("Payment Attempt", fresh, "status"), "initiated")
+		self.assertEqual(frappe.db.get_value("Payment Attempt", fresh, "status"), "Initiated")
 
 	def test_scan_resolves_aged_ambiguous(self):
 		inv = self._open_invoice()
 		old = self._ambiguous_attempt(inv, minutes_old=60)
 		with gateway_status("succeeded"):
 			reconciliation.run_reconciliation()
-		self.assertEqual(frappe.db.get_value("Payment Attempt", old, "status"), "captured")
+		self.assertEqual(frappe.db.get_value("Payment Attempt", old, "status"), "Captured")

--- a/central/billing/tests/test_refunds.py
+++ b/central/billing/tests/test_refunds.py
@@ -25,7 +25,7 @@ GATEWAY = "GW-Test-Stripe"
 def stub_refund(success=True, refund_id="rfnd_1"):
 	adapter = MagicMock()
 	adapter.refund.return_value = RefundResult(
-		success=success, status="completed" if success else "failed", gateway_refund_id=refund_id
+		success=success, status="Completed" if success else "Failed", gateway_refund_id=refund_id
 	)
 	with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
 		yield adapter
@@ -53,7 +53,7 @@ class RefundTestBase(IntegrationTestCase):
 	def _paid_invoice_with_attempt(self, total=1000):
 		inv = frappe.get_doc(
 			{
-				"doctype": "Invoice", "team": TEAM, "invoice_type": "billable", "status": "Paid",
+				"doctype": "Invoice", "team": TEAM, "invoice_type": "Billable", "status": "Paid",
 				"period_start": "2026-05-01", "period_end": "2026-05-31", "currency": "INR",
 				"subtotal": total, "total": total, "expected_collection": total, "amount_paid": total,
 			}
@@ -61,7 +61,7 @@ class RefundTestBase(IntegrationTestCase):
 		attempt = frappe.get_doc(
 			{
 				"doctype": "Payment Attempt", "invoice": inv, "team": TEAM, "gateway": GATEWAY,
-				"amount": total, "currency": "INR", "status": "captured",
+				"amount": total, "currency": "INR", "status": "Captured",
 				"gateway_transaction_id": "pi_paid",
 			}
 		).insert(ignore_permissions=True).name
@@ -75,24 +75,24 @@ class TestFullDispute(RefundTestBase):
 			refund = refunds.full_dispute(attempt, reason="fraud dispute")
 
 		adapter.refund.assert_called_once()
-		self.assertEqual(refund.destination, "source")
+		self.assertEqual(refund.destination, "Source")
 		self.assertEqual(refund.amount, 1000.0)
-		self.assertEqual(refund.status, "completed")
+		self.assertEqual(refund.status, "Completed")
 		self.assertEqual(refund.gateway_refund_id, "rfnd_full")
-		# Invoice stays Paid (no 'refunded' state); the attempt is marked refunded.
+		# Invoice stays Paid (no 'Refunded' state); the attempt is marked refunded.
 		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Paid")
-		self.assertEqual(frappe.db.get_value("Payment Attempt", attempt, "status"), "refunded")
+		self.assertEqual(frappe.db.get_value("Payment Attempt", attempt, "status"), "Refunded")
 
 	def test_failed_gateway_refund_is_recorded(self):
 		inv, attempt = self._paid_invoice_with_attempt(1000)
 		with stub_refund(success=False):
 			refund = refunds.full_dispute(attempt)
-		self.assertEqual(refund.status, "failed")
-		self.assertEqual(frappe.db.get_value("Payment Attempt", attempt, "status"), "captured")
+		self.assertEqual(refund.status, "Failed")
+		self.assertEqual(frappe.db.get_value("Payment Attempt", attempt, "status"), "Captured")
 
 	def test_refund_only_on_captured_charge(self):
 		inv, attempt = self._paid_invoice_with_attempt(1000)
-		frappe.db.set_value("Payment Attempt", attempt, "status", "failed")
+		frappe.db.set_value("Payment Attempt", attempt, "status", "Failed")
 		with self.assertRaises(frappe.ValidationError):
 			refunds.full_dispute(attempt)
 
@@ -105,8 +105,8 @@ class TestPartialOvercharge(RefundTestBase):
 			refund = refunds.partial_overcharge(attempt, amount=150, reason="overcharge")
 			adapter.refund.assert_not_called()
 
-		self.assertEqual(refund.destination, "wallet")
-		self.assertEqual(refund.status, "completed")
+		self.assertEqual(refund.destination, "Wallet")
+		self.assertEqual(refund.status, "Completed")
 		self.assertEqual(credits.get_balance(TEAM)["balance"], 150)
 		# The credit is sourced from the Refund and applies next cycle.
 		entry = frappe.get_all(
@@ -114,7 +114,7 @@ class TestPartialOvercharge(RefundTestBase):
 			{"team": TEAM, "reference_type": "Refund", "reference_name": refund.name},
 			["entry_type", "amount"],
 		)
-		self.assertEqual(entry[0]["entry_type"], "credit")
+		self.assertEqual(entry[0]["entry_type"], "Credit")
 		self.assertEqual(entry[0]["amount"], 150)
 		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Paid")
 
@@ -123,7 +123,7 @@ class TestPartialOvercharge(RefundTestBase):
 		with stub_refund(success=True, refund_id="rfnd_part") as adapter:
 			refund = refunds.partial_overcharge(attempt, amount=150, to_source=True)
 			adapter.refund.assert_called_once()
-		self.assertEqual(refund.destination, "source")
+		self.assertEqual(refund.destination, "Source")
 		self.assertEqual(credits.get_balance(TEAM)["balance"], 0)  # not wallet
 
 
@@ -149,7 +149,7 @@ class TestPrePaymentCorrection(RefundTestBase):
 			  "effective_from": "2026-06-01 00:00:00", "effective_to": None}]
 		)
 		sub = subscriptions.create_subscription(
-			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="monthly"
+			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="Monthly"
 		).name
 		first = invoicing.generate_draft_invoice(sub, "2026-06-01", "2026-06-30")
 

--- a/central/billing/tests/test_settlement.py
+++ b/central/billing/tests/test_settlement.py
@@ -33,7 +33,7 @@ def stub_adapter(success=True, txn_id="pi_x"):
 	adapter = MagicMock()
 	adapter.charge.return_value = PaymentResult(
 		success=success,
-		status="captured" if success else "failed",
+		status="Captured" if success else "Failed",
 		gateway_transaction_id=txn_id if success else None,
 		failure_code=None if success else "card_declined",
 	)
@@ -78,8 +78,8 @@ class SettlementTestBase(IntegrationTestCase):
 				"doctype": "Payment Method",
 				"team": TEAM,
 				"gateway": GATEWAY,
-				"method_type": "card",
-				"status": "active",
+				"method_type": "Card",
+				"status": "Active",
 				"gateway_method_id": "pm_card",
 				"gateway_customer_id": "cus_1",
 				"is_default": 1,
@@ -92,7 +92,7 @@ class SettlementTestBase(IntegrationTestCase):
 			team=TEAM,
 			cluster=CLUSTER,
 			plan=PLAN,
-			billing_cycle="monthly",
+			billing_cycle="Monthly",
 			default_payment_method=method,
 			gateway=GATEWAY if with_card else None,
 		).name
@@ -131,7 +131,7 @@ class TestWaterfall(SettlementTestBase):
 		self.assertEqual(adapter.charge.call_args.args[0].amount, 600.0)
 		attempt = frappe.get_doc("Payment Attempt", result["charge"]["attempt"])
 		self.assertEqual(attempt.amount, 600.0)
-		self.assertEqual(attempt.status, "captured")
+		self.assertEqual(attempt.status, "Captured")
 		self.assertEqual(credits.get_balance(TEAM)["balance"], 0)
 
 	def test_credits_cover_in_full_settles_without_charge(self):
@@ -157,10 +157,10 @@ class TestWaterfall(SettlementTestBase):
 		# Declined remainder: invoice stays Open for dunning (#14), not stopped.
 		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Open")
 		self.assertEqual(
-			frappe.db.get_value("Subscription", sub, "account_standing"), "current"
+			frappe.db.get_value("Subscription", sub, "account_standing"), "Current"
 		)
 		attempt = frappe.get_all("Payment Attempt", {"invoice": inv}, ["status"])[0]
-		self.assertEqual(attempt.status, "failed")
+		self.assertEqual(attempt.status, "Failed")
 
 
 class TestSettlementSources(SettlementTestBase):

--- a/central/billing/tests/test_stripe_adapter.py
+++ b/central/billing/tests/test_stripe_adapter.py
@@ -23,7 +23,7 @@ def make_stripe_gateway(name="GW-Test-Stripe"):
 			"doctype": "Payment Gateway",
 			"__newname": name,
 			"title": "Stripe (Test)",
-			"adapter_key": "stripe",
+			"adapter_key": "Stripe",
 			"currencies": [{"currency": "USD", "is_default": 1}],
 			"api_secret": "sk_test_123",
 			"webhook_secret": "whsec_test_123",
@@ -70,7 +70,7 @@ class TestStripeAdapter(GatewayAdapterContract, IntegrationTestCase):
 
 	@contextmanager
 	def charge_declines(self, code="card_declined"):
-		err = stripe.error.CardError("Your card was declined.", "card", code)
+		err = stripe.error.CardError("Your card was declined.", "Card", code)
 		with patch.object(stripe.PaymentIntent, "create", side_effect=err) as m:
 			self._last_create = m
 			yield
@@ -174,8 +174,8 @@ class TestStripeAdapter(GatewayAdapterContract, IntegrationTestCase):
 
 	def test_get_mandate_status(self):
 		adapter = self.make_adapter()
-		with patch.object(stripe.Mandate, "retrieve", return_value=frappe._dict(status="active")):
-			self.assertEqual(adapter.get_mandate_status("mandate_x"), "active")
+		with patch.object(stripe.Mandate, "retrieve", return_value=frappe._dict(status="Active")):
+			self.assertEqual(adapter.get_mandate_status("mandate_x"), "Active")
 
 	def test_verify_payment_signature_is_unsupported(self):
 		adapter = self.make_adapter()

--- a/central/billing/tests/test_subscriptions.py
+++ b/central/billing/tests/test_subscriptions.py
@@ -33,16 +33,16 @@ class SubscriptionTestBase(IntegrationTestCase):
 
 	def make_sub(self):
 		return subscriptions.create_subscription(
-			team=TEAM, cluster="ap-south-1", plan=PLAN, billing_cycle="monthly"
+			team=TEAM, cluster="ap-south-1", plan=PLAN, billing_cycle="Monthly"
 		)
 
 
 class TestSubscriptionIntent(SubscriptionTestBase):
 	def test_create_records_intent_and_writes_created_change(self):
 		sub = self.make_sub()
-		self.assertEqual(sub.account_standing, "current")  # starts in good standing
+		self.assertEqual(sub.account_standing, "Current")  # starts in good standing
 		self.assertEqual(sub.plan, PLAN)
-		self.assertEqual(len(changes_for(sub.name, "created")), 1)
+		self.assertEqual(len(changes_for(sub.name, "Created")), 1)
 
 	def test_no_combined_operational_financial_enum_exists(self):
 		# Central owns ONLY account_standing; operational state is the Agent's.
@@ -50,7 +50,7 @@ class TestSubscriptionIntent(SubscriptionTestBase):
 		standing = meta.get_field("account_standing")
 		self.assertEqual(
 			sorted(o for o in standing.options.split("\n") if o),
-			["current", "past_due", "suspended"],
+			["Current", "Past Due", "Suspended"],
 		)
 		# No field carries the operational axis.
 		fieldnames = {df.fieldname for df in meta.fields}
@@ -61,18 +61,18 @@ class TestSubscriptionIntent(SubscriptionTestBase):
 		sub = self.make_sub()
 		subscriptions.change_plan(sub.name, PLAN_B)
 		self.assertEqual(frappe.db.get_value("Subscription", sub.name, "plan"), PLAN_B)
-		change = frappe.get_doc("Subscription Change", changes_for(sub.name, "plan_changed")[0])
+		change = frappe.get_doc("Subscription Change", changes_for(sub.name, "Plan Changed")[0])
 		self.assertEqual(change.old_value, PLAN)
 		self.assertEqual(change.new_value, PLAN_B)
 
 	def test_cancel_writes_history(self):
 		sub = self.make_sub()
 		subscriptions.cancel_subscription(sub.name)
-		self.assertEqual(len(changes_for(sub.name, "cancelled")), 1)
+		self.assertEqual(len(changes_for(sub.name, "Cancelled")), 1)
 
 	def test_history_is_append_only(self):
 		sub = self.make_sub()
-		change = frappe.get_doc("Subscription Change", changes_for(sub.name, "created")[0])
+		change = frappe.get_doc("Subscription Change", changes_for(sub.name, "Created")[0])
 		change.new_value = "tampered"
 		with self.assertRaises(frappe.ValidationError):
 			change.save(ignore_permissions=True)
@@ -81,35 +81,35 @@ class TestSubscriptionIntent(SubscriptionTestBase):
 class TestAccountStandingStateMachine(SubscriptionTestBase):
 	def test_grace_then_suspend_then_reactivate(self):
 		sub = self.make_sub()
-		subscriptions.set_standing(sub.name, "past_due")
-		self.assertEqual(frappe.db.get_value("Subscription", sub.name, "account_standing"), "past_due")
-		subscriptions.set_standing(sub.name, "suspended")
-		self.assertEqual(frappe.db.get_value("Subscription", sub.name, "account_standing"), "suspended")
-		subscriptions.set_standing(sub.name, "current")
-		self.assertEqual(frappe.db.get_value("Subscription", sub.name, "account_standing"), "current")
+		subscriptions.set_standing(sub.name, "Past Due")
+		self.assertEqual(frappe.db.get_value("Subscription", sub.name, "account_standing"), "Past Due")
+		subscriptions.set_standing(sub.name, "Suspended")
+		self.assertEqual(frappe.db.get_value("Subscription", sub.name, "account_standing"), "Suspended")
+		subscriptions.set_standing(sub.name, "Current")
+		self.assertEqual(frappe.db.get_value("Subscription", sub.name, "account_standing"), "Current")
 		# Each transition is logged.
-		self.assertTrue(changes_for(sub.name, "past_due"))
-		self.assertTrue(changes_for(sub.name, "suspended"))
-		self.assertTrue(changes_for(sub.name, "reactivated"))
+		self.assertTrue(changes_for(sub.name, "Past Due"))
+		self.assertTrue(changes_for(sub.name, "Suspended"))
+		self.assertTrue(changes_for(sub.name, "Reactivated"))
 
 	def test_past_due_can_recover_directly_to_current(self):
 		sub = self.make_sub()
-		subscriptions.set_standing(sub.name, "past_due")
-		subscriptions.set_standing(sub.name, "current")
-		self.assertEqual(frappe.db.get_value("Subscription", sub.name, "account_standing"), "current")
+		subscriptions.set_standing(sub.name, "Past Due")
+		subscriptions.set_standing(sub.name, "Current")
+		self.assertEqual(frappe.db.get_value("Subscription", sub.name, "account_standing"), "Current")
 
 	def test_invalid_transitions_raise(self):
 		sub = self.make_sub()
 		# current -> suspended skips the grace step.
 		with self.assertRaises(InvalidTransition):
-			subscriptions.set_standing(sub.name, "suspended")
+			subscriptions.set_standing(sub.name, "Suspended")
 		# current -> current is a no-op transition, not allowed.
 		with self.assertRaises(InvalidTransition):
-			subscriptions.set_standing(sub.name, "current")
+			subscriptions.set_standing(sub.name, "Current")
 		# Move to past_due, then an illegal jump back-and-forth.
-		subscriptions.set_standing(sub.name, "past_due")
+		subscriptions.set_standing(sub.name, "Past Due")
 		with self.assertRaises(InvalidTransition):
-			subscriptions.set_standing(sub.name, "past_due")  # same-state
+			subscriptions.set_standing(sub.name, "Past Due")  # same-state
 
 	def test_unknown_standing_raises(self):
 		sub = self.make_sub()

--- a/central/billing/tests/test_tax.py
+++ b/central/billing/tests/test_tax.py
@@ -47,7 +47,7 @@ class TaxTestBase(IntegrationTestCase):
 		self._purge()
 		provision()  # full-month fixed line = 1000
 		self.sub = subscriptions.create_subscription(
-			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="monthly"
+			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="Monthly"
 		).name
 
 	def tearDown(self):
@@ -71,7 +71,7 @@ class TaxTestBase(IntegrationTestCase):
 class TestOutputTax(TaxTestBase):
 	def test_no_profile_is_untaxed(self):
 		inv = self._invoice()
-		self.assertEqual(inv.output_tax_type, "none")
+		self.assertEqual(inv.output_tax_type, "None")
 		self.assertEqual(inv.output_tax_amount, 0)
 		self.assertEqual(inv.total, 1000.0)
 		self.assertEqual(inv.expected_collection, 1000.0)
@@ -86,10 +86,10 @@ class TestOutputTax(TaxTestBase):
 
 class TestZeroRating(TaxTestBase):
 	def test_sez_is_zero_with_a_reason_code(self):
-		set_tax_profile(output_tax_type="GST", output_tax_rate=18, zero_rated=1, zero_rating_reason="sez_lut")
+		set_tax_profile(output_tax_type="GST", output_tax_rate=18, zero_rated=1, zero_rating_reason="SEZ LUT")
 		inv = self._invoice()
 		self.assertEqual(inv.output_tax_amount, 0)  # zero-rated
-		self.assertEqual(inv.zero_rating_reason, "sez_lut")  # ... but with a reason
+		self.assertEqual(inv.zero_rating_reason, "SEZ LUT")  # ... but with a reason
 		self.assertEqual(inv.total, 1000.0)
 
 	def test_zero_rated_profile_requires_a_reason(self):

--- a/central/billing/tests/test_trials.py
+++ b/central/billing/tests/test_trials.py
@@ -45,7 +45,7 @@ class TrialTestBase(IntegrationTestCase):
 		self._purge()
 		recompute_trust_tier(TEAM, paid_invoice_count=0, cumulative_paid=0)  # entry tier t0
 		self.sub = subscriptions.create_subscription(
-			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="monthly"
+			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="Monthly"
 		).name
 
 	def tearDown(self):
@@ -69,7 +69,7 @@ class TestCostReportGeneration(TrialTestBase):
 		self.assertTrue(trials.is_trial_team(TEAM))
 		provision()
 		name = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
-		self.assertEqual(frappe.db.get_value("Invoice", name, "invoice_type"), "cost_report")
+		self.assertEqual(frappe.db.get_value("Invoice", name, "invoice_type"), "Cost Report")
 
 	def test_cost_report_is_computed_but_not_charged(self):
 		provision()
@@ -92,20 +92,20 @@ class TestConversion(TrialTestBase):
 		provision()
 		# June: trial → cost_report.
 		june = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
-		self.assertEqual(frappe.db.get_value("Invoice", june, "invoice_type"), "cost_report")
+		self.assertEqual(frappe.db.get_value("Invoice", june, "invoice_type"), "Cost Report")
 
 		trials.convert_to_paid(TEAM)
 		self.assertFalse(trials.is_trial_team(TEAM))
 
 		# July invoice is billable; the resource's lock is untouched (still running).
 		july = invoicing.generate_draft_invoice(self.sub, "2026-07-01", "2026-07-31")
-		self.assertEqual(frappe.db.get_value("Invoice", july, "invoice_type"), "billable")
+		self.assertEqual(frappe.db.get_value("Invoice", july, "invoice_type"), "Billable")
 		active_locks = frappe.get_all(
 			"Price Lock", {"team": TEAM, "resource_id": "srv-trial", "ended_at": ["is", "not set"]}
 		)
 		self.assertEqual(len(active_locks), 1)
 		self.assertEqual(
-			frappe.db.get_value("Subscription", self.sub, "account_standing"), "current"
+			frappe.db.get_value("Subscription", self.sub, "account_standing"), "Current"
 		)
 
 
@@ -115,7 +115,7 @@ class TestSubsidyAndExpiry(TrialTestBase):
 		provision("srv-a", rate=1000, start="2099-01-01 00:00:00")
 		provision("srv-b", rate=2000, start="2099-01-01 00:00:00")
 		name = invoicing.generate_draft_invoice(self.sub, "2099-01-01", "2099-01-31")
-		self.assertEqual(frappe.db.get_value("Invoice", name, "invoice_type"), "cost_report")
+		self.assertEqual(frappe.db.get_value("Invoice", name, "invoice_type"), "Cost Report")
 
 		subsidy = trials.subsidy_total("2099-01-01", "2099-01-31")
 		self.assertEqual(subsidy, 3000.0)  # 1000 + 2000, full month

--- a/central/billing/tests/test_webhooks.py
+++ b/central/billing/tests/test_webhooks.py
@@ -42,7 +42,7 @@ class TestStripeWebhookReceiver(IntegrationTestCase):
 
 	def test_valid_signed_event_is_stored_and_enqueued(self):
 		with signature(valid=True), patch("frappe.enqueue") as enqueue:
-			process_webhook("stripe", PAYLOAD, HEADERS)
+			process_webhook("Stripe", PAYLOAD, HEADERS)
 
 		self.assertEqual(frappe.local.response.http_status_code, 200)
 		self.assertEqual(self._events(), 1)
@@ -50,7 +50,7 @@ class TestStripeWebhookReceiver(IntegrationTestCase):
 
 	def test_invalid_signature_returns_400_with_zero_db_writes(self):
 		with signature(valid=False), patch("frappe.enqueue") as enqueue:
-			process_webhook("stripe", PAYLOAD, HEADERS)
+			process_webhook("Stripe", PAYLOAD, HEADERS)
 
 		self.assertEqual(frappe.local.response.http_status_code, 400)
 		self.assertEqual(self._events(), 0)
@@ -63,13 +63,13 @@ class TestStripeWebhookReceiver(IntegrationTestCase):
 			with patch(
 				"central.billing.gateways.stripe_adapter.StripeAdapter.parse_webhook_event"
 			) as parse:
-				process_webhook("stripe", PAYLOAD, HEADERS)
+				process_webhook("Stripe", PAYLOAD, HEADERS)
 		parse.assert_not_called()
 
 	def test_replayed_event_is_deduped(self):
 		with signature(valid=True), patch("frappe.enqueue") as enqueue:
-			process_webhook("stripe", PAYLOAD, HEADERS)
-			process_webhook("stripe", PAYLOAD, HEADERS)
+			process_webhook("Stripe", PAYLOAD, HEADERS)
+			process_webhook("Stripe", PAYLOAD, HEADERS)
 
 		self.assertEqual(frappe.local.response.http_status_code, 200)
 		self.assertEqual(self._events(), 1)  # no duplicate
@@ -108,7 +108,7 @@ class TestRazorpayWebhookReceiver(IntegrationTestCase):
 
 	def test_valid_signed_event_is_stored_and_enqueued(self):
 		with razorpay_signature(valid=True), patch("frappe.enqueue") as enqueue:
-			process_webhook("razorpay", R_PAYLOAD, R_HEADERS)
+			process_webhook("Razorpay", R_PAYLOAD, R_HEADERS)
 
 		self.assertEqual(frappe.local.response.http_status_code, 200)
 		self.assertEqual(self._events(), 1)
@@ -116,7 +116,7 @@ class TestRazorpayWebhookReceiver(IntegrationTestCase):
 
 	def test_invalid_signature_returns_400_with_zero_db_writes(self):
 		with razorpay_signature(valid=False), patch("frappe.enqueue") as enqueue:
-			process_webhook("razorpay", R_PAYLOAD, R_HEADERS)
+			process_webhook("Razorpay", R_PAYLOAD, R_HEADERS)
 
 		self.assertEqual(frappe.local.response.http_status_code, 400)
 		self.assertEqual(self._events(), 0)

--- a/central/billing/tests/utils.py
+++ b/central/billing/tests/utils.py
@@ -17,9 +17,9 @@ DEFAULT_ADDON_RATES = [
 ]
 
 DEFAULT_INCLUDES = [
-	{"resource_type": "compute", "quantity": 2, "unit": "vCPU"},
-	{"resource_type": "memory", "quantity": 4, "unit": "GB"},
-	{"resource_type": "disk", "quantity": 80, "unit": "GB"},
+	{"resource_type": "Compute", "quantity": 2, "unit": "vCPU"},
+	{"resource_type": "Memory", "quantity": 4, "unit": "GB"},
+	{"resource_type": "Disk", "quantity": 80, "unit": "GB"},
 ]
 
 
@@ -33,7 +33,7 @@ def make_plan(name, rates=None, includes=None, **kwargs):
 			"doctype": "Plan",
 			"__newname": name,
 			"title": kwargs.get("title", name),
-			"billing_cycle": kwargs.get("billing_cycle", "monthly"),
+			"billing_cycle": kwargs.get("billing_cycle", "Monthly"),
 			"is_active": kwargs.get("is_active", 1),
 			"includes": includes if includes is not None else DEFAULT_INCLUDES,
 		}
@@ -53,11 +53,11 @@ def make_addon(name, rates=None, **kwargs):
 			"doctype": "Add-on",
 			"__newname": name,
 			"title": kwargs.get("title", name),
-			"resource_type": kwargs.get("resource_type", "transfer"),
+			"resource_type": kwargs.get("resource_type", "Transfer"),
 			"unit": kwargs.get("unit", "GB"),
-			"billing_type": kwargs.get("billing_type", "metered"),
-			"billing_interval": kwargs.get("billing_interval", "monthly"),
-			"pricing_mode": kwargs.get("pricing_mode", "grandfathered"),
+			"billing_type": kwargs.get("billing_type", "Metered"),
+			"billing_interval": kwargs.get("billing_interval", "Monthly"),
+			"pricing_mode": kwargs.get("pricing_mode", "Grandfathered"),
 		}
 	)
 	doc.insert(ignore_permissions=True)

--- a/central/patches.txt
+++ b/central/patches.txt
@@ -28,3 +28,6 @@ central.billing.patches.v06_payment_gateway_currency.migrate_gateway_currencies
 # holds the authoritative balance so bookings no longer FOR UPDATE the ledger
 # (which gap-locked the creation index and deadlocked cross-team bookings) — #06.
 central.billing.patches.v07_credit_wallet_balance.backfill_wallet_balance
+# Title-case every billing Select field's stored values (past_due -> Past Due,
+# stripe -> Stripe, …) to match the field option lists now rendered Title Case.
+central.billing.patches.v08_titlecase_select_options.titlecase_options


### PR DESCRIPTION
Every billing Select field's options moved from lower/snake_case to Title Case (account_standing past_due -> Past Due, invoice_type cost_report -> Cost Report, adapter_key stripe -> Stripe, …), with acronyms preserved (UPI/IP/SEZ LUT/GST/VAT). Field options + defaults updated across 16 DocTypes; stored-value references rewritten across controllers, APIs, gateways and tests (scoped to central/billing — IAM/users/oauth and Frappe scheduler keys left untouched).

Only field values change — NOT dictionary keys. Hardcoded response/aggregation payload keys stay lowercase (e.g. {"monthly": …} run-rate buckets, {"captured": 0} counters, {"synced": …}/{"sent": …} return shapes). Dicts whose KEYS are a field's value used for runtime lookup keep Title Case (_TEMPLATES by event_type, _STANDING_RANK / state machine by account_standing, gateway registry by adapter_key).

Gateway-protocol strings stay in their native casing: Stripe payment_method_types=["card"], Razorpay payload statuses captured/processed/ pending, PayPal payment_source key, and reconciliation's .lower()-compared gateway vocab. Derived identifiers fixed so the rename stays stable: Notification Preference fieldname (notify_<slug>) and the webhook callback URL (adapter_key.lower()).

v08_titlecase_select_options patch rewrites existing rows old -> new via frappe.qb (idempotent, post_model_sync). 319 tests green on central.local.