### PR TITLE
demo: seed Gateway Customer store + Billing Profile for demo team

### DIFF
--- a/central/billing/demo/_factory.py
+++ b/central/billing/demo/_factory.py
@@ -154,6 +154,7 @@ def _payment_setup(team, slug, currency, state):
 			"mandate_max_amount": 200000, "mandate_currency": "INR", "is_default": 1,
 			"validated_at": frappe.utils.now_datetime(),
 		}).insert(ignore_permissions=True).name
+		_gateway_customer(team, RAZORPAY, f"cust_{slug}")
 		return RAZORPAY, pm
 	gateway = STRIPE[currency]
 	pm = frappe.get_doc({
@@ -162,7 +163,23 @@ def _payment_setup(team, slug, currency, state):
 		"gateway_customer_id": f"cus_{slug}", "expiry_month": 11, "expiry_year": 2030,
 		"is_default": 1, "validated_at": frappe.utils.now_datetime(),
 	}).insert(ignore_permissions=True).name
+	_gateway_customer(team, gateway, f"cus_{slug}")
 	return gateway, pm
+
+
+def _gateway_customer(team, gateway, customer_id):
+	"""Mirror the production Gateway Customer store: one (team, gateway)→customer_id
+	row, the id every payment-method setup, recurring charge AND wallet top-up reuses.
+	The demo Payment Methods carry the same id, so the store stays consistent — the
+	state the v10 backfill leaves."""
+	existing = frappe.db.get_value("Gateway Customer", {"team": team, "gateway": gateway}, "name")
+	if existing:
+		frappe.delete_doc("Gateway Customer", existing, force=True)
+	frappe.get_doc({
+		"doctype": "Gateway Customer", "team": team, "gateway": gateway,
+		"adapter_key": frappe.db.get_value("Payment Gateway", gateway, "adapter_key"),
+		"gateway_customer_id": customer_id,
+	}).insert(ignore_permissions=True)
 
 
 def _failed_attempt(team, invoice, pm, gateway, retry, when=None):
@@ -267,9 +284,9 @@ def _wipe_all():
 	"""Drop every billing record so the demo is the only data present."""
 	children = ("Catalog Rate", "Plan Includes", "Invoice Line Item",
 				"Subscription Change")
-	transactional = ("Invoice", "Payment Attempt", "Refund", "Payment Method", "Price Lock",
-					 "Usage Rollup", "Credit Ledger Entry", "Credit Wallet", "Billing Notification Log",
-					 "Entitlement Token", "Webhook Event", "Subscription")
+	transactional = ("Invoice", "Payment Attempt", "Refund", "Payment Method", "Gateway Customer",
+					 "Price Lock", "Usage Rollup", "Credit Ledger Entry", "Credit Wallet",
+					 "Billing Notification Log", "Entitlement Token", "Webhook Event", "Subscription")
 	config = ("Trust Tier", "Tax Profile", "Billing Profile")
 	catalog = ("Plan", "Add-on", "Payment Gateway", "Trust Tier Level")
 	for dt in children + transactional + config + catalog:

--- a/central/billing/demo/demo.py
+++ b/central/billing/demo/demo.py
@@ -32,6 +32,7 @@ def seed():
 	_catalog()
 	_gateway()
 	_tier_and_tax()
+	_billing_profile()
 	card = _payment_method()
 	sub = subscriptions.create_subscription(
 		team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="Monthly"
@@ -254,6 +255,29 @@ def _tier_and_tax():
 	)
 
 
+def _billing_profile():
+	"""A complete Billing Profile for the demo team. It is mandatory before any money
+	moves (top-up / payment method) and gates the dashboard, so without it the demo
+	team's UI is unreachable. Currency is INR — matching its wallet, card and invoices."""
+	_replace(
+		"Billing Profile",
+		TEAM,
+		{
+			"team": TEAM,
+			"currency": "INR",
+			"legal_name": "Demo Cloud Pvt Ltd",
+			"email": OWNER,
+			"phone": "+919900000000",
+			"gstin": "27AAPFU0939F1ZV",
+			"address_line1": "1 Demo Street",
+			"city": "Mumbai",
+			"state": "Maharashtra",
+			"country": "India",
+			"pincode": "400001",
+		},
+	)
+
+
 def _payment_method():
 	name = frappe.db.get_value("Payment Method", {"team": TEAM, "gateway": GATEWAY}, "name")
 	values = {
@@ -272,7 +296,24 @@ def _payment_method():
 	}
 	if name:
 		frappe.delete_doc("Payment Method", name, force=True)
