### PR TITLE
fix(billing): collect phone inline for Razorpay card mandate;

### DIFF
--- a/central/billing/api/dashboard/methods.py
+++ b/central/billing/api/dashboard/methods.py
@@ -103,9 +103,11 @@ def add_demo_card(team: str | None = None, gateway: str | None = None,
 
 @frappe.whitelist(methods=["POST"])
 def setup_payment_method_order(team: str | None = None, gateway: str | None = None,
-							   method_type: str = "UPI Autopay") -> dict:
+							   method_type: str = "UPI Autopay", contact: str | None = None) -> dict:
 	"""Begin adding a Razorpay recurring method — UPI Autopay mandate (ceiling =
-	trust-tier cap) or a card token. Returns the order handles the UI runs
+	trust-tier cap) or a card token. `contact` is the phone the UI collects inline
+	for a card mandate when the billing profile has none (Razorpay requires a
+	customer contact for recurring cards). Returns the order handles the UI runs
 	Razorpay Checkout against (#08)."""
 	team = _resolve_team(team, authz.MANAGE)
 	_require_billing_setup(team)
@@ -113,7 +115,7 @@ def setup_payment_method_order(team: str | None = None, gateway: str | None = No
 	from central.billing.payments import mandates
 
 	if method_type == "Card":
-		return mandates.setup_card(team, gw)
+		return mandates.setup_card(team, gw, contact=contact)
 	return mandates.setup_mandate(team, gw)
 
 

--- a/central/billing/payments/mandates.py
+++ b/central/billing/payments/mandates.py
@@ -76,26 +76,34 @@ def _ensure_customer(team: str, gateway: str, adapter, customer_id: str | None =
 	return payments.ensure_gateway_customer(team, gateway, adapter, customer_id)
 
 
-def _require_recurring_contact(team: str, gateway: str, adapter, customer_id: str):
-	"""Razorpay recurring orders require the customer to carry a contact (phone) —
-	without it the order fails with "The contact field is required for recurring
-	links". Pull name/email/phone from the billing profile, refuse clearly if the
-	phone is missing, and sync them onto the (possibly reused or older) customer so
-	a contactless one is fixed in place."""
+def _require_card_contact(team: str, gateway: str, adapter, customer_id: str, contact: str | None = None):
+	"""A Razorpay *card* mandate order needs the customer to carry a contact (phone)
+	— without it Razorpay errors "The contact field is required for recurring links".
+	(UPI Autopay does not need one, so this is only called from the card path.)
+
+	The phone is optional on the billing profile, so the dashboard collects it inline
+	at card setup when missing and passes it here. Use the inline `contact` else the
+	profile's phone; persist an inline one back to the profile (asked once); sync
+	name/email/contact onto the (possibly reused / older, contactless) customer.
+	"""
 	if frappe.db.get_value("Payment Gateway", gateway, "adapter_key") != "Razorpay":
 		return
 	p = (
 		frappe.db.get_value("Billing Profile", team, ["legal_name", "email", "phone"], as_dict=True)
 		or frappe._dict()
 	)
-	if not str(p.phone or "").strip():
+	contact = str(contact or "").strip()
+	phone = contact or str(p.phone or "").strip()
+	if not phone:
 		frappe.throw(
-			"Add a phone number to your billing profile before setting up a recurring "
-			"payment method.",
+			"A phone number is required to set up a recurring card payment with Razorpay.",
 			frappe.ValidationError,
 		)
+	# An inline-provided phone is saved to the profile so it's collected only once.
+	if contact and contact != str(p.phone or ""):
+		frappe.db.set_value("Billing Profile", team, "phone", contact)
 	adapter.update_customer(
-		customer_id, {"name": p.legal_name or team, "email": p.email, "contact": p.phone}
+		customer_id, {"name": p.legal_name or team, "email": p.email, "contact": phone}
 	)
 
 
@@ -115,7 +123,7 @@ def setup_mandate(team: str, gateway: str, customer_id: str | None = None, is_de
 	cap = team_cap(team)
 	adapter = _adapter(gateway)
 	customer_id = _ensure_customer(team, gateway, adapter, customer_id)
-	_require_recurring_contact(team, gateway, adapter, customer_id)
+	# UPI Autopay carries no customer contact — no phone needed here.
 	handles = adapter.setup_payment_method(
 		team, {"method": "upi", "max_amount": cap, "customer_id": customer_id}
 	)
@@ -137,16 +145,17 @@ def setup_mandate(team: str, gateway: str, customer_id: str | None = None, is_de
 	return {**handles, "payment_method": method.name}
 
 
-def setup_card(team: str, gateway: str, customer_id: str | None = None) -> dict:
+def setup_card(team: str, gateway: str, customer_id: str | None = None, contact: str | None = None) -> dict:
 	"""Begin a Razorpay recurring-card authorisation (no UPI MCC limit).
 
 	Same Checkout → token → recurring-charge machinery as a UPI mandate, but on
-	the card rail. Returns the client-side handles plus the pending Payment
-	Method name.
+	the card rail. A Razorpay card mandate needs the customer to have a contact;
+	`contact` is the phone the dashboard collects inline when the profile has none.
+	Returns the client-side handles plus the pending Payment Method name.
 	"""
 	adapter = _adapter(gateway)
 	customer_id = _ensure_customer(team, gateway, adapter, customer_id)
-	_require_recurring_contact(team, gateway, adapter, customer_id)
+	_require_card_contact(team, gateway, adapter, customer_id, contact=contact)
 	handles = adapter.setup_payment_method(
 		team, {"method": "card", "max_amount": CARD_TOKEN_MAX, "customer_id": customer_id}
 	)

--- a/central/billing/tests/test_mandates.py
+++ b/central/billing/tests/test_mandates.py
@@ -283,21 +283,36 @@ class TestRazorpayCardSetup(MandateTestBase):
 			mandates.setup_card(TEAM, GATEWAY)
 			adapter.create_customer.assert_not_called()
 
-	def test_recurring_setup_requires_a_phone(self):
-		# Razorpay recurring needs the customer to carry a contact; refuse clearly
-		# (before any order) when the billing profile has no phone.
+	def test_card_setup_requires_a_phone_when_none_available(self):
+		# A Razorpay card mandate needs a contact; with no profile phone AND none
+		# supplied inline, refuse clearly (before any order).
 		frappe.db.set_value("Billing Profile", TEAM, "phone", "")
 		with stub_adapter():
 			with self.assertRaises(frappe.ValidationError):
 				mandates.setup_card(TEAM, GATEWAY)
 
-	def test_recurring_setup_syncs_contact_onto_customer(self):
-		# The profile's name/email/phone are pushed onto the (possibly reused)
-		# customer, so a contactless one is fixed before the recurring order.
+	def test_card_setup_uses_inline_phone_persists_and_syncs(self):
+		# Phone is optional on the profile: collected inline at card setup, saved
+		# back to the profile (asked once), and synced onto the customer.
+		frappe.db.set_value("Billing Profile", TEAM, "phone", "")
+		with stub_adapter() as adapter:
+			mandates.setup_card(TEAM, GATEWAY, contact="8888888888")
+			self.assertEqual(adapter.update_customer.call_args.args[1]["contact"], "8888888888")
+			self.assertEqual(frappe.db.get_value("Billing Profile", TEAM, "phone"), "8888888888")
+
+	def test_card_setup_syncs_profile_contact_onto_customer(self):
+		# With a profile phone present, it's synced onto the (possibly reused,
+		# contactless) customer before the recurring order.
 		with stub_adapter() as adapter:
 			mandates.setup_card(TEAM, GATEWAY)
-			adapter.update_customer.assert_called()
 			self.assertEqual(adapter.update_customer.call_args.args[1]["contact"], "9999999999")
+
+	def test_upi_setup_needs_no_phone(self):
+		# UPI Autopay carries no customer contact — setup works with no phone.
+		frappe.db.set_value("Billing Profile", TEAM, "phone", "")
+		with stub_adapter():
+			result = mandates.setup_mandate(TEAM, GATEWAY, customer_id="cust_x")
+		self.assertTrue(result["payment_method"])
 
 
 class TestAddMethodGatewayResolution(IntegrationTestCase):

--- a/dashboard/src/components/AddMethodDialog.vue
+++ b/dashboard/src/components/AddMethodDialog.vue
@@ -1,7 +1,7 @@
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useCall } from 'frappe-ui'
-import { Dialog, Button, LoadingText } from 'frappe-ui'
+import { Dialog, Button, FormControl, LoadingText } from 'frappe-ui'
 import { API, m } from '@/api/endpoints'
 import { useTeam } from '@/composables/useTeam'
 import { useAddPaymentMethod } from '@/composables/useAddPaymentMethod'
@@ -13,11 +13,9 @@ const open = defineModel({ type: Boolean, default: false })
 const emit = defineEmits(['done'])
 const { currentTeam } = useTeam()
 
-const options = useCall({
-  url: m(API.paymentMethodOptions),
-  params: () => ({ team: currentTeam.value }),
-  refetch: true,
-})
+const params = () => ({ team: currentTeam.value })
+const options = useCall({ url: m(API.paymentMethodOptions), params, refetch: true })
+const profile = useCall({ url: m(API.billingProfile), params, refetch: true })
 
 const { run, loading } = useAddPaymentMethod({
   onDone: (res) => {
@@ -27,6 +25,22 @@ const { run, loading } = useAddPaymentMethod({
 })
 
 const upiBlocked = computed(() => options.data && !options.data.allow_upi)
+
+// A Razorpay card mandate needs a customer contact; phone is optional on the
+// profile, so collect it inline here when it's missing.
+const cardNeedsPhone = computed(
+  () => options.data?.adapter_key === 'Razorpay' && !String(profile.data?.phone || '').trim(),
+)
+const askPhone = ref(false)
+const phone = ref('')
+
+function onCard() {
+  if (cardNeedsPhone.value && !phone.value.trim()) {
+    askPhone.value = true
+    return
+  }
+  run('Card', phone.value.trim() || undefined)
+}
 </script>
 
 <template>
@@ -40,7 +54,7 @@ const upiBlocked = computed(() => options.data && !options.data.allow_upi)
           v-if="options.data.methods.includes('Card')"
           class="flex w-full items-center justify-between rounded border border-outline-gray-2 px-4 py-3 text-left hover:border-outline-gray-3 disabled:opacity-50"
           :disabled="loading"
-          @click="run('Card')"
+          @click="onCard"
         >
           <div>
             <p class="text-sm text-ink-gray-8">Card</p>
@@ -50,6 +64,23 @@ const upiBlocked = computed(() => options.data && !options.data.allow_upi)
           </div>
           <span class="lucide-credit-card size-5 text-ink-gray-5" />
         </button>
+
+        <div v-if="askPhone" class="space-y-2 rounded border border-outline-gray-2 px-4 py-3">
+          <FormControl
+            v-model="phone"
+            type="text"
+            label="Phone number"
+            placeholder="Mobile number"
+            description="Razorpay requires a contact for recurring card payments. Saved to your billing profile."
+          />
+          <Button
+            variant="solid"
+            label="Continue"
+            :loading="loading"
+            :disabled="!phone.trim()"
+            @click="run('Card', phone.trim())"
+          />
+        </div>
 
         <button
           v-if="options.data.methods.includes('UPI Autopay')"

--- a/dashboard/src/composables/useAddPaymentMethod.js
+++ b/dashboard/src/composables/useAddPaymentMethod.js
@@ -20,9 +20,13 @@ export function useAddPaymentMethod({ onDone } = {}) {
   const setup = useCall({ url: m(API.setupPaymentMethodOrder), method: 'POST', immediate: false })
   const confirm = useCall({ url: m(API.confirmPaymentMethodOrder), method: 'POST', immediate: false })
 
-  async function run(methodType) {
+  async function run(methodType, contact) {
     try {
-      const order = await setup.submit({ team: currentTeam.value, method_type: methodType })
+      const params = { team: currentTeam.value, method_type: methodType }
+      // A Razorpay card mandate needs a customer contact; the dialog collects it
+      // inline when the billing profile has no phone.
+      if (contact) params.contact = contact
+      const order = await setup.submit(params)
       const handles = await openRazorpayCheckout(order, {
         name: 'Central',
         description: methodType === 'Card' ? 'Save card' : 'Set up UPI Autopay',


### PR DESCRIPTION

Phone stays optional on the billing profile, but a Razorpay *card* mandate requires the customer to carry a contact. Two corrections:

- UPI Autopay carries no contact (per press), so the phone requirement no longer fires for setup_mandate — only for setup_card.
- For a card mandate with no profile phone, the Add-Card dialog now collects one inline (explaining Razorpay needs it for recurring cards); it's passed to setup_payment_method_order -> setup_card(contact=...), saved back to the profile (asked once), and synced onto the customer. Only if neither a profile phone nor an inline one is available do we refuse, with a clear message.

fail_existing is unrelated here (customer-creation idempotency, not the recurring order's contact rule). Tests: card requires-a-phone, inline phone persists+syncs, profile phone syncs, UPI needs no phone. Full suite 337 green.