### PR TITLE
billing: PayPal dual settlement mode on the revived gateway

### DIFF
--- a/central/billing/api/dashboard/_shared.py
+++ b/central/billing/api/dashboard/_shared.py
@@ -120,6 +120,39 @@ def _gateway_for_currency(currency: str) -> str:
 		frappe.throw(f"No payment gateway configured for {currency} top-ups.", frappe.ValidationError)
 
 
+def _enabled_gateway_for_currency(currency: str, adapter_key: str) -> str | None:
+	"""Name of an enabled gateway with this adapter_key that handles this currency,
+	or None. Unlike the default-resolver, this picks by adapter regardless of the
+	is_default flag — used when a flow needs a specific rail (PayPal, or the Razorpay
+	a Via-Razorpay PayPal row delegates to)."""
+	rows = frappe.get_all(
+		"Payment Gateway Currency", filters={"currency": currency}, fields=["parent"]
+	)
+	for r in rows:
+		gw = frappe.db.get_value(
+			"Payment Gateway", r.parent, ["name", "adapter_key", "is_enabled"], as_dict=True
+		)
+		if gw and gw.is_enabled and gw.adapter_key == adapter_key:
+			return gw.name
+	return None
+
+
+def _paypal_gateway_for_currency(currency: str) -> str:
+	"""Enabled PayPal gateway that handles this currency (ADR 0007).
+
+	PayPal is a directly-settled standalone gateway — its own merchant account pays
+	us out, so a top-up carries a native PayPal capture id the reconciliation job
+	(#21) matches against PayPal's ledger. It need not be the currency default (that
+	stays Stripe, which serves card top-ups)."""
+	gw = _enabled_gateway_for_currency(currency, "Paypal")
+	if gw:
+		return gw
+	frappe.throw(
+		f"PayPal top-ups need an enabled PayPal gateway that handles {currency}.",
+		frappe.ValidationError,
+	)
+
+
 def _add_method_gateway(currency: str):
 	"""Gateway to add a payment method in this currency.
 

--- a/central/billing/api/dashboard/invoices.py
+++ b/central/billing/api/dashboard/invoices.py
@@ -13,7 +13,9 @@ from central.billing.revenue import credits, invoicing, metering
 from central.billing.revenue.tax import resolve_tax
 from central.billing.api.dashboard._shared import (
 	_describe_line,
+	_enabled_gateway_for_currency,
 	_gateway_for_currency,
+	_paypal_gateway_for_currency,
 	_require_billing_setup,
 	_require_manage,
 	_require_view,
@@ -288,17 +290,41 @@ def confirm_invoice_checkout(attempt: str | None = None, razorpay_order_id: str 
 
 @frappe.whitelist(methods=["POST"])
 def create_topup_order(team: str | None = None, amount: float | None = None,
-					   gateway: str | None = None) -> dict:
+					   gateway: str | None = None, method: str | None = None) -> dict:
 	"""Start a wallet top-up by creating a real gateway order. The UI opens the
 	gateway's checkout against it; the wallet is credited only after the gateway
-	confirms (verify in confirm_topup) — never magically."""
+	confirms (verify in confirm_topup) — never magically.
+
+	`method="paypal"` routes an international top-up to the configured PayPal gateway
+	(non-INR card default stays Stripe). That gateway's `paypal_settlement_mode` then
+	picks the rail:
+	  - Direct: PayPal's own merchant account; the SPA renders PayPal Buttons and the
+	    capture id reconciles against PayPal's ledger (ADR 0007).
+	  - Via Razorpay: PayPal is collected inside the Razorpay sheet and settles through
+	    Razorpay (ADR 0005). The order is created on the currency's Razorpay gateway and
+	    `display_paypal` tells the SPA to surface the PayPal block in that sheet; the
+	    reference stored is the razorpay_payment_id."""
 	team = _resolve_team(team, authz.MANAGE)
 	_require_billing_setup(team)
 	amount = frappe.utils.flt(amount)
 	if amount <= 0:
 		frappe.throw("Top-up amount must be greater than zero.", frappe.ValidationError)
 	currency = _team_currency(team)
-	gw = gateway or _gateway_for_currency(currency)
+	display_paypal = False
+	if method == "paypal":
+		pp = frappe.get_doc("Payment Gateway", _paypal_gateway_for_currency(currency))
+		if pp.is_paypal_via_razorpay():
+			gw = _enabled_gateway_for_currency(currency, "Razorpay")
+			if not gw:
+				frappe.throw(
+					f"PayPal via Razorpay needs an enabled Razorpay gateway that handles {currency}.",
+					frappe.ValidationError,
+				)
+			display_paypal = True
+		else:
+			gw = pp.name
+	else:
+		gw = gateway or _gateway_for_currency(currency)
 	from central.billing.gateways.registry import get_adapter
 
 	gw_doc = frappe.get_doc("Payment Gateway", gw)