-	return frappe.get_doc(values).insert(ignore_permissions=True).name
+	pm = frappe.get_doc(values).insert(ignore_permissions=True).name
+	# Mirror the Gateway Customer store: the card and any later top-up / charge reuse
+	# this one (team, gateway) customer id.
+	_gateway_customer(TEAM, GATEWAY, "cus_demo")
+	return pm
+
+
+def _gateway_customer(team, gateway, customer_id):
+	"""One (team, gateway)→customer_id row, the id every setup, charge and wallet
+	top-up reuses (the state the v10 backfill leaves)."""
+	existing = frappe.db.get_value("Gateway Customer", {"team": team, "gateway": gateway}, "name")
+	if existing:
+		frappe.delete_doc("Gateway Customer", existing, force=True)
+	frappe.get_doc({
+		"doctype": "Gateway Customer", "team": team, "gateway": gateway,
+		"adapter_key": frappe.db.get_value("Payment Gateway", gateway, "adapter_key"),
+		"gateway_customer_id": customer_id,
+	}).insert(ignore_permissions=True)
 
 
 def _attempt(name, card, amount, status, when, retry, **extra):
@@ -370,11 +411,11 @@ def _wipe():
 	for sub in frappe.get_all("Subscription", {"team": TEAM}, pluck="name"):
 		frappe.db.delete("Subscription Change", {"subscription": sub})
 	for dt in (
-		"Invoice", "Payment Attempt", "Payment Method", "Price Lock", "Usage Rollup",
-		"Credit Ledger Entry", "Subscription", "Billing Notification Log",
+		"Invoice", "Payment Attempt", "Payment Method", "Gateway Customer", "Price Lock",
+		"Usage Rollup", "Credit Ledger Entry", "Subscription", "Billing Notification Log",
 	):
 		frappe.db.delete(dt, {"team": TEAM})
-	for dt in ("Credit Wallet", "Trust Tier", "Tax Profile", "Notification Preference"):
+	for dt in ("Credit Wallet", "Trust Tier", "Tax Profile", "Notification Preference", "Billing Profile"):
 		if frappe.db.exists(dt, TEAM):
 			frappe.delete_doc(dt, TEAM, force=True)
 	for inv in frappe.get_all("Team Invitation", {"team": TEAM}, pluck="name"):

--- a/central/billing/demo/demo_scenarios.py
+++ b/central/billing/demo/demo_scenarios.py
@@ -31,10 +31,12 @@ from central.billing.platform.sync import receive_meter_rollups, receive_usage_e
 from central.billing.demo._factory import (
 	ANCHOR,
 	PLAN_SIZES,
+	STRIPE,
 	_catalog,
 	_ensure_demo_team,
 	_ensure_signing_key,
 	_failed_attempt,
+	_gateway_customer,
 	_gateways,
 	_month_periods,
 	_payment_setup,
@@ -45,6 +47,10 @@ from central.billing.demo._factory import (
 	_tiers,
 	_wipe_all,
 )
+
+# Wallet-top-up states: no card on file, but the team funds its wallet through a
+# gateway top-up — which now mints a reusable Gateway Customer (the new top-up path).
+_TOPUP_STATES = ("credits", "credits_full", "credits_partial")
 
 # Card teams: which historical month indices show a failed-then-settled trail in
 # the invoice Activity (month index → failed retries before the capture). A few
@@ -183,6 +189,10 @@ def _build_team(team, slug, tier, currency, months, state, resources):
 	_tax(team, currency)
 	_profile(team, slug, currency, resources[0][0])
 	gateway, pm = _payment_setup(team, slug, currency, state)
+	# A card/UPI team already got its Gateway Customer in _payment_setup. A top-up-only
+	# team has no card, but its wallet top-up now mints + reuses a customer too.
+	if pm is None and state in _TOPUP_STATES:
+		_gateway_customer(team, STRIPE[currency], f"cus_{slug}")
 
 	periods = _month_periods(months)
 	first_start = periods[0][0] if periods else ANCHOR


### PR DESCRIPTION
Reflect the gateway-customer-on-top-up feature in the demo datasets and make the single-team demo dashboard reachable.

- _factory: new _gateway_customer helper mints a (team, gateway)→customer_id row mirroring the store; _payment_setup creates it for every card/UPI method (same id the Payment Method carries — the v10 backfill state).
- demo_scenarios: wallet-top-up teams (credits / credits_full / credits_partial) have no card but now get a Gateway Customer too, just as the new top-up path mints one.
- demo: add a complete Billing Profile for the `demo` team — it is mandatory before any money moves and gates the dashboard, so without it the team's UI was unreachable. Also seed its demo::GW-Demo-Stripe customer row.
- Extend both wipes (_wipe / _wipe_all) to clear Gateway Customer (+ Billing Profile for the demo team) on re-seed.