### PR TITLE
feat(asset): Asset (VM) model + Atlas inventory contract (#20)

### DIFF
--- a/central/atlas_client.py
+++ b/central/atlas_client.py
@@ -9,9 +9,22 @@ import requests
 
 REQUEST_TIMEOUT = 30
 
+# Frozen inventory contract Atlas fulfils (#36) and Central mirrors into Asset rows
+# (#20/#27). One dict per VM:
+INVENTORY_VM_FIELDS = ("resource_id", "status", "gateway_url")
+
 
 class AtlasError(frappe.ValidationError):
 	pass
+
+
+def stub_vm_inventory(team: str) -> list[dict]:
+	"""Canned inventory in INVENTORY_VM_FIELDS shape — used by the dev sync until
+	Atlas ships the real endpoint (#36). Keeps Central buildable against a fake."""
+	return [
+		{"resource_id": "vm-blr-1", "status": "Running", "gateway_url": "http://localhost:3030"},
+		{"resource_id": "vm-blr-2", "status": "Stopped", "gateway_url": ""},
+	]
 
 
 def get_atlas_instance(region: str):
@@ -51,3 +64,13 @@ class AtlasClient:
 	def ping(self) -> dict:
 		"""Cheap reachability + auth check against the frappe ping endpoint."""
 		return self.request("GET", "/api/method/ping")
+
+	def list_vms(self, team: str) -> list[dict]:
+		"""Inventory of a team's VMs in this cluster — the registry mirror source.
+
+		Atlas (#36) returns one dict per VM in INVENTORY_VM_FIELDS: `resource_id`,
+		`status` (Provisioning/Running/Stopped/Terminated), `gateway_url` (set only
+		when Running). The cluster/region is implied by this Atlas Instance, and
+		`team` scopes the result server-side.
+		"""
+		return self.request("GET", "/api/method/atlas.api.list_team_vms", params={"team": team})

--- a/central/central/doctype/asset/asset.json
+++ b/central/central/doctype/asset/asset.json
@@ -1,0 +1,93 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "field:resource_id",
+ "creation": "2026-06-16 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "resource_id",
+  "team",
+  "cluster",
+  "status",
+  "gateway_url",
+  "last_synced_at"
+ ],
+ "fields": [
+  {
+   "description": "The VM identifier in Atlas (the source of truth).",
+   "fieldname": "resource_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Resource ID",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "description": "Owning Central team (mirrored from Atlas).",
+   "fieldname": "team",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Team",
+   "options": "Team",
+   "reqd": 1
+  },
+  {
+   "description": "The cluster (Atlas Instance / region) this VM lives in.",
+   "fieldname": "cluster",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Cluster",
+   "options": "Atlas Instance",
+   "reqd": 1
+  },
+  {
+   "default": "Provisioning",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Provisioning\nRunning\nStopped\nTerminated"
+  },
+  {
+   "description": "The bench gateway Central deep-links into (VM leaf). Empty unless Running.",
+   "fieldname": "gateway_url",
+   "fieldtype": "Data",
+   "label": "Gateway URL",
+   "options": "URL"
+  },
+  {
+   "fieldname": "last_synced_at",
+   "fieldtype": "Datetime",
+   "label": "Last Synced At",
+   "read_only": 1
+  }
+ ],
+ "links": [],
+ "modified": "2026-06-16 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Central",
+ "name": "Asset",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "resource_id",
+ "sort_order": "ASC",
+ "title_field": "resource_id"
+}

--- a/central/central/doctype/asset/asset.py
+++ b/central/central/doctype/asset/asset.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from frappe.model.document import Document
+
+
+class Asset(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		cluster: DF.Link
+		gateway_url: DF.Data | None
+		last_synced_at: DF.Datetime | None
+		resource_id: DF.Data
+		status: DF.Literal["Provisioning", "Running", "Stopped", "Terminated"]
+		team: DF.Link
+	# end: auto-generated types
+
+	pass

--- a/central/tests/test_asset.py
+++ b/central/tests/test_asset.py
@@ -1,0 +1,64 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from central.atlas_client import INVENTORY_VM_FIELDS, AtlasClient, stub_vm_inventory
+from central.tests.test_iam import ensure_user
+
+
+class TestAsset(IntegrationTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.owner = ensure_user("asset.owner@example.test")
+		self.team = frappe.get_doc(
+			{
+				"doctype": "Team",
+				"team_name": "Asset Team",
+				"owner_user": self.owner,
+				"members": [{"user": self.owner, "role": "Owner", "status": "Active"}],
+			}
+		).insert()
+		self.cluster = "blr-asset"
+		if not frappe.db.exists("Atlas Instance", self.cluster):
+			frappe.get_doc(
+				{
+					"doctype": "Atlas Instance",
+					"region": self.cluster,
+					"base_url": "https://atlas.example.test",
+					"status": "Active",
+					"api_key": "k",
+					"api_secret": "s",
+				}
+			).insert()
+
+	def test_asset_named_by_resource_id_and_links(self):
+		asset = frappe.get_doc(
+			{
+				"doctype": "Asset",
+				"resource_id": "vm-xyz",
+				"team": self.team.name,
+				"cluster": self.cluster,
+				"status": "Running",
+				"gateway_url": "http://localhost:3030",
+			}
+		).insert()
+		self.assertEqual(asset.name, "vm-xyz")
+		self.assertEqual(asset.team, self.team.name)
+		self.assertEqual(asset.cluster, self.cluster)
+
+	def test_inventory_stub_matches_contract_shape(self):
+		vms = stub_vm_inventory(self.team.name)
+		self.assertTrue(vms)
+		for vm in vms:
+			self.assertEqual(set(vm.keys()), set(INVENTORY_VM_FIELDS))
+
+	def test_list_vms_calls_team_scoped_endpoint(self):
+		inst = frappe.get_doc("Atlas Instance", self.cluster)
+		with patch("central.atlas_client.requests.request") as req:
+			req.return_value.json.return_value = []
+			req.return_value.raise_for_status.return_value = None
+			AtlasClient(inst).list_vms(self.team.name)
+			_, kwargs = req.call_args
+			self.assertEqual(kwargs["params"], {"team": self.team.name})
+			self.assertTrue(req.call_args[0][1].endswith("/api/method/atlas.api.list_team_vms"))


### PR DESCRIPTION
The data-model + inventory contract for the registry. A **cluster = one Atlas Instance** (#44); the **VMs are the `Asset`s**.

### What's here
- **`Asset` DocType** — one row per VM: `resource_id` (name), `team` (owner → Team), `cluster` (→ Atlas Instance), `status` (Provisioning/Running/Stopped/Terminated), `gateway_url` (the bench deep-link, set only when Running), `last_synced_at`. System-Manager-only perms for now.
- **Inventory contract** on `AtlasClient`: `list_vms(team)` hitting Atlas's team-scoped endpoint, the frozen `INVENTORY_VM_FIELDS` (`resource_id`, `status`, `gateway_url`), and `stub_vm_inventory` so Central is buildable before Atlas ships #36.

### Verification
`central.tests.test_asset` (3) — named by `resource_id` + links resolve, stub matches the contract shape, `list_vms` calls the team-scoped endpoint. Green locally. frappe-dev patterns followed (naming `field:resource_id`, `By fieldname`, no manual audit fields).

### Scope / next
- **Team-scoped read permissions** (`permission_query_conditions` + `cluster:view`/`vm:view`) → #26.
- **The real authenticated mirror sync** writing Asset rows → #27 (wires `list_vms`/`stub_vm_inventory`).

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)