### PR TITLE
feat(iam): add bench control plane capabilities (#39)

### DIFF
--- a/central/central/doctype/capability/capability.json
+++ b/central/central/doctype/capability/capability.json
@@ -28,7 +28,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Plane",
-   "options": "central\natlas",
+   "options": "central\natlas\nbench",
    "reqd": 1
   },
   {

--- a/central/fixtures/capability.json
+++ b/central/fixtures/capability.json
@@ -1,5 +1,15 @@
 [
  {
+  "capability": "app:install",
+  "description": "Install and uninstall apps on a site.",
+  "docstatus": 0,
+  "doctype": "Capability",
+  "modified": "2026-06-15 00:00:00",
+  "name": "app:install",
+  "plane": "bench",
+  "resource": "app"
+ },
+ {
   "capability": "asset:view",
   "description": "View team-owned assets in the Central registry.",
   "docstatus": 0,
@@ -8,6 +18,26 @@
   "name": "asset:view",
   "plane": "central",
   "resource": "asset"
+ },
+ {
+  "capability": "bench:config",
+  "description": "Edit bench-level config.",
+  "docstatus": 0,
+  "doctype": "Capability",
+  "modified": "2026-06-15 00:00:00",
+  "name": "bench:config",
+  "plane": "bench",
+  "resource": "bench"
+ },
+ {
+  "capability": "bench:manage",
+  "description": "Start/stop processes, run updates and upgrades.",
+  "docstatus": 0,
+  "doctype": "Capability",
+  "modified": "2026-06-15 00:00:00",
+  "name": "bench:manage",
+  "plane": "bench",
+  "resource": "bench"
  },
  {
   "capability": "billing:manage",
@@ -28,6 +58,106 @@
   "name": "billing:view",
   "plane": "central",
   "resource": "billing"
+ },
+ {
+  "capability": "db:access",
+  "description": "Database console and query access.",
+  "docstatus": 0,
+  "doctype": "Capability",
+  "modified": "2026-06-15 00:00:00",
+  "name": "db:access",
+  "plane": "bench",
+  "resource": "database"
+ },
+ {
+  "capability": "log:view",
+  "description": "View logs.",
+  "docstatus": 0,
+  "doctype": "Capability",
+  "modified": "2026-06-15 00:00:00",
+  "name": "log:view",
+  "plane": "bench",
+  "resource": "log"
+ },
+ {
+  "capability": "site:backup",
+  "description": "Trigger and download site backups.",
+  "docstatus": 0,
+  "doctype": "Capability",
+  "modified": "2026-06-15 00:00:00",
+  "name": "site:backup",
+  "plane": "bench",
+  "resource": "site"
+ },
+ {
+  "capability": "site:config",
+  "description": "Edit site config (site_config.json).",
+  "docstatus": 0,
+  "doctype": "Capability",
+  "modified": "2026-06-15 00:00:00",
+  "name": "site:config",
+  "plane": "bench",
+  "resource": "site"
+ },
+ {
+  "capability": "site:create",
+  "description": "Create a new site.",
+  "docstatus": 0,
+  "doctype": "Capability",
+  "modified": "2026-06-15 00:00:00",
+  "name": "site:create",
+  "plane": "bench",
+  "resource": "site"
+ },
+ {
+  "capability": "site:delete",
+  "description": "Drop a site.",
+  "docstatus": 0,
+  "doctype": "Capability",
+  "modified": "2026-06-15 00:00:00",
+  "name": "site:delete",
+  "plane": "bench",
+  "resource": "site"
+ },
+ {
+  "capability": "site:migrate",
+  "description": "Run migrate and schema changes.",
+  "docstatus": 0,
+  "doctype": "Capability",
+  "modified": "2026-06-15 00:00:00",
+  "name": "site:migrate",
+  "plane": "bench",
+  "resource": "site"
+ },
+ {
+  "capability": "site:restore",
+  "description": "Restore a site from backup.",
+  "docstatus": 0,
+  "doctype": "Capability",
+  "modified": "2026-06-15 00:00:00",
+  "name": "site:restore",
+  "plane": "bench",
+  "resource": "site"
+ },
+ {
+  "capability": "site:view",
+  "description": "List sites; view site detail, logs, tasks.",
+  "docstatus": 0,
+  "doctype": "Capability",
+  "modified": "2026-06-15 00:00:00",
+  "name": "site:view",
+  "plane": "bench",
+  "resource": "site"
+ },
+ {
+  "capability": "task:run",
+  "description": "Run bench tasks and manage processes.",
+  "docstatus": 0,
+  "doctype": "Capability",
+  "modified": "2026-06-15 00:00:00",
+  "name": "task:run",
+  "plane": "bench",
+  "resource": "task"
  },
  {
   "capability": "team:delete",
@@ -74,7 +204,7 @@
   "description": "Rebuild virtual machines and restore snapshots in Atlas.",
   "docstatus": 0,
   "doctype": "Capability",
-  "modified": "2026-06-09 00:00:00.000000",
+  "modified": "2026-06-09 00:00:00",
   "name": "vm:rebuild",
   "plane": "atlas",
   "resource": "virtual machine"
@@ -94,7 +224,7 @@
   "description": "Create, clone, and delete virtual machine snapshots in Atlas.",
   "docstatus": 0,
   "doctype": "Capability",
-  "modified": "2026-06-09 00:00:00.000000",
+  "modified": "2026-06-09 00:00:00",
   "name": "vm:snapshot",
   "plane": "atlas",
   "resource": "virtual machine"

--- a/central/fixtures/team_role.json
+++ b/central/fixtures/team_role.json
@@ -2,13 +2,52 @@
  {
   "capabilities": [
    {
+    "capability": "app:install"
+   },
+   {
     "capability": "asset:view"
+   },
+   {
+    "capability": "bench:config"
+   },
+   {
+    "capability": "bench:manage"
    },
    {
     "capability": "billing:manage"
    },
    {
     "capability": "billing:view"
+   },
+   {
+    "capability": "db:access"
+   },
+   {
+    "capability": "log:view"
+   },
+   {
+    "capability": "site:backup"
+   },
+   {
+    "capability": "site:config"
+   },
+   {
+    "capability": "site:create"
+   },
+   {
+    "capability": "site:delete"
+   },
+   {
+    "capability": "site:migrate"
+   },
+   {
+    "capability": "site:restore"
+   },
+   {
+    "capability": "site:view"
+   },
+   {
+    "capability": "task:run"
    },
    {
     "capability": "team:delete"
@@ -55,7 +94,46 @@
  {
   "capabilities": [
    {
+    "capability": "app:install"
+   },
+   {
     "capability": "asset:view"
+   },
+   {
+    "capability": "bench:config"
+   },
+   {
+    "capability": "bench:manage"
+   },
+   {
+    "capability": "db:access"
+   },
+   {
+    "capability": "log:view"
+   },
+   {
+    "capability": "site:backup"
+   },
+   {
+    "capability": "site:config"
+   },
+   {
+    "capability": "site:create"
+   },
+   {
+    "capability": "site:delete"
+   },
+   {
+    "capability": "site:migrate"
+   },
+   {
+    "capability": "site:restore"
+   },
+   {
+    "capability": "site:view"
+   },
+   {
+    "capability": "task:run"
    },
    {
     "capability": "team:edit"
@@ -99,7 +177,34 @@
  {
   "capabilities": [
    {
+    "capability": "app:install"
+   },
+   {
     "capability": "asset:view"
+   },
+   {
+    "capability": "db:access"
+   },
+   {
+    "capability": "log:view"
+   },
+   {
+    "capability": "site:backup"
+   },
+   {
+    "capability": "site:config"
+   },
+   {
+    "capability": "site:migrate"
+   },
+   {
+    "capability": "site:restore"
+   },
+   {
+    "capability": "site:view"
+   },
+   {
+    "capability": "task:run"
    },
    {
     "capability": "vm:create"
@@ -140,6 +245,12 @@
     "capability": "asset:view"
    },
    {
+    "capability": "log:view"
+   },
+   {
+    "capability": "site:view"
+   },
+   {
     "capability": "vm:view"
    }
   ],
@@ -161,6 +272,9 @@
    },
    {
     "capability": "billing:view"
+   },
+   {
+    "capability": "site:view"
    },
    {
     "capability": "vm:view"

--- a/central/tests/test_iam.py
+++ b/central/tests/test_iam.py
@@ -47,7 +47,9 @@ class TestCentralIAM(IntegrationTestCase):
 		return team
 
 	def test_fixtures_create_capability_catalog_and_system_roles(self):
-		self.assertEqual(frappe.db.count("Capability"), 14)
+		# 27 capabilities across three planes: central (6), atlas (8), bench (13).
+		self.assertEqual(frappe.db.count("Capability"), 27)
+		self.assertEqual(frappe.db.count("Capability", {"plane": "bench"}), 13)
 
 		owner_caps = set(frappe.get_all("Role Capability", {"parent": "Owner"}, pluck="capability"))
 		admin_caps = set(frappe.get_all("Role Capability", {"parent": "Admin"}, pluck="capability"))
@@ -58,7 +60,13 @@ class TestCentralIAM(IntegrationTestCase):
 		for caps in (owner_caps, admin_caps, developer_caps):
 			self.assertIn("vm:snapshot", caps)
 			self.assertIn("vm:rebuild", caps)
-		self.assertEqual(viewer_caps, {"asset:view", "vm:view"})
+		# Bench plane: Owner/Admin manage the bench; Developer operates sites but
+		# can't create/drop them; Viewer is read-only.
+		self.assertIn("site:create", owner_caps)
+		self.assertIn("site:create", admin_caps)
+		self.assertNotIn("site:create", developer_caps)
+		self.assertIn("site:migrate", developer_caps)
+		self.assertEqual(viewer_caps, {"asset:view", "log:view", "site:view", "vm:view"})
 		self.assertNotIn("vm:snapshot", billing_caps)
 		self.assertNotIn("vm:rebuild", billing_caps)
 
@@ -85,7 +93,10 @@ class TestCentralIAM(IntegrationTestCase):
 		effective = get_effective_permissions(self.viewer, team.name)
 
 		self.assertEqual(effective["user"], self.viewer)
-		self.assertEqual(effective["teams"][team.name]["caps"], ["asset:view", "vm:view"])
+		self.assertEqual(
+			effective["teams"][team.name]["caps"],
+			["asset:view", "log:view", "site:view", "vm:view"],
+		)
 		self.assertEqual(effective["teams"][team.name]["grants"][0]["source"], "member")
 
 	def test_permission_probe_evaluates_on_save(self):


### PR DESCRIPTION
Add 13 bench-plane capabilities and their system-role assignments into fixtures so a fresh install reproduces the full 27-capability taxonomy. Mirrors the vocabulary enforced bench-side in admin/backend/auth.py. Adds `bench` to Capability.plane options.