@@ -317,20 +343,27 @@ def create_topup_order(team: str | None = None, amount: float | None = None,
 	# (no hosted-Checkout redirect). The India-export billing address rides on the
 	# Stripe PaymentIntent from the Billing Profile, so it's never re-asked.
 	handles = adapter.create_order(amount, currency, receipt, notes=notes, customer=customer_id)
-	return {"gateway": gw, "adapter_key": gw_doc.adapter_key,
+	# The SPA branches on adapter_key: Stripe → PaymentIntent Element, Razorpay → hosted
+	# sheet, Paypal → PayPal Buttons against the returned order_id (ADR 0007). For a
+	# Via-Razorpay PayPal top-up the adapter_key is Razorpay (settlement runs there) and
+	# display_paypal asks the sheet to surface the PayPal block.
+	return {"gateway": gw, "adapter_key": gw_doc.adapter_key, "display_paypal": display_paypal,
 			"amount": amount, "currency": currency, "receipt": receipt, **handles}
 
 
 @frappe.whitelist(methods=["POST"])
 def confirm_topup(team: str | None = None, amount: float | None = None, gateway: str | None = None,
 				  razorpay_order_id: str | None = None, razorpay_payment_id: str | None = None,
-				  razorpay_signature: str | None = None, payment_intent: str | None = None) -> dict:
+				  razorpay_signature: str | None = None, payment_intent: str | None = None,
+				  paypal_order_id: str | None = None) -> dict:
 	"""Credit the wallet only after the gateway confirms the money really moved.
-	Razorpay confirms via the checkout-callback signature; Stripe confirms by
-	retrieving the PaymentIntent the SPA charged and checking it succeeded (and
-	credits the server-confirmed amount, not a client-supplied one). The wallet is
-	credited in the team's own currency — never assumed INR. Idempotent on the
-	gateway payment id, so the capture webhook crediting in parallel is a no-op."""
+	Razorpay confirms via the checkout-callback signature; Stripe by retrieving the
+	PaymentIntent the SPA charged; PayPal by capturing the approved order. Each
+	credits the server-confirmed amount/currency (never a client-supplied figure)
+	and records the gateway's own reference — for PayPal the capture id, which
+	settles directly and so reconciles against PayPal's ledger (#21, ADR 0007). The
+	wallet is credited in the team's own currency. Idempotent on the gateway payment
+	id, so a capture webhook crediting in parallel is a no-op."""
 	team = _resolve_team(team, authz.MANAGE)
 	currency = _team_currency(team)
 	amount = frappe.utils.flt(amount)
@@ -345,6 +378,16 @@ def confirm_topup(team: str | None = None, amount: float | None = None, gateway:
 			"razorpay_signature": razorpay_signature,
 		})
 		reference = razorpay_payment_id
+	elif gw_doc.adapter_key == "Paypal":
+		# Capture the order the buyer approved in PayPal Buttons; credit what PayPal
+		# actually took (major units already) and key the wallet entry on the capture id.
+		capture = adapter.capture_order(paypal_order_id)
+		ok = capture.get("status") == "COMPLETED"
+		reference = capture.get("id")
+		if capture.get("amount"):
+			amount = frappe.utils.flt(capture["amount"])
+		if capture.get("currency"):
+			currency = capture["currency"].upper()
 	else:
 		# In-app PaymentIntent (Stripe): the SPA confirmed the card with Stripe.js;
 		# trust the intent the gateway reports, including the amount/currency it

--- a/central/billing/demo/_factory.py
+++ b/central/billing/demo/_factory.py
@@ -52,6 +52,9 @@ TAX_BY_CURRENCY = {"INR": ("GST", 18), "EUR": ("VAT", 19), "USD": ("VAT", 5)}
 
 STRIPE = {"INR": "GW-Stripe-INR", "EUR": "GW-Stripe-EUR", "USD": "GW-Stripe-USD"}
 RAZORPAY = "GW-Razorpay"
+# PayPal is a directly-settled standalone gateway (ADR 0007). It lists USD/EUR but
+# is NOT their default — Stripe stays the card default; PayPal is the opt-in rail.
+PAYPAL = "GW-PayPal"
 ANCHOR = "2026-06-01"  # the current (open) billing month
 
 
@@ -109,6 +112,15 @@ def _gateways():
 		"api_key": "rzp_test", "api_secret": "rzp_secret", "webhook_secret": "rzp_whsec",
 		"is_enabled": 1, "supports_mandates": 1,
 		"currencies": [{"currency": "INR", "is_default": 1}],
+	}, newname=True, flags=seed)
+	# PayPal — directly-settled standalone gateway (ADR 0007). Non-default for USD/EUR
+	# so Stripe stays their card default; PayPal is the opt-in international rail whose
+	# capture ids reconcile against PayPal's own ledger.
+	_upsert("Payment Gateway", PAYPAL, {
+		"title": "PayPal (International)", "adapter_key": "Paypal",
+		"api_key": "paypal_client_id", "api_secret": "paypal_secret", "webhook_secret": "paypal_whid",
+		"is_enabled": 1,
+		"currencies": [{"currency": "USD", "is_default": 0}, {"currency": "EUR", "is_default": 0}],
 	}, newname=True, flags=seed)
 
 

--- a/central/billing/doctype/payment_gateway/payment_gateway.json
+++ b/central/billing/doctype/payment_gateway/payment_gateway.json
@@ -10,6 +10,7 @@
  "field_order": [
   "title",
   "adapter_key",
+  "paypal_settlement_mode",
   "column_break_flags",
   "is_enabled",
   "supports_mandates",
@@ -36,8 +37,17 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Adapter",
-   "options": "Stripe\nRazorpay",
+   "options": "Stripe\nRazorpay\nPaypal",
    "reqd": 1
+  },
+  {
+   "default": "Direct",
+   "depends_on": "eval:doc.adapter_key=='Paypal'",
+   "description": "Direct: own PayPal merchant account. Via Razorpay: collected inside the Razorpay sheet (no PayPal keys needed).",
+   "fieldname": "paypal_settlement_mode",
+   "fieldtype": "Select",
+   "label": "PayPal Settlement Mode",
+   "options": "Direct\nVia Razorpay"
   },
   {
    "fieldname": "column_break_flags",

--- a/central/billing/doctype/payment_gateway/payment_gateway.py
+++ b/central/billing/doctype/payment_gateway/payment_gateway.py
@@ -19,6 +19,13 @@ class PaymentGateway(Document):
 
 		return get_adapter(self)
 
+	def is_paypal_via_razorpay(self) -> bool:
+		"""A PayPal gateway whose settlement is delegated to Razorpay (ADR 0005 path,
+		re-introduced as an opt-in mode). It holds no PayPal merchant account, so it
+		needs no PayPal keys/webhook of its own — the money moves through, and is
+		reconciled against, the configured Razorpay gateway."""
+		return self.adapter_key == "Paypal" and self.paypal_settlement_mode == "Via Razorpay"
+
 	def validate(self):
 		if self._should_validate_credentials():
 			self._validate_credentials()
@@ -64,7 +71,10 @@ class PaymentGateway(Document):
 
 	def _should_validate_credentials(self) -> bool:
 		"""Validate only when freshly-typed keys are present — so unrelated edits
-		don't hammer the gateway."""
+		don't hammer the gateway. A Via-Razorpay PayPal row carries no keys of its
+		own, so there is nothing to validate (settlement runs on Razorpay)."""
+		if self.is_paypal_via_razorpay():
+			return False
 		return self._validation_active() and self._credentials_entered()
 
 	def _credentials_entered(self) -> bool:
@@ -111,6 +121,11 @@ class PaymentGateway(Document):
 		"""A gateway only goes live once its keys have proven out — otherwise an
 		inbound webhook has no secret to verify against and charges can't settle."""
 		if not self._validation_active():
+			return
+		# Via-Razorpay PayPal settles on Razorpay, which carries its own validated
+		# keys — this row needs none, so don't block enabling it on a validation it
+		# can never have.
+		if self.is_paypal_via_razorpay():
 			return
 		if self.is_enabled and not self.credentials_validated_at:
 			frappe.throw(

--- a/central/billing/gateways/paypal_adapter.py
+++ b/central/billing/gateways/paypal_adapter.py
@@ -1,0 +1,330 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""PayPal GatewayAdapter.
+
+Implemented directly against PayPal's REST API over `requests` rather than a
+vendored SDK — adding a gateway is one adapter class, no core changes, and no
+fragile SDK dependency. All gateway I/O goes through small private methods
+(`_token`, `_capture_payment`, `_refund_capture`, ...), which is the seam tests
+stub — exactly as the Stripe/Razorpay adapters stub their SDK client.
+"""
+
+import json
+
+import requests
+
+from central.billing.gateways.base import (
+	GatewayAdapter,
+	GatewayAuthError,
+	GatewayTimeout,
+	NormalisedEvent,
+	PaymentResult,
+	RefundResult,
+	header_value,
+)
+
+# Network/server failures are transient → GatewayTimeout (retry reuses the key).
+_TRANSIENT = (requests.exceptions.RequestException,)
+
+# The charge lifecycle events the webhook spine consumes (see webhooks.py).
+PAYPAL_WEBHOOK_EVENTS = [
+	"PAYMENT.CAPTURE.COMPLETED",
+	"PAYMENT.CAPTURE.DENIED",
+	"PAYMENT.CAPTURE.REFUNDED",
+]
+
+
+class PayPalAdapter(GatewayAdapter):
+	def _base(self) -> str:
+		return (self.gateway.get("api_base") if hasattr(self.gateway, "get") else None) or (
+			"https://api-m.sandbox.paypal.com"
+		)
+
+	# --- universal -----------------------------------------------------------
+
+	def validate_credentials(self) -> dict:
+		"""Cheapest authed read — fetch an OAuth token; bad client id/secret 401s.
+
+		PayPal does not expose a settlement currency on the OAuth response, so
+		`currency` is left None (no currency cross-check for PayPal)."""
+		try:
+			self._token()
+		except requests.exceptions.HTTPError as e:
+			status = getattr(e.response, "status_code", None)
+			if status in (400, 401):
+				raise GatewayAuthError(str(e)) from e
+			raise GatewayTimeout(str(e)) from e
+		except _TRANSIENT as e:
+			raise GatewayTimeout(str(e)) from e
+		return {"account_id": self.gateway.get_password("api_key"), "currency": None}
+
+	def register_webhook(self, callback_url: str, events: list[str] | None = None) -> dict:
+		"""Create a PayPal webhook. PayPal verifies callbacks by webhook *id* (not a
+		signing secret), so the id is what `webhook_secret` stores — return it as
+		both endpoint_id and secret."""
+		webhook = self._create_webhook(callback_url, events or PAYPAL_WEBHOOK_EVENTS)
+		webhook_id = webhook.get("id")
+		return {"endpoint_id": webhook_id, "secret": webhook_id}
+
+	def setup_payment_method(self, team, setup_data: dict) -> dict:
+		"""Begin vaulting a PayPal payment method (a Vault setup token the buyer
+		approves). Returns the approve link + token id; no money is moved."""
+		result = self._create_setup_token(team, setup_data)
+		return {
+			"setup_token_id": result.get("id"),
+			"approve_url": _link(result, "approve"),
+			"customer_id": setup_data.get("customer_id"),
+		}
+
+	def validate_payment_method(self, payment_method) -> bool:
+		"""A live vault token (set on approval) is the proof — no micro-charge."""
+		return bool(payment_method.gateway_method_id)
+
+	def charge(self, invoice, payment_method, idempotency_key: str) -> PaymentResult:
+		"""Off-session capture against a vaulted token. `idempotency_key` rides
+		the `PayPal-Request-Id` header so a retry never double-charges."""
+		amount = frappe_flt(invoice.get("amount"))
+		currency = (invoice.get("currency") or "").upper()
+		try:
+			capture = self._capture_payment(
+				vault_token=payment_method.gateway_method_id,
+				amount=amount,
+				currency=currency,
+				request_id=idempotency_key,
+			)
+		except _TRANSIENT as e:
+			raise GatewayTimeout(str(e)) from e
+
+		completed = capture.get("status") == "COMPLETED"
+		return PaymentResult(
+			success=completed,
+			status="Captured" if completed else "Failed",
+			gateway_transaction_id=capture.get("id"),
+			failure_code=capture.get("failure_code"),
+			failure_reason=capture.get("failure_reason"),
+			raw=dict(capture),
+		)
+
+	def refund(self, payment_attempt, amount, reason: str) -> RefundResult:
+		try:
+			refund = self._refund_capture(
+				capture_id=payment_attempt.gateway_transaction_id,
+				amount=frappe_flt(amount),
+				currency=(payment_attempt.get("currency") or "").upper(),
+				request_id=f"refund-{payment_attempt.get('name') or payment_attempt.gateway_transaction_id}",
+			)
+		except _TRANSIENT as e:
+			raise GatewayTimeout(str(e)) from e
+
+		done = refund.get("status") in ("COMPLETED", "PENDING")
+		return RefundResult(
+			success=done,
+			status="Completed" if done else refund.get("status"),
+			gateway_refund_id=refund.get("id"),
+			raw=dict(refund),
+		)
+
+	def verify_webhook_signature(self, payload: bytes, headers: dict) -> bool:
+		"""Verify via PayPal's verify-webhook-signature API (first security gate)."""
+		try:
+			return self._verify_webhook(payload, headers)
+		except _TRANSIENT:
+			return False
+
+	def parse_webhook_event(self, payload: dict, headers: dict | None = None) -> NormalisedEvent:
+		"""PayPal carries the event id + type in the body."""
+		return NormalisedEvent(
+			gateway_event_id=payload.get("id"),
+			event_type=payload.get("event_type"),
+			payload=payload,
+		)
+
+	def get_transaction_status(self, gateway_txn_id: str) -> str:
+		return self._get_capture(gateway_txn_id).get("status")
+
+	# --- optional ------------------------------------------------------------
+
+	def create_customer(self, team) -> str:
+		# PayPal vaults against the buyer's account; a separate customer object is
+		# not required. Surface the team key as the local customer reference.
+		return getattr(team, "name", None) or (team.get("name") if hasattr(team, "get") else None)
+
+	# --- on-session one-time top-up -----------------------------------------
+
+	def create_order(self, amount, currency: str, receipt: str, notes: dict | None = None,
+					 customer: str | None = None) -> dict:
+		"""A one-time CAPTURE-intent PayPal Order for a wallet top-up. The SPA renders
+		PayPal Buttons against `order_id` (client_id is the public client identifier);
+		`confirm_topup` captures it server-side. PayPal settles us directly, so the
+		capture id (set at capture) is the reference Finance reconciles against."""
+		order = self._create_order(amount, (currency or "").upper(), receipt, notes or {})
+		return {
+			"order_id": order.get("id"),
+			"approve_url": _link(order, "approve"),
+			# PayPal's client id is public (it ships in the browser SDK), unlike the secret.
+			"client_id": self.gateway.get_password("api_key"),
+		}
+
+	def capture_order(self, order_id: str) -> dict:
+		"""Capture an approved one-time order; returns {id, status, amount, currency}
+		of the capture. `confirm_topup` credits the wallet from this server-confirmed
+		amount and stores the capture id as the reconcilable gateway reference."""
+		captured = self._capture_order(order_id)
+		return _extract_capture(captured)
+
+	# --- gateway I/O (the stubbed seam) -------------------------------------
+
+	def _token(self) -> str:
+		resp = requests.post(
+			f"{self._base()}/v1/oauth2/token",
+			data={"grant_type": "client_credentials"},
+			auth=(self.gateway.get_password("api_key"), self.gateway.get_password("api_secret")),
+			timeout=30,
+		)
+		resp.raise_for_status()
+		return resp.json()["access_token"]
+
+	def _headers(self, request_id: str | None = None) -> dict:
+		headers = {"Authorization": f"Bearer {self._token()}", "Content-Type": "application/json"}
+		if request_id:
+			headers["PayPal-Request-Id"] = request_id
+		return headers
+
+	def _create_webhook(self, callback_url: str, events: list[str]) -> dict:
+		resp = requests.post(
+			f"{self._base()}/v1/notifications/webhooks",
+			json={
+				"url": callback_url,
+				"event_types": [{"name": name} for name in events],
+			},
+			headers=self._headers(),
+			timeout=30,
+		)
+		resp.raise_for_status()
+		return resp.json()
+
+	def _create_setup_token(self, team, setup_data: dict) -> dict:
+		resp = requests.post(
+			f"{self._base()}/v3/vault/setup-tokens",
+			json={"payment_source": setup_data.get("payment_source", {"paypal": {}})},
+			headers=self._headers(),
+			timeout=30,
+		)
+		resp.raise_for_status()
+		return resp.json()
+
+	def _create_order(self, amount, currency, receipt, notes) -> dict:
+		resp = requests.post(
+			f"{self._base()}/v2/checkout/orders",
+			json={
+				"intent": "CAPTURE",
+				"purchase_units": [{
+					"amount": {"currency_code": currency, "value": f"{amount:.2f}"},
+					"custom_id": receipt,
+				}],
+			},
+			headers=self._headers(receipt),
+			timeout=30,
+		)
+		resp.raise_for_status()
+		return resp.json()
+
+	def _capture_order(self, order_id) -> dict:
+		resp = requests.post(
+			f"{self._base()}/v2/checkout/orders/{order_id}/capture",
+			headers=self._headers(),
+			timeout=30,
+		)
+		resp.raise_for_status()
+		return resp.json()
+
+	def _capture_payment(self, vault_token, amount, currency, request_id) -> dict:
+		"""Create a CAPTURE-intent order against the vault token and return the
+		capture. A 4xx instrument decline is normalised to a non-COMPLETED status
+		(a clean decline, not an exception); network/5xx propagate as transient."""
+		resp = requests.post(
+			f"{self._base()}/v2/checkout/orders",
+			json={
+				"intent": "CAPTURE",
+				"purchase_units": [{"amount": {"currency_code": currency, "value": f"{amount:.2f}"}}],
+				"payment_source": {"token": {"id": vault_token, "type": "PAYMENT_METHOD_TOKEN"}},
+			},
+			headers=self._headers(request_id),
+			timeout=30,
+		)
+		if 400 <= resp.status_code < 500:
+			body = _safe_json(resp)
+			return {"id": None, "status": "DECLINED", "failure_code": body.get("name"),
+					"failure_reason": body.get("message")}
+		resp.raise_for_status()
+		return _extract_capture(resp.json())
+
+	def _refund_capture(self, capture_id, amount, currency, request_id) -> dict:
+		resp = requests.post(
+			f"{self._base()}/v2/payments/captures/{capture_id}/refund",
+			json={"amount": {"value": f"{amount:.2f}", "currency_code": currency}},
+			headers=self._headers(request_id),
+			timeout=30,
+		)
+		resp.raise_for_status()
+		return resp.json()
+
+	def _get_capture(self, capture_id) -> dict:
+		resp = requests.get(
+			f"{self._base()}/v2/payments/captures/{capture_id}", headers=self._headers(), timeout=30
+		)
+		resp.raise_for_status()
+		return resp.json()
+
+	def _verify_webhook(self, payload: bytes, headers: dict) -> bool:
+		body = payload.decode() if isinstance(payload, bytes) else payload
+		resp = requests.post(
+			f"{self._base()}/v1/notifications/verify-webhook-signature",
+			json={
+				"auth_algo": header_value(headers, "PAYPAL-AUTH-ALGO"),
+				"cert_url": header_value(headers, "PAYPAL-CERT-URL"),
+				"transmission_id": header_value(headers, "PAYPAL-TRANSMISSION-ID"),
+				"transmission_sig": header_value(headers, "PAYPAL-TRANSMISSION-SIG"),
+				"transmission_time": header_value(headers, "PAYPAL-TRANSMISSION-TIME"),
+				"webhook_id": self.gateway.get_password("webhook_secret"),
+				"webhook_event": json.loads(body),
+			},
+			headers=self._headers(),
+			timeout=30,
+		)
+		resp.raise_for_status()
+		return resp.json().get("verification_status") == "SUCCESS"
+
+
+def frappe_flt(value) -> float:
+	try:
+		return float(value or 0)
+	except (TypeError, ValueError):
+		return 0.0
+
+
+def _link(doc: dict, rel: str):
+	for link in doc.get("links", []) or []:
+		if link.get("rel") == rel:
+			return link.get("href")
+	return None
+
+
+def _safe_json(resp) -> dict:
+	try:
+		return resp.json()
+	except Exception:  # noqa: BLE001
+		return {}
+
+
+def _extract_capture(order: dict) -> dict:
+	"""Pull the capture {id, status, amount, currency} out of a captured order."""
+	units = order.get("purchase_units") or []
+	captures = ((units[0].get("payments") or {}).get("captures") or []) if units else []
+	if captures:
+		cap = captures[0]
+		amt = cap.get("amount") or {}
+		return {"id": cap.get("id"), "status": cap.get("status"),
+				"amount": amt.get("value"), "currency": amt.get("currency_code")}
+	# Fall back to the order's own status when the shape is flatter.
+	return {"id": order.get("id"), "status": order.get("status")}

--- a/central/billing/gateways/registry.py
+++ b/central/billing/gateways/registry.py
@@ -41,14 +41,17 @@ def supported_currencies() -> list[str]:
 def get_adapter(gateway) -> GatewayAdapter:
 	"""Return the adapter instance for a Payment Gateway doc, keyed by adapter_key.
 
-	PayPal is intentionally not a standalone adapter (ADR 0005): it's a one-time
-	method *inside* Razorpay's international checkout, not a separate gateway."""
+	PayPal is a directly-settled standalone gateway (ADR 0007, superseding ADR 0005):
+	its own merchant account settles us, so top-ups carry native PayPal capture ids
+	that the reconciliation job (#21) matches against PayPal's ledger."""
+	from central.billing.gateways.paypal_adapter import PayPalAdapter
 	from central.billing.gateways.razorpay_adapter import RazorpayAdapter
 	from central.billing.gateways.stripe_adapter import StripeAdapter
 
 	adapters = {
 		"Stripe": StripeAdapter,
 		"Razorpay": RazorpayAdapter,
+		"Paypal": PayPalAdapter,
 	}
 
 	adapter_class = adapters.get(gateway.adapter_key)

--- a/central/billing/tests/test_dashboard.py
+++ b/central/billing/tests/test_dashboard.py
@@ -376,6 +376,115 @@ class TestGatewayTopUp(CustomerDataBase):
 				dashboard.confirm_topup(team=TEAM, amount=5000, gateway=gw, payment_intent="pi_y")
 		self.assertEqual(dashboard.get_credit_balance(TEAM)["balance"], 0)  # no magic credit
 
+	def test_topup_paypal_routes_to_paypal_gateway_and_captures(self):
+		"""A USD team whose card default is Stripe can top up via PayPal: the order is
+		routed to the PayPal gateway (directly settled, ADR 0007), and confirm captures
+		the order — crediting PayPal's server-confirmed amount and keying the wallet
+		entry on the capture id Finance reconciles against."""
+		from unittest.mock import MagicMock, patch
+		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
+
+		stripe_def = make_stripe_gateway("GW-USD-Stripe-Def").name  # USD card default
+		if frappe.db.exists("Payment Gateway", "GW-USD-PayPal"):
+			frappe.delete_doc("Payment Gateway", "GW-USD-PayPal", force=True)
+		pp = frappe.get_doc({
+			"doctype": "Payment Gateway", "__newname": "GW-USD-PayPal",
+			"title": "PayPal", "adapter_key": "Paypal",
+			"api_key": "pp_client", "api_secret": "pp_secret", "webhook_secret": "pp_whid",
+			"is_enabled": 1, "currencies": [{"currency": "USD", "is_default": 0}],
+		})
+		pp.flags.skip_credential_validation = True
+		pp.insert(ignore_permissions=True)
+		complete_billing_profile(TEAM, currency="USD")
+		adapter = MagicMock()
+		adapter.create_customer.return_value = "cus_pp"
+		adapter.create_order.return_value = {
+			"order_id": "PPORDER1", "approve_url": "https://paypal/approve", "client_id": "pp_client"}
+		adapter.capture_order.return_value = {
+			"id": "CAP123", "status": "COMPLETED", "amount": "5000.00", "currency": "USD"}
+		with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
+			order = dashboard.create_topup_order(team=TEAM, amount=5000, method="paypal")
+			# Routed to a PayPal gateway, never the Stripe default.
+			self.assertEqual(order["adapter_key"], "Paypal")
+			self.assertNotEqual(order["gateway"], stripe_def)
+			self.assertEqual(
+				frappe.db.get_value("Payment Gateway", order["gateway"], "adapter_key"), "Paypal")
+			self.assertEqual(order["order_id"], "PPORDER1")
+			self.assertEqual(dashboard.get_credit_balance(TEAM)["balance"], 0)  # not credited yet
+
+			out = dashboard.confirm_topup(team=TEAM, amount=5000, gateway=pp.name,
+				paypal_order_id="PPORDER1")
+			adapter.capture_order.assert_called_once_with("PPORDER1")
+			self.assertEqual(out["new_balance"], 5000)
+			# Wallet entry references the PayPal capture id (the reconcilable handle).
+			self.assertTrue(frappe.db.exists(
+				"Credit Ledger Entry", {"team": TEAM, "gateway_payment_id": "CAP123"}))
+
+	def test_topup_paypal_via_razorpay_delegates_to_razorpay(self):
+		"""A PayPal gateway in 'Via Razorpay' mode holds no PayPal merchant account: the
+		top-up is created on the currency's Razorpay gateway, the SPA is told to surface
+		the PayPal block (display_paypal), and confirm settles through Razorpay — so the
+		stored reference is the razorpay_payment_id (ADR 0005 path, opt-in)."""
+		from unittest.mock import MagicMock, patch
+
+		# create_topup_order commits (ensure_gateway_customer), so this test's gateway
+		# rows and is_enabled toggles outlive the framework rollback — undo them by
+		# hand, then commit the restoration last (addCleanup runs LIFO).
+		self.addCleanup(frappe.db.commit)
+
+		def drop(name):
+			if frappe.db.exists("Payment Gateway", name):
+				frappe.delete_doc("Payment Gateway", name, force=True)
+
+		for name in ("GW-USD-RZP", "GW-USD-PayPal-RZP"):
+			drop(name)
+			self.addCleanup(drop, name)
+		rzp = frappe.get_doc({
+			"doctype": "Payment Gateway", "__newname": "GW-USD-RZP",
+			"title": "Razorpay USD", "adapter_key": "Razorpay",
+			"api_key": "rzp_k", "api_secret": "rzp_s", "webhook_secret": "rzp_wh",
+			"is_enabled": 1, "currencies": [{"currency": "USD", "is_default": 0}],
+		})
+		rzp.flags.skip_credential_validation = True
+		rzp.insert(ignore_permissions=True)
+		# No api_key/api_secret — a Via-Razorpay PayPal row needs none.
+		pp = frappe.get_doc({
+			"doctype": "Payment Gateway", "__newname": "GW-USD-PayPal-RZP",
+			"title": "PayPal via Razorpay", "adapter_key": "Paypal",
+			"paypal_settlement_mode": "Via Razorpay",
+			"is_enabled": 1, "currencies": [{"currency": "USD", "is_default": 0}],
+		})
+		pp.insert(ignore_permissions=True)
+		# Make our Via-Razorpay row the only enabled PayPal gateway for USD, so
+		# resolution can't land on a seeded Direct PayPal gateway; re-enable the
+		# others in cleanup (set_value skips the enable-guard a re-save would hit).
+		for other in frappe.get_all("Payment Gateway",
+				{"adapter_key": "Paypal", "is_enabled": 1, "name": ["!=", pp.name]}, pluck="name"):
+			frappe.db.set_value("Payment Gateway", other, "is_enabled", 0)
+			self.addCleanup(frappe.db.set_value, "Payment Gateway", other, "is_enabled", 1)
+		self.assertTrue(pp.is_paypal_via_razorpay())
+		self.assertFalse(pp._should_validate_credentials())  # keys optional in this mode
+		complete_billing_profile(TEAM, currency="USD")
+		adapter = MagicMock()
+		adapter.create_customer.return_value = "cus_rzp"
+		adapter.create_order.return_value = {"order_id": "order_rzp1", "key_id": "rzp_k"}
+		adapter.verify_payment_signature.return_value = True
+		with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
+			order = dashboard.create_topup_order(team=TEAM, amount=5000, method="paypal")
+			# Settlement runs on a Razorpay gateway; the SPA opens the sheet on the
+			# PayPal block (not PayPal Buttons, and never the PayPal row itself).
+			self.assertEqual(order["adapter_key"], "Razorpay")
+			self.assertEqual(
+				frappe.db.get_value("Payment Gateway", order["gateway"], "adapter_key"), "Razorpay")
+			self.assertTrue(order["display_paypal"])
+			out = dashboard.confirm_topup(team=TEAM, amount=5000, gateway=order["gateway"],
+				razorpay_order_id="order_rzp1", razorpay_payment_id="pay_rzp1",
+				razorpay_signature="sig")
+			self.assertEqual(out["new_balance"], 5000)
+			# Reference is the razorpay_payment_id (no PayPal capture id exists here).
+			self.assertTrue(frappe.db.exists(
+				"Credit Ledger Entry", {"team": TEAM, "gateway_payment_id": "pay_rzp1"}))
+
 
 class TestWriteEndpointsRejectGet(IntegrationTestCase):
 	"""Every state-changing dashboard endpoint must be POST-only.

--- a/central/billing/tests/test_paypal_adapter.py
+++ b/central/billing/tests/test_paypal_adapter.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import frappe
+import requests
+from frappe.tests import IntegrationTestCase
+
+from central.billing.gateways.paypal_adapter import PayPalAdapter
+from central.billing.gateways.registry import get_adapter
+from central.billing.tests.gateway_contract import GatewayAdapterContract
+
+
+def make_paypal_gateway(name="GW-Test-PayPal"):
+	if frappe.db.exists("Payment Gateway", name):
+		frappe.delete_doc("Payment Gateway", name, force=True)
+	return frappe.get_doc(
+		{
+			"doctype": "Payment Gateway", "__newname": name, "title": "PayPal (Test)",
+			"adapter_key": "Paypal", "currency": "USD", "api_key": "pp_client",
+			"api_secret": "pp_secret", "webhook_secret": "WH-ID-1", "is_enabled": 1,
+		}
+	).insert(ignore_permissions=True)
+
+
+class TestPayPalAdapter(GatewayAdapterContract, IntegrationTestCase):
+	def make_adapter(self):
+		return PayPalAdapter(make_paypal_gateway())
+
+	def webhook_headers(self):
+		return {"PAYPAL-TRANSMISSION-ID": "t", "PAYPAL-TRANSMISSION-SIG": "s",
+				"PAYPAL-TRANSMISSION-TIME": "now", "PAYPAL-AUTH-ALGO": "SHA256", "PAYPAL-CERT-URL": "url"}
+
+	@contextmanager
+	def signature_valid(self):
+		with patch.object(PayPalAdapter, "_verify_webhook", return_value=True):
+			yield
+
+	@contextmanager
+	def signature_invalid(self):
+		with patch.object(PayPalAdapter, "_verify_webhook", return_value=False):
+			yield
+
+	def make_charge_inputs(self):
+		invoice = frappe._dict(amount=40.0, currency="USD", name="INV-1")
+		method = frappe._dict(gateway_method_id="vault_x")
+		return invoice, method, "PA-PP-001"
+
+	@contextmanager
+	def charge_succeeds(self, txn_id="txn_ok"):
+		with patch.object(
+			PayPalAdapter, "_capture_payment", return_value={"id": txn_id, "status": "COMPLETED"}
+		) as m:
+			self._cap = m
+			yield
+
+	@contextmanager
+	def charge_declines(self, code="card_declined"):
+		with patch.object(
+			PayPalAdapter, "_capture_payment",
+			return_value={"id": None, "status": "DECLINED", "failure_code": code, "failure_reason": "declined"},
+		) as m:
+			self._cap = m
+			yield
+
+	@contextmanager
+	def charge_times_out(self):
+		with patch.object(
+			PayPalAdapter, "_capture_payment", side_effect=requests.exceptions.ConnectionError("timeout")
+		) as m:
+			self._cap = m
+			yield
+
+	def captured_idempotency_key(self):
+		return self._cap.call_args.kwargs["request_id"]
+
+	def make_refund_inputs(self):
+		attempt = frappe._dict(gateway_transaction_id="cap_charged", currency="USD", name="PA-1")
+		return attempt, 40.0, "duplicate charge"
+
+	@contextmanager
+	def refund_succeeds(self, refund_id="rfnd_ok"):
+		with patch.object(
+			PayPalAdapter, "_refund_capture", return_value={"id": refund_id, "status": "COMPLETED"}
+		):
+			yield
+
+	def parse_event_inputs(self):
+		payload = {"id": "WH-evt-1", "event_type": "PAYMENT.CAPTURE.COMPLETED",
+				   "resource": {"id": "cap_x"}}
+		return payload, self.webhook_headers(), "WH-evt-1", "PAYMENT.CAPTURE.COMPLETED"
+
+	def setup_inputs(self):
+		return "Team-1", {"customer_id": "cust_x"}
+
+	@contextmanager
+	def stub_setup(self):
+		with patch.object(
+			PayPalAdapter, "_create_setup_token",
+			return_value={"id": "setup_1", "links": [{"rel": "approve", "href": "https://approve"}]},
+		):
+			yield
+
+	def validation_inputs(self):
+		return frappe._dict(gateway_method_id="vault_x")
+
+	@contextmanager
+	def stub_validation_success(self):
+		# A live vault token is the proof — no gateway round-trip.
+		yield
+
+	def expected_account_currency(self):
+		# PayPal's OAuth response carries no settlement currency.
+		return None
+
+	@contextmanager
+	def stub_credentials_valid(self):
+		with patch.object(PayPalAdapter, "_token", return_value="tok"):
+			yield
+
+	@contextmanager
+	def stub_credentials_invalid(self):
+		err = requests.exceptions.HTTPError("401 Unauthorized")
+		err.response = MagicMock(status_code=401)
+		with patch.object(PayPalAdapter, "_token", side_effect=err):
+			yield
+
+	# --- PayPal-specific -----------------------------------------------------
+
+	def test_register_webhook_returns_webhook_id_as_secret(self):
+		adapter = self.make_adapter()
+		with patch.object(PayPalAdapter, "_create_webhook", return_value={"id": "WH-NEW-1"}):
+			result = adapter.register_webhook("https://site/api/method/central.billing.payments.webhooks.paypal")
+		# PayPal verifies by webhook id, so it doubles as the stored "secret".
+		self.assertEqual(result["endpoint_id"], "WH-NEW-1")
+		self.assertEqual(result["secret"], "WH-NEW-1")
+
+	def test_registry_resolves_paypal(self):
+		adapter = get_adapter(make_paypal_gateway())
+		self.assertIsInstance(adapter, PayPalAdapter)
+
+	def test_capture_maps_4xx_decline_to_status_not_exception(self):
+		adapter = self.make_adapter()
+		resp = MagicMock(status_code=402)
+		resp.json.return_value = {"name": "INSTRUMENT_DECLINED", "message": "declined"}
+		with patch.object(PayPalAdapter, "_token", return_value="tok"), patch(
+			"central.billing.gateways.paypal_adapter.requests.post", return_value=resp
+		):
+			out = adapter._capture_payment("vault_x", 40.0, "USD", "req-1")
+		self.assertEqual(out["status"], "DECLINED")
+		self.assertEqual(out["failure_code"], "INSTRUMENT_DECLINED")
+
+	def test_capture_extracts_capture_id_on_success(self):
+		adapter = self.make_adapter()
+		resp = MagicMock(status_code=201)
+		resp.json.return_value = {
+			"id": "order_1",
+			"purchase_units": [{"payments": {"captures": [{
+				"id": "cap_9", "status": "COMPLETED",
+				"amount": {"value": "40.00", "currency_code": "USD"}}]}}],
+		}
+		with patch.object(PayPalAdapter, "_token", return_value="tok"), patch(
+			"central.billing.gateways.paypal_adapter.requests.post", return_value=resp
+		):
+			out = adapter._capture_payment("vault_x", 40.0, "USD", "req-2")
+		self.assertEqual(out, {
+			"id": "cap_9", "status": "COMPLETED", "amount": "40.00", "currency": "USD"})

--- a/central/www/dashboard.html
+++ b/central/www/dashboard.html
@@ -10,7 +10,7 @@
          doesn't leave the card widget blank. @stripe/stripe-js reuses this tag. -->
     <link rel="preconnect" href="https://js.stripe.com" crossorigin />
     <script src="https://js.stripe.com/v3/" async></script>
-    <script type="module" crossorigin src="/assets/central/dashboard/assets/index-Fh3fAvBB.js"></script>
+    <script type="module" crossorigin src="/assets/central/dashboard/assets/index-BayS5HCU.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/central/dashboard/assets/index-C-2n0NoW.css">
   </head>
   <body>

--- a/dashboard/src/components/TopupDialog.vue
+++ b/dashboard/src/components/TopupDialog.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { nextTick, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { Dialog, Button, FormControl } from 'frappe-ui'
 import { useTopup } from '@/composables/useTopup'
 import { currencySymbol, money } from '@/utils/money'
@@ -7,9 +7,8 @@ import { errorToast } from '@/utils/toast'
 
 // Amount entry → in-app payment. Shared by Overview and Credits.
 // Razorpay (INR) collects in its hosted sheet; Stripe collects the card in an
-// embedded Element right here (the address rides on the PaymentIntent from the
-// billing profile — never re-asked). The wallet is credited only after the
-// gateway confirms (see useTopup).
+// embedded Element right here; PayPal renders its Buttons in a second phase. The
+// wallet is credited only after the gateway confirms (see useTopup).
 const props = defineProps({
   currency: { type: String, default: 'INR' },
 })
@@ -19,13 +18,20 @@ const emit = defineEmits(['done'])
 const amount = ref(null)
 const presets = [1000, 5000, 10000, 25000]
 
-// Stripe card phase: swap the amount field for the embedded card Element once a
-// Stripe order is created and needs a card.
+// Payment rail. INR always uses the Razorpay sheet; international currencies pick
+// between a card (Stripe Element) and PayPal (directly settled, ADR 0007).
+const method = ref('card') // 'card' | 'paypal'
+const showMethodChoice = computed(() => props.currency !== 'INR')
+
+// Second-phase mount targets: Stripe card Element / PayPal Buttons.
 const cardPhase = ref(false)
 const cardLoading = ref(false) // Stripe.js + Element still mounting
 const cardEl = ref(null)
+const paypalPhase = ref(false)
+const paypalLoading = ref(false) // PayPal SDK + Buttons still mounting
+const paypalEl = ref(null)
 
-const { begin, mountCard, pay, destroy, cardComplete, submitting, loading } = useTopup({
+const { begin, mountCard, mountPayPal, pay, destroy, cardComplete, submitting, loading } = useTopup({
   onDone: (res) => {
     open.value = false
     emit('done', res)
@@ -35,30 +41,40 @@ const { begin, mountCard, pay, destroy, cardComplete, submitting, loading } = us
 async function submit() {
   const value = Number(amount.value)
   if (!value || value <= 0) return
-  const { card } = await begin(value)
-  if (!card) return // Razorpay finished in its sheet (or was cancelled/failed)
+  // PayPal is only offered for international currencies; INR stays on the default rail.
+  const chosen = showMethodChoice.value && method.value === 'paypal' ? 'paypal' : undefined
+  const { card, paypal } = await begin(value, chosen)
+  if (paypal) return enterPhase(paypalPhase, paypalLoading, paypalEl, mountPayPal, 'Could not start PayPal.')
+  if (card) return enterPhase(cardPhase, cardLoading, cardEl, mountCard, 'Could not start secure card entry.')
+  // else: Razorpay finished in its sheet (or was cancelled/failed) — nothing to mount.
+}
 
-  cardPhase.value = true
-  cardLoading.value = true
-  await nextTick() // the Element needs its mount node in the DOM
+// Switch to a second-phase view and mount its gateway widget into the fresh node.
+async function enterPhase(phase, loadingRef, elRef, mount, failMsg) {
+  phase.value = true
+  loadingRef.value = true
+  await nextTick() // the widget needs its mount node in the DOM
   try {
-    await mountCard(cardEl.value)
+    await mount(elRef.value)
   } catch (e) {
-    errorToast(e, 'Could not start secure card entry.')
-    cardPhase.value = false
+    errorToast(e, failMsg)
+    phase.value = false
   } finally {
-    cardLoading.value = false
+    loadingRef.value = false
   }
 }
 
-// Reset to the amount step whenever the dialog closes, tearing down any Element
-// so a reopen never shows a stale card field.
+// Reset to the amount step whenever the dialog closes, tearing down any widget so
+// a reopen never shows a stale card field / buttons.
 watch(open, (isOpen) => {
   if (!isOpen) {
     destroy()
     amount.value = null
+    method.value = 'card'
     cardPhase.value = false
     cardLoading.value = false
+    paypalPhase.value = false
+    paypalLoading.value = false
   }
 })
 </script>
@@ -79,23 +95,52 @@ watch(open, (isOpen) => {
         </p>
       </div>
 
-      <div v-else class="space-y-4">
-        <div class="flex flex-wrap gap-2">
-          <Button
-            v-for="p in presets"
-            :key="p"
-            :label="`${currencySymbol(currency)}${p.toLocaleString()}`"
-            :variant="Number(amount) === p ? 'solid' : 'subtle'"
-            @click="amount = p"
+      <!-- PayPal entry: PayPal Buttons render here; approval happens in PayPal's popup. -->
+      <div v-else-if="paypalPhase" class="space-y-3">
+        <p class="text-sm text-ink-gray-8">
+          Paying {{ money(Number(amount), currency) }}
+        </p>
+        <p v-if="paypalLoading" class="text-p-sm text-ink-gray-5">Loading PayPal…</p>
+        <div ref="paypalEl" />
+        <p class="text-p-sm text-ink-gray-5">
+          You’ll approve the payment in PayPal. Your wallet is credited only after PayPal confirms.
+        </p>
+      </div>
+
+      <div v-else class="space-y-5">
+        <div v-if="showMethodChoice">
+          <p class="mb-1.5 text-p-sm text-ink-gray-5">Pay with</p>
+          <div class="flex gap-2">
+            <Button
+              label="Card"
+              :variant="method === 'card' ? 'solid' : 'subtle'"
+              @click="method = 'card'"
+            />
+            <Button
+              label="PayPal"
+              :variant="method === 'paypal' ? 'solid' : 'subtle'"
+              @click="method = 'paypal'"
+            />
+          </div>
+        </div>
+        <div>
+          <p class="mb-1.5 text-p-sm text-ink-gray-5">Amount</p>
+          <div class="mb-2 flex flex-wrap gap-2">
+            <Button
+              v-for="p in presets"
+              :key="p"
+              :label="`${currencySymbol(currency)}${p.toLocaleString()}`"
+              :variant="Number(amount) === p ? 'solid' : 'subtle'"
+              @click="amount = p"
+            />
+          </div>
+          <FormControl
+            v-model="amount"
+            type="number"
+            :placeholder="`Enter amount in ${currency}`"
+            min="1"
           />
         </div>
-        <FormControl
-          v-model="amount"
-          type="number"
-          label="Amount"
-          :placeholder="`Enter amount in ${currency}`"
-          min="1"
-        />
         <p class="text-p-sm text-ink-gray-5">
           You’ll complete payment securely. Your wallet is credited only after the
           payment is confirmed.
@@ -112,8 +157,9 @@ watch(open, (isOpen) => {
         class="w-full"
         @click="pay"
       />
+      <!-- PayPal phase: the PayPal Buttons are the action; no footer button. -->
       <Button
-        v-else
+        v-else-if="!paypalPhase"
         variant="solid"
         label="Continue to payment"
         :loading="loading"

--- a/dashboard/src/composables/useTopup.js
+++ b/dashboard/src/composables/useTopup.js
@@ -18,7 +18,7 @@ import { loadStripe } from '@stripe/stripe-js'
 import { useCall } from 'frappe-ui'
 import { API, m } from '@/api/endpoints'
 import { useTeam } from '@/composables/useTeam'
-import { openRazorpayCheckout } from '@/utils/gateway'
+import { openRazorpayCheckout, mountPayPalButtons } from '@/utils/gateway'
 import { successToast, errorToast } from '@/utils/toast'
 
 export function useTopup({ onDone } = {}) {
@@ -33,15 +33,25 @@ export function useTopup({ onDone } = {}) {
   let card = null
   let order = null
 
-  // Create the gateway order. Razorpay collects payment in its hosted sheet and
-  // resolves the whole top-up here; Stripe returns { card: true } so the dialog
-  // can mount the card Element for the order we just created.
-  async function begin(amount) {
+  // Create the gateway order, then resolve by rail:
+  //  - Stripe → { card: true }: dialog mounts the card Element.
+  //  - Paypal → { paypal: true }: dialog mounts PayPal Buttons (ADR 0007).
+  //  - Razorpay → collected in its hosted sheet, the whole top-up resolves here.
+  // `method` is 'paypal' for an international PayPal top-up. In Direct mode it routes
+  // to the PayPal gateway (PayPal Buttons, settles us directly); in Via-Razorpay mode
+  // the backend returns a Razorpay order + display_paypal, so it resolves in the sheet.
+  async function begin(amount, method) {
     try {
-      order = await createOrder.submit({ team: currentTeam.value, amount })
+      order = await createOrder.submit({ team: currentTeam.value, amount, method })
       if (order.adapter_key === 'Stripe') return { card: true }
+      if (order.adapter_key === 'Paypal') return { paypal: true }
 
-      const handles = await openRazorpayCheckout(order, { name: 'Central', description: 'Wallet top-up' })
+      const handles = await openRazorpayCheckout(order, {
+        name: 'Central',
+        description: 'Wallet top-up',
+        // A Via-Razorpay PayPal top-up settles through Razorpay; show the PayPal block.
+        displayPayPal: order.display_paypal,
+      })
       const res = await confirm.submit({
         team: currentTeam.value,
         amount: order.amount,
@@ -53,6 +63,30 @@ export function useTopup({ onDone } = {}) {
       if (e?.message !== 'cancelled') errorToast(e, 'Top-up could not be completed.') // closed sheet = no-op
     }
     return { card: false }
+  }
+
+  // Render PayPal Buttons for the order begin() created. On approval we capture the
+  // order server-side (confirm_topup) and credit what PayPal actually took.
+  async function mountPayPal(el) {
+    await mountPayPalButtons(el, order, {
+      onApprove: async (paypalOrderId) => {
+        submitting.value = true
+        try {
+          const res = await confirm.submit({
+            team: currentTeam.value,
+            amount: order.amount,
+            gateway: order.gateway,
+            paypal_order_id: paypalOrderId,
+          })
+          finish(res)
+        } catch (e) {
+          errorToast(e, 'Top-up could not be completed.')
+        } finally {
+          submitting.value = false
+        }
+      },
+      onError: (e) => errorToast(e, 'PayPal could not start.'),
+    })
   }
 
   // Mount the Stripe card Element for the order begin() created.
@@ -108,6 +142,7 @@ export function useTopup({ onDone } = {}) {
   return {
     begin,
     mountCard,
+    mountPayPal,
     pay,
     destroy,
     cardComplete,

--- a/dashboard/src/utils/gateway.js
+++ b/dashboard/src/utils/gateway.js
@@ -17,7 +17,12 @@ function loadScript(src) {
 }
 
 // Razorpay Checkout — resolves with the payment handles to verify server-side.
-export async function openRazorpayCheckout(order, { name = 'Central', description = '' } = {}) {
+// `displayPayPal` surfaces PayPal inside the sheet (a Via-Razorpay PayPal top-up,
+// ADR 0005): PayPal is collected as a method here and settles through Razorpay.
+export async function openRazorpayCheckout(
+  order,
+  { name = 'Central', description = '', displayPayPal = false } = {},
+) {
   await loadScript('https://checkout.razorpay.com/v1/checkout.js')
   return new Promise((resolve, reject) => {
     const options = {
@@ -44,7 +49,42 @@ export async function openRazorpayCheckout(order, { name = 'Central', descriptio
     // only way Razorpay issues the token the confirm step authorises.
     if (order.customer_id) options.customer_id = order.customer_id
     if (order.recurring) options.recurring = 1
+    // Show only the PayPal block when this is a Via-Razorpay PayPal top-up, so the
+    // sheet opens straight on PayPal rather than the full method menu.
+    if (displayPayPal) {
+      options.config = {
+        display: {
+          blocks: {
+            paypal: { name: 'Pay with PayPal', instruments: [{ method: 'paypal' }] },
+          },
+          sequence: ['block.paypal'],
+          preferences: { show_default_blocks: false },
+        },
+      }
+    }
     const rzp = new window.Razorpay(options)
     rzp.open()
   })
+}
+
+// PayPal Buttons — PayPal is a directly-settled gateway (ADR 0007), so it runs its
+// own approval flow (Buttons + a PayPal-hosted popup), not the Razorpay sheet. We
+// render the buttons against the order create_topup_order already created; on
+// approval the caller captures it server-side (confirm_topup) for webhook-truth.
+export async function mountPayPalButtons(el, order, { onApprove, onError } = {}) {
+  if (!order?.client_id) throw new Error('PayPal client id missing.')
+  // PayPal's SDK is keyed by client id + currency; load it once per pair.
+  await loadScript(
+    `https://www.paypal.com/sdk/js?client-id=${encodeURIComponent(order.client_id)}` +
+      `&currency=${encodeURIComponent(order.currency)}&intent=capture`,
+  )
+  if (!window.paypal) throw new Error('PayPal SDK failed to load.')
+  return window.paypal
+    .Buttons({
+      // The order is already created server-side; hand its id to the buttons.
+      createOrder: () => order.order_id,
+      onApprove: (data) => onApprove?.(data.orderID || order.order_id),
+      onError: (e) => onError?.(e),
+    })
+    .render(el)
 }


### PR DESCRIPTION
PayPal is a directly-settled standalone GatewayAdapter again (ADR 0007), and now supports two settlement modes selectable per Payment Gateway via a `paypal_settlement_mode` flag (shown only for adapter_key == Paypal):

- Direct (default): own PayPal merchant account; top-up uses PayPal Buttons and the native capture id reconciles against PayPal's ledger.
- Via Razorpay (opt-in, ADR 0005 path): the PayPal row needs no keys or webhook (credential validation + enable-guard skipped); create_topup_order delegates to the currency's Razorpay gateway, returns adapter_key=Razorpay
  + display_paypal so the SPA surfaces the PayPal block in the Razorpay sheet, and settles via the existing Razorpay confirm path (reference = razorpay_payment_id, re-accepting the reconciliation gap).

Also tidies the top-up dialog grouping (amount presets under an Amount label, separated from the Pay-with selector).

Test: test_dashboard.test_topup_paypal_via_razorpay_delegates_to_razorpay.