### PR TITLE
fix(billing): in-app Stripe wallet top-up (no hosted-Checkout redirect)

### DIFF
--- a/central/billing/api/dashboard/invoices.py
+++ b/central/billing/api/dashboard/invoices.py
@@ -312,19 +312,11 @@ def create_topup_order(team: str | None = None, amount: float | None = None,
 	customer_id = ensure_gateway_customer(team, gw, adapter)
 	receipt = f"topup-{team}-{frappe.generate_hash(length=8)}"
 	notes = {"team": team, "purpose": "wallet_topup"}
-	if gw_doc.adapter_key == "Stripe":
-		# Hosted Stripe Checkout: the SPA redirects out and returns to /billing/credits,
-		# which confirms the session. Stripe fills in {CHECKOUT_SESSION_ID}.
-		from urllib.parse import quote
-
-		base = frappe.utils.get_url()
-		success_url = (f"{base}/billing/credits?topup=success&gateway={quote(gw)}"
-					   f"&team={quote(team)}&session={{CHECKOUT_SESSION_ID}}")
-		cancel_url = f"{base}/billing/credits?topup=cancelled"
-		handles = adapter.create_checkout_session(
-			amount, currency, receipt, success_url, cancel_url, notes=notes, customer=customer_id)
-	else:
-		handles = adapter.create_order(amount, currency, receipt, notes=notes, customer=customer_id)
+	# Both rails collect the card in-app: Razorpay in its hosted sheet over the
+	# returned order, Stripe via a PaymentIntent the SPA confirms with Stripe.js
+	# (no hosted-Checkout redirect). The India-export billing address rides on the
+	# Stripe PaymentIntent from the Billing Profile, so it's never re-asked.
+	handles = adapter.create_order(amount, currency, receipt, notes=notes, customer=customer_id)
 	return {"gateway": gw, "adapter_key": gw_doc.adapter_key,
 			"amount": amount, "currency": currency, "receipt": receipt, **handles}
 
@@ -332,12 +324,13 @@ def create_topup_order(team: str | None = None, amount: float | None = None,
 @frappe.whitelist(methods=["POST"])
 def confirm_topup(team: str | None = None, amount: float | None = None, gateway: str | None = None,
 				  razorpay_order_id: str | None = None, razorpay_payment_id: str | None = None,
-				  razorpay_signature: str | None = None, session: str | None = None) -> dict:
+				  razorpay_signature: str | None = None, payment_intent: str | None = None) -> dict:
 	"""Credit the wallet only after the gateway confirms the money really moved.
 	Razorpay confirms via the checkout-callback signature; Stripe confirms by
-	retrieving the hosted Checkout session and checking it was paid (and credits
-	the server-confirmed amount, not a client-supplied one). The wallet is credited
-	in the team's own currency — never assumed INR."""
+	retrieving the PaymentIntent the SPA charged and checking it succeeded (and
+	credits the server-confirmed amount, not a client-supplied one). The wallet is
+	credited in the team's own currency — never assumed INR. Idempotent on the
+	gateway payment id, so the capture webhook crediting in parallel is a no-op."""
 	team = _resolve_team(team, authz.MANAGE)
 	currency = _team_currency(team)
 	amount = frappe.utils.flt(amount)
@@ -353,15 +346,17 @@ def confirm_topup(team: str | None = None, amount: float | None = None, gateway:
 		})
 		reference = razorpay_payment_id
 	else:
-		# Hosted-checkout gateways (Stripe): trust the session the gateway confirms,
-		# including the amount/currency it actually charged.
-		checkout = adapter.get_checkout_session(session)
-		ok = checkout.get("payment_status") == "paid"
-		reference = checkout.get("payment_intent")
-		if checkout.get("amount_total"):
-			amount = frappe.utils.flt(checkout["amount_total"]) / 100
-		if checkout.get("currency"):
-			currency = checkout["currency"].upper()
+		# In-app PaymentIntent (Stripe): the SPA confirmed the card with Stripe.js;
+		# trust the intent the gateway reports, including the amount/currency it
+		# actually charged — never a client-supplied figure.
+		intent = adapter.get_payment_intent(payment_intent)
+		ok = intent.get("status") == "succeeded"
+		reference = intent.get("id")
+		minor = intent.get("amount_received") or intent.get("amount")
+		if minor:
+			amount = frappe.utils.flt(minor) / 100
+		if intent.get("currency"):
+			currency = intent["currency"].upper()
 	if not ok:
 		frappe.throw("Payment confirmation failed.", frappe.ValidationError)
 	return credits.purchase(team, amount, currency,

--- a/central/billing/gateways/stripe_adapter.py
+++ b/central/billing/gateways/stripe_adapter.py
@@ -257,10 +257,23 @@ class StripeAdapter(GatewayAdapter):
 			description="Wallet top-up")
 		if customer:
 			params["customer"] = customer
+		# Carry the billing name + address from the team's Billing Profile so an
+		# in-app (on-session) top-up clears the same India-export requirement that
+		# off-session charge()/validate_payment_method() satisfy — the customer
+		# never re-enters an address the profile already holds.
+		shipping = _export_shipping((notes or {}).get("team"))
+		if shipping:
+			params["shipping"] = shipping
 		intent = _to_dict(stripe.PaymentIntent.create(**params))
 		return {"client_secret": intent.get("client_secret"), "payment_intent_id": intent.get("id"),
 				"amount": intent.get("amount"), "publishable_key": self.get_credential("api_key"),
 				"currency": (currency or "usd").upper()}
+
+	def get_payment_intent(self, payment_intent_id: str) -> dict:
+		"""Retrieve a PaymentIntent so a top-up can be confirmed from what Stripe
+		actually charged (status + amount + currency), not a client-supplied figure."""
+		self._configure()
+		return _to_dict(stripe.PaymentIntent.retrieve(payment_intent_id))
 
 	def create_checkout_session(self, amount, currency: str, receipt: str,
 								success_url: str, cancel_url: str, notes: dict | None = None,

--- a/central/billing/tests/test_dashboard.py
+++ b/central/billing/tests/test_dashboard.py
@@ -336,9 +336,10 @@ class TestGatewayTopUp(CustomerDataBase):
 					razorpay_order_id="o", razorpay_payment_id="p", razorpay_signature="bad")
 		self.assertEqual(dashboard.get_credit_balance(TEAM)["balance"], 0)  # no magic credit
 
-	def test_topup_stripe_uses_hosted_checkout_and_confirms_via_session(self):
-		"""A Stripe (e.g. EUR) team gets a hosted Checkout redirect, and the wallet
-		is credited from the server-confirmed session amount/currency — not INR."""
+	def test_topup_stripe_uses_inapp_payment_intent_and_confirms_via_intent(self):
+		"""A Stripe (e.g. EUR) team gets an in-app PaymentIntent (no hosted-Checkout
+		redirect), and the wallet is credited from the server-confirmed intent
+		amount/currency — not INR, not a client-supplied figure."""
 		from unittest.mock import MagicMock, patch
 		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
 
@@ -346,32 +347,33 @@ class TestGatewayTopUp(CustomerDataBase):
 		complete_billing_profile(TEAM)
 		adapter = MagicMock()
 		adapter.create_customer.return_value = "cus_stripe"
-		adapter.create_checkout_session.return_value = {"checkout_url": "https://stripe.test/cs", "session_id": "cs_x"}
-		adapter.get_checkout_session.return_value = {
-			"payment_status": "paid", "payment_intent": "pi_x", "amount_total": 500000, "currency": "eur"}
+		adapter.create_order.return_value = {
+			"client_secret": "pi_x_secret", "payment_intent_id": "pi_x", "publishable_key": "pk_test"}
+		adapter.get_payment_intent.return_value = {
+			"status": "succeeded", "id": "pi_x", "amount_received": 500000, "currency": "eur"}
 		with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
 			order = dashboard.create_topup_order(team=TEAM, amount=5000, gateway=gw)
 			self.assertEqual(order["adapter_key"], "Stripe")
-			self.assertEqual(order["checkout_url"], "https://stripe.test/cs")  # redirect, not a Razorpay order
-			adapter.create_checkout_session.assert_called_once()
-			# The hosted session is bound to the team's reused gateway customer.
-			self.assertEqual(adapter.create_checkout_session.call_args.kwargs["customer"], "cus_stripe")
+			self.assertEqual(order["client_secret"], "pi_x_secret")  # in-app intent, not a redirect URL
+			adapter.create_order.assert_called_once()
+			# The intent is bound to the team's reused gateway customer.
+			self.assertEqual(adapter.create_order.call_args.kwargs["customer"], "cus_stripe")
 			self.assertEqual(dashboard.get_credit_balance(TEAM)["balance"], 0)  # not credited yet
 
-			out = dashboard.confirm_topup(team=TEAM, amount=5000, gateway=gw, session="cs_x")
-			adapter.get_checkout_session.assert_called_once_with("cs_x")
+			out = dashboard.confirm_topup(team=TEAM, amount=5000, gateway=gw, payment_intent="pi_x")
+			adapter.get_payment_intent.assert_called_once_with("pi_x")
 			self.assertEqual(out["new_balance"], 5000)
 
-	def test_topup_stripe_rejects_unpaid_session(self):
+	def test_topup_stripe_rejects_unsucceeded_intent(self):
 		from unittest.mock import MagicMock, patch
 		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
 
 		gw = make_stripe_gateway("GW-Cust-Stripe-T2").name
 		adapter = MagicMock()
-		adapter.get_checkout_session.return_value = {"payment_status": "unpaid", "payment_intent": "pi_y"}
+		adapter.get_payment_intent.return_value = {"status": "requires_payment_method", "id": "pi_y"}
 		with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
 			with self.assertRaises(frappe.ValidationError):
-				dashboard.confirm_topup(team=TEAM, amount=5000, gateway=gw, session="cs_y")
+				dashboard.confirm_topup(team=TEAM, amount=5000, gateway=gw, payment_intent="pi_y")
 		self.assertEqual(dashboard.get_credit_balance(TEAM)["balance"], 0)  # no magic credit
 
 

--- a/central/billing/tests/test_stripe_adapter.py
+++ b/central/billing/tests/test_stripe_adapter.py
@@ -213,3 +213,15 @@ class TestStripeAdapter(GatewayAdapterContract, IntegrationTestCase):
 		intent = stripe.PaymentIntent.construct_from({"id": "pi_x", "status": "succeeded"}, "sk_test")
 		with patch.object(stripe.PaymentIntent, "retrieve", return_value=intent):
 			self.assertEqual(adapter.get_transaction_status("pi_x"), "succeeded")
+
+	def test_get_payment_intent_normalises_real_stripe_object(self):
+		"""confirm_topup reads the full intent (status + amount + currency) to credit
+		from what Stripe actually charged, so it must normalise a real StripeObject."""
+		adapter = self.make_adapter()
+		intent = stripe.PaymentIntent.construct_from(
+			{"id": "pi_x", "status": "succeeded", "amount_received": 5000, "currency": "eur"}, "sk_test")
+		with patch.object(stripe.PaymentIntent, "retrieve", return_value=intent):
+			out = adapter.get_payment_intent("pi_x")
+		self.assertEqual(out["status"], "succeeded")
+		self.assertEqual(out["amount_received"], 5000)
+		self.assertEqual(out["currency"], "eur")

--- a/central/www/dashboard.html
+++ b/central/www/dashboard.html
@@ -10,7 +10,7 @@
          doesn't leave the card widget blank. @stripe/stripe-js reuses this tag. -->
     <link rel="preconnect" href="https://js.stripe.com" crossorigin />
     <script src="https://js.stripe.com/v3/" async></script>
-    <script type="module" crossorigin src="/assets/central/dashboard/assets/index-v0sIo8Qb.js"></script>
+    <script type="module" crossorigin src="/assets/central/dashboard/assets/index-Fh3fAvBB.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/central/dashboard/assets/index-C-2n0NoW.css">
   </head>
   <body>

--- a/dashboard/src/components/TopupDialog.vue
+++ b/dashboard/src/components/TopupDialog.vue
@@ -1,11 +1,15 @@
 <script setup>
-import { ref } from 'vue'
+import { nextTick, ref, watch } from 'vue'
 import { Dialog, Button, FormControl } from 'frappe-ui'
 import { useTopup } from '@/composables/useTopup'
-import { currencySymbol } from '@/utils/money'
+import { currencySymbol, money } from '@/utils/money'
+import { errorToast } from '@/utils/toast'
 
-// Amount entry → gateway checkout. Shared by Overview and Credits.
-// The wallet is credited only after the gateway confirms (see useTopup).
+// Amount entry → in-app payment. Shared by Overview and Credits.
+// Razorpay (INR) collects in its hosted sheet; Stripe collects the card in an
+// embedded Element right here (the address rides on the PaymentIntent from the
+// billing profile — never re-asked). The wallet is credited only after the
+// gateway confirms (see useTopup).
 const props = defineProps({
   currency: { type: String, default: 'INR' },
 })
@@ -15,10 +19,15 @@ const emit = defineEmits(['done'])
 const amount = ref(null)
 const presets = [1000, 5000, 10000, 25000]
 
-const { run, loading } = useTopup({
+// Stripe card phase: swap the amount field for the embedded card Element once a
+// Stripe order is created and needs a card.
+const cardPhase = ref(false)
+const cardLoading = ref(false) // Stripe.js + Element still mounting
+const cardEl = ref(null)
+
+const { begin, mountCard, pay, destroy, cardComplete, submitting, loading } = useTopup({
   onDone: (res) => {
     open.value = false
-    amount.value = null
     emit('done', res)
   },
 })
@@ -26,14 +35,51 @@ const { run, loading } = useTopup({
 async function submit() {
   const value = Number(amount.value)
   if (!value || value <= 0) return
-  await run(value)
+  const { card } = await begin(value)
+  if (!card) return // Razorpay finished in its sheet (or was cancelled/failed)
+
+  cardPhase.value = true
+  cardLoading.value = true
+  await nextTick() // the Element needs its mount node in the DOM
+  try {
+    await mountCard(cardEl.value)
+  } catch (e) {
+    errorToast(e, 'Could not start secure card entry.')
+    cardPhase.value = false
+  } finally {
+    cardLoading.value = false
+  }
 }
+
+// Reset to the amount step whenever the dialog closes, tearing down any Element
+// so a reopen never shows a stale card field.
+watch(open, (isOpen) => {
+  if (!isOpen) {
+    destroy()
+    amount.value = null
+    cardPhase.value = false
+    cardLoading.value = false
+  }
+})
 </script>
 
 <template>
   <Dialog v-model="open" :options="{ title: 'Top up wallet' }">
     <template #body-content>
-      <div class="space-y-4">
+      <!-- Stripe card entry: Element renders inside the iframe Stripe hosts. -->
+      <div v-if="cardPhase" class="space-y-3">
+        <p class="text-sm text-ink-gray-8">
+          Paying {{ money(Number(amount), currency) }}
+        </p>
+        <p v-if="cardLoading" class="text-p-sm text-ink-gray-5">Loading secure card field…</p>
+        <div ref="cardEl" class="rounded border border-outline-gray-2 px-3 py-3" />
+        <p class="text-p-sm text-ink-gray-5">
+          Card details are entered on Stripe’s secure field — we never see your card number.
+          Your billing address is taken from your billing profile.
+        </p>
+      </div>
+
+      <div v-else class="space-y-4">
         <div class="flex flex-wrap gap-2">
           <Button
             v-for="p in presets"
@@ -51,13 +97,23 @@ async function submit() {
           min="1"
         />
         <p class="text-p-sm text-ink-gray-5">
-          You’ll complete payment on the gateway’s secure checkout. Your wallet is
-          credited only after the payment is confirmed.
+          You’ll complete payment securely. Your wallet is credited only after the
+          payment is confirmed.
         </p>
       </div>
     </template>
     <template #actions>
       <Button
+        v-if="cardPhase"
+        variant="solid"
+        :label="submitting ? 'Paying…' : 'Pay'"
+        :loading="submitting"
+        :disabled="!cardComplete"
+        class="w-full"
+        @click="pay"
+      />
+      <Button
+        v-else
         variant="solid"
         label="Continue to payment"
         :loading="loading"

--- a/dashboard/src/composables/useTopup.js
+++ b/dashboard/src/composables/useTopup.js
@@ -1,59 +1,118 @@
 // Wallet top-up — prepaid customers add credit through a real gateway order.
 //
 // Flow (webhook/confirm-truth, no magic crediting):
-//   1. create_topup_order  → a real gateway order/checkout-session handle.
-//   2. open the gateway's hosted element (Razorpay sheet) or redirect (Stripe).
-//   3. confirm_topup       → backend verifies the gateway actually took the money,
+//   1. begin(amount)  → create_topup_order makes a real gateway order.
+//   2. Razorpay finishes in its hosted sheet right here; Stripe needs an in-app
+//      card field, so begin() returns { card: true } and the dialog calls
+//      mountCard()/pay() — no hosted-Checkout redirect.
+//   3. confirm_topup  → backend verifies the gateway actually took the money,
 //      then credits the wallet in the team's own currency.
-// Stripe redirects out and returns to /billing/credits, which finishes step 3 from
-// the URL — so for Stripe this composable ends at the redirect.
+//
+// The PAN is entered in a Stripe Element (a PCI-scoped iframe Stripe hosts); it
+// never touches our form or server. The India-export billing address rides on
+// the PaymentIntent from the Billing Profile (set server-side), so the customer
+// is never asked to re-enter an address we already hold.
 
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
+import { loadStripe } from '@stripe/stripe-js'
 import { useCall } from 'frappe-ui'
 import { API, m } from '@/api/endpoints'
 import { useTeam } from '@/composables/useTeam'
-import { openRazorpayCheckout, redirectToStripeCheckout } from '@/utils/gateway'
-import { successToast, infoToast, errorToast } from '@/utils/toast'
+import { openRazorpayCheckout } from '@/utils/gateway'
+import { successToast, errorToast } from '@/utils/toast'
 
 export function useTopup({ onDone } = {}) {
   const { currentTeam } = useTeam()
   const createOrder = useCall({ url: m(API.createTopupOrder), method: 'POST', immediate: false })
   const confirm = useCall({ url: m(API.confirmTopup), method: 'POST', immediate: false })
 
-  async function run(amount) {
+  // Stripe card-phase state — populated only once a Stripe order needs a card.
+  const cardComplete = ref(false) // the card field is filled in and valid
+  const submitting = ref(false)
+  let stripe = null
+  let card = null
+  let order = null
+
+  // Create the gateway order. Razorpay collects payment in its hosted sheet and
+  // resolves the whole top-up here; Stripe returns { card: true } so the dialog
+  // can mount the card Element for the order we just created.
+  async function begin(amount) {
     try {
-      const order = await createOrder.submit({ team: currentTeam.value, amount })
+      order = await createOrder.submit({ team: currentTeam.value, amount })
+      if (order.adapter_key === 'Stripe') return { card: true }
 
-      if (order.adapter_key === 'Stripe') {
-        // Hands off to hosted Checkout; /billing/credits confirms on return.
-        infoToast('Redirecting to secure checkout…')
-        redirectToStripeCheckout(order)
-        return
-      }
-
-      // Razorpay: collect the payment in the hosted sheet, then verify server-side.
-      const handles = await openRazorpayCheckout(order, {
-        name: 'Central',
-        description: 'Wallet top-up',
-      })
+      const handles = await openRazorpayCheckout(order, { name: 'Central', description: 'Wallet top-up' })
       const res = await confirm.submit({
         team: currentTeam.value,
         amount: order.amount,
         gateway: order.gateway,
         ...handles,
       })
-      successToast('Wallet topped up.')
-      onDone?.(res)
+      finish(res)
+    } catch (e) {
+      if (e?.message !== 'cancelled') errorToast(e, 'Top-up could not be completed.') // closed sheet = no-op
+    }
+    return { card: false }
+  }
+
+  // Mount the Stripe card Element for the order begin() created.
+  async function mountCard(el) {
+    if (!order?.publishable_key) throw new Error('Stripe publishable key missing.')
+    stripe = await loadStripe(order.publishable_key)
+    if (!stripe) throw new Error('Stripe.js failed to load.')
+    card = stripe.elements().create('card', { hidePostalCode: true })
+    card.on('change', (e) => (cardComplete.value = !!e.complete))
+    card.mount(el)
+  }
+
+  // Confirm the PaymentIntent with the entered card, then credit server-side
+  // from what Stripe actually charged.
+  async function pay() {
+    if (!stripe || !card || !order?.client_secret) return
+    submitting.value = true
+    try {
+      const { paymentIntent, error } = await stripe.confirmCardPayment(order.client_secret, {
+        payment_method: { card },
+      })
+      if (error) throw error
+      if (paymentIntent?.status !== 'succeeded') throw new Error('Payment was not completed.')
+
+      const res = await confirm.submit({
+        team: currentTeam.value,
+        amount: order.amount,
+        gateway: order.gateway,
+        payment_intent: paymentIntent.id,
+      })
+      finish(res)
       return res
     } catch (e) {
-      if (e?.message === 'cancelled') return // customer closed the sheet
       errorToast(e, 'Top-up could not be completed.')
+    } finally {
+      submitting.value = false
     }
   }
 
+  function finish(res) {
+    successToast('Wallet topped up.')
+    onDone?.(res)
+  }
+
+  function destroy() {
+    card?.destroy()
+    card = null
+    stripe = null
+    order = null
+    cardComplete.value = false
+  }
+
   return {
-    run,
-    // Either leg in flight counts as busy.
+    begin,
+    mountCard,
+    pay,
+    destroy,
+    cardComplete,
+    submitting,
+    // Order creation or server confirm in flight counts as busy.
     loading: computed(() => createOrder.loading || confirm.loading),
   }
 }

--- a/dashboard/src/pages/billing/Credits.vue
+++ b/dashboard/src/pages/billing/Credits.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { computed, ref, onMounted } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import { useCall } from 'frappe-ui'
 import { Button, LoadingText } from 'frappe-ui'
 import PageHeader from '@/components/PageHeader.vue'
@@ -11,9 +11,7 @@ import { useTeam } from '@/composables/useTeam'
 import { useCapabilities } from '@/composables/useCapabilities'
 import { useBillingSetup } from '@/composables/useBillingSetup'
 import { money, signedMoney } from '@/utils/money'
-import { successToast, errorToast, infoToast } from '@/utils/toast'
 
-const route = useRoute()
 const router = useRouter()
 const { currentTeam } = useTeam()
 const { canManage } = useCapabilities()
@@ -34,39 +32,6 @@ function reloadAll() {
 // Credits go up on top-up/refund, down when applied to an invoice.
 function isCredit(entry) {
   return Number(entry.amount) >= 0 && entry.entry_type !== 'Debit'
-}
-
-// ── Stripe hosted-checkout return ──
-// Stripe redirects back here with ?topup=success&gateway&session — finish the
-// purchase by confirming server-side (confirm_topup verifies the session paid).
-const confirmTopup = useCall({ url: m(API.confirmTopup), method: 'POST', immediate: false })
-
-onMounted(async () => {
-  const q = route.query
-  if (q.topup === 'cancelled') {
-    infoToast('Top-up cancelled.')
-    clearQuery()
-    return
-  }
-  if (q.topup === 'success' && q.session) {
-    try {
-      await confirmTopup.submit({
-        team: q.team || currentTeam.value,
-        gateway: q.gateway,
-        session: q.session,
-      })
-      successToast('Wallet topped up.')
-      reloadAll()
-    } catch (e) {
-      errorToast(e, 'Could not confirm the top-up.')
-    } finally {
-      clearQuery()
-    }
-  }
-})
-
-function clearQuery() {
-  router.replace({ query: {} })
 }
 </script>
 

--- a/dashboard/src/utils/gateway.js
+++ b/dashboard/src/utils/gateway.js
@@ -48,11 +48,3 @@ export async function openRazorpayCheckout(order, { name = 'Central', descriptio
     rzp.open()
   })
 }
-
-// Stripe hosted Checkout — a redirect; the page returns to /billing/credits,
-// which finishes via confirm_topup using the session id in the URL.
-export function redirectToStripeCheckout(order) {
-  const url = order.checkout_url || order.url
-  if (!url) throw new Error('No Stripe checkout URL returned')
-  window.location.assign(url)
-}


### PR DESCRIPTION
Top-up now confirms a PaymentIntent in an embedded Stripe Element, mirroring the add-payment-method flow, instead of redirecting to Stripe's hosted Checkout page. The India-export billing address rides on the PaymentIntent from the Billing Profile (server-side), so the customer is no longer asked to re-enter an address we already hold.

- stripe_adapter: create_order attaches shipping from the profile (parity with off-session charge/validate); add get_payment_intent.
- invoices: create_topup_order always uses create_order; confirm_topup verifies via the PaymentIntent (payment_intent param) and credits the server-reported amount. Capture webhook still credits idempotently as a backstop.
- dashboard: useTopup drives the in-app card phase; TopupDialog gains a Stripe card Element; drop the dead redirect-return handler and redirectToStripeCheckout.
- tests: updated Stripe top-up tests to the PaymentIntent flow + get_payment_intent.