### PR TITLE
feat(atlas): Atlas Instance registry + authenticated AtlasClient (#44)

### DIFF
--- a/central/atlas_client.py
+++ b/central/atlas_client.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import frappe
+import requests
+
+# Edge B: Central → regional Atlas. Authenticated with the per-region API
+# key/secret stored on the `Atlas Instance` record (frappe token auth). The
+# inventory sync (#27) and the billing push both call Atlas through this client.
+
+REQUEST_TIMEOUT = 30
+
+
+class AtlasError(frappe.ValidationError):
+	pass
+
+
+def get_atlas_instance(region: str):
+	"""Resolve a region (= cluster) to its `Atlas Instance`, or raise."""
+	name = frappe.db.get_value("Atlas Instance", {"region": region})
+	if not name:
+		frappe.throw(f"No Atlas registered for region '{region}'.", AtlasError)
+	return frappe.get_doc("Atlas Instance", name)
+
+
+class AtlasClient:
+	"""Thin authenticated HTTP client for one regional Atlas."""
+
+	def __init__(self, instance):
+		self.instance = instance
+
+	@classmethod
+	def for_region(cls, region: str) -> "AtlasClient":
+		return cls(get_atlas_instance(region))
+
+	def _headers(self) -> dict:
+		secret = self.instance.get_password("api_secret")
+		return {"Authorization": f"token {self.instance.api_key}:{secret}"}
+
+	def _url(self, path: str) -> str:
+		return f"{self.instance.base_url.rstrip('/')}/{path.lstrip('/')}"
+
+	def request(self, method: str, path: str, **kwargs) -> dict:
+		if self.instance.status == "Disabled":
+			frappe.throw(f"Atlas '{self.instance.region}' is disabled.", AtlasError)
+		resp = requests.request(
+			method, self._url(path), headers=self._headers(), timeout=REQUEST_TIMEOUT, **kwargs
+		)
+		resp.raise_for_status()
+		return resp.json()
+
+	def ping(self) -> dict:
+		"""Cheap reachability + auth check against the frappe ping endpoint."""
+		return self.request("GET", "/api/method/ping")

--- a/central/central/doctype/atlas_instance/atlas_instance.json
+++ b/central/central/doctype/atlas_instance/atlas_instance.json
@@ -1,0 +1,110 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "field:region",
+ "creation": "2026-06-16 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "region",
+  "base_url",
+  "status",
+  "column_break_auth",
+  "api_key",
+  "api_secret",
+  "section_break_health",
+  "reachable",
+  "last_synced_at"
+ ],
+ "fields": [
+  {
+   "description": "The cluster the user sees. One Atlas = one region.",
+   "fieldname": "region",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Region",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "description": "Base URL of the regional Atlas, e.g. https://blr.atlas.example.com",
+   "fieldname": "base_url",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Base URL",
+   "options": "URL",
+   "reqd": 1
+  },
+  {
+   "default": "Active",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Active\nDraining\nDisabled",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_auth",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "frappe API key of the Central service user on the Atlas site.",
+   "fieldname": "api_key",
+   "fieldtype": "Data",
+   "label": "API Key",
+   "reqd": 1
+  },
+  {
+   "description": "frappe API secret (stored encrypted). Sent as `token key:secret`.",
+   "fieldname": "api_secret",
+   "fieldtype": "Password",
+   "label": "API Secret",
+   "reqd": 1
+  },
+  {
+   "fieldname": "section_break_health",
+   "fieldtype": "Section Break",
+   "label": "Health"
+  },
+  {
+   "default": "0",
+   "fieldname": "reachable",
+   "fieldtype": "Check",
+   "label": "Reachable",
+   "read_only": 1
+  },
+  {
+   "fieldname": "last_synced_at",
+   "fieldtype": "Datetime",
+   "label": "Last Synced At",
+   "read_only": 1
+  }
+ ],
+ "links": [],
+ "modified": "2026-06-16 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Central",
+ "name": "Atlas Instance",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "region",
+ "sort_order": "ASC",
+ "states": [],
+ "title_field": "region"
+}

--- a/central/central/doctype/atlas_instance/atlas_instance.py
+++ b/central/central/doctype/atlas_instance/atlas_instance.py
@@ -25,6 +25,8 @@ class AtlasInstance(Document):
 	@frappe.whitelist()
 	def test_connection(self) -> dict:
 		"""Operator action: ping the Atlas API and record reachability."""
+		if "System Manager" not in frappe.get_roles():
+			frappe.throw("Not permitted.", frappe.PermissionError)
 		from central.atlas_client import AtlasClient
 
 		try:

--- a/central/central/doctype/atlas_instance/atlas_instance.py
+++ b/central/central/doctype/atlas_instance/atlas_instance.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import frappe
+from frappe.model.document import Document
+
+
+class AtlasInstance(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		api_key: DF.Data
+		api_secret: DF.Password
+		base_url: DF.Data
+		last_synced_at: DF.Datetime | None
+		reachable: DF.Check
+		region: DF.Data
+		status: DF.Literal["Active", "Draining", "Disabled"]
+	# end: auto-generated types
+
+	@frappe.whitelist()
+	def test_connection(self) -> dict:
+		"""Operator action: ping the Atlas API and record reachability."""
+		from central.atlas_client import AtlasClient
+
+		try:
+			AtlasClient(self).ping()
+		except Exception as exc:
+			self.db_set("reachable", 0)
+			return {"reachable": False, "error": str(exc)}
+		self.db_set("reachable", 1)
+		return {"reachable": True}

--- a/central/tests/test_atlas_instance.py
+++ b/central/tests/test_atlas_instance.py
@@ -1,0 +1,53 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from central.atlas_client import AtlasClient, AtlasError, get_atlas_instance
+
+
+class TestAtlasInstance(IntegrationTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def make_instance(self, region: str, status: str = "Active"):
+		if frappe.db.exists("Atlas Instance", region):
+			frappe.delete_doc("Atlas Instance", region, force=True)
+		return frappe.get_doc(
+			{
+				"doctype": "Atlas Instance",
+				"region": region,
+				"base_url": "https://atlas.example.test",
+				"status": status,
+				"api_key": "key123",
+				"api_secret": "secret456",
+			}
+		).insert()
+
+	def test_secret_is_stored_encrypted(self):
+		inst = self.make_instance("blr-secret")
+		# Plaintext is retrievable via get_password, but never stored in the column.
+		self.assertEqual(inst.get_password("api_secret"), "secret456")
+		raw = frappe.db.get_value("Atlas Instance", inst.name, "api_secret")
+		self.assertNotEqual(raw, "secret456")
+
+	def test_region_resolver(self):
+		inst = self.make_instance("blr-resolve")
+		self.assertEqual(get_atlas_instance("blr-resolve").name, inst.name)
+		with self.assertRaises(AtlasError):
+			get_atlas_instance("no-such-region")
+
+	def test_request_sends_token_auth_and_disabled_is_blocked(self):
+		inst = self.make_instance("blr-auth")
+		with patch("central.atlas_client.requests.request") as req:
+			req.return_value.json.return_value = {"message": "pong"}
+			req.return_value.raise_for_status.return_value = None
+			AtlasClient(inst).ping()
+			_, kwargs = req.call_args
+			self.assertEqual(kwargs["headers"]["Authorization"], "token key123:secret456")
+			self.assertEqual(req.call_args[0][1], "https://atlas.example.test/api/method/ping")
+
+		inst.status = "Disabled"
+		inst.save()
+		with self.assertRaises(AtlasError):
+			AtlasClient(inst).ping()


### PR DESCRIPTION
The **Edge-B trust anchor** — how Central authenticates to each regional Atlas to mirror clusters/VMs (the data half of the user journey). Independent of the Edge-A token handoff (#21, merged).

### What's here
- **`Atlas Instance` DocType** — one record per region (= one cluster = one Atlas): `base_url`, `status` (Active/Draining/Disabled), `api_key`, **encrypted** `api_secret` (Password field), `reachable` + `last_synced_at` health. System Manager only.
- **`central/atlas_client.py`** — `AtlasClient` token-auth transport (`Authorization: token key:secret`), `get_atlas_instance(region)` resolver, `ping()`/`test_connection()`; refuses calls to a `Disabled` instance.

### Verification
`central.tests.test_atlas_instance` (3) — secret stored encrypted (not in the column), region resolver (hit + miss), token-auth header + URL + disabled-blocked. All green locally.

### Deferred (follow-ups, noted in the issue)
- Consolidate the billing `agent_*` `site_config` into this record (touches working billing sync — separate PR).
- Inventory endpoints + the team-scoped mirror — that's #27.

### Acceptance criteria status (#44)
- [x] Per-Atlas credentials (one record per region)
- [x] Secret stored as encrypted Password field
- [x] Disabled status gates outbound calls
- [ ] Rotation/revocation tooling — basic (edit secret / set Disabled); richer flow later
- [ ] `agent_*` migration — deferred follow-up

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)