### PR TITLE
feat(atlas): authenticated Atlas->Asset mirror sync + registry endpoint (#27)

### DIFF
--- a/central/atlas.py
+++ b/central/atlas.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import frappe
+
+from central.atlas_client import AtlasClient, stub_vm_inventory
+from central.iam import can, get_user_team_names, user_has_operator_bypass
+
+# Edge B → registry mirror. `registry` is the dashboard's entry point: it pulls a
+# team's VMs from every Active Atlas (cluster), mirrors them into Asset rows, and
+# returns them. Source of truth stays in Atlas; Central holds a read model.
+
+
+def _inventory(instance, team: str) -> list[dict]:
+	"""Team's VMs in one cluster. Real Atlas call, or the dev stub when the
+	`atlas_use_stub_inventory` flag is set — never fabricated data in prod."""
+	if frappe.conf.get("atlas_use_stub_inventory"):
+		return stub_vm_inventory(team)
+	return AtlasClient(instance).list_vms(team)
+
+
+def _upsert_asset(team: str, cluster: str, vm: dict, now) -> None:
+	rid = vm["resource_id"]
+	doc = frappe.get_doc("Asset", rid) if frappe.db.exists("Asset", rid) else frappe.new_doc("Asset")
+	doc.resource_id = rid
+	doc.team = team
+	doc.cluster = cluster
+	doc.status = vm.get("status") or "Provisioning"
+	doc.gateway_url = vm.get("gateway_url") or None
+	doc.last_synced_at = now
+	doc.save(ignore_permissions=True)
+
+
+def sync_team_assets(team: str) -> dict:
+	"""Mirror a team's VMs from every Active Atlas into Asset rows. Fail-soft: a
+	cluster that errors is reported in `stale`, leaving its last-known mirror intact."""
+	now = frappe.utils.now_datetime()
+	synced, stale = [], []
+	for region in frappe.get_all("Atlas Instance", filters={"status": "Active"}, pluck="name"):
+		instance = frappe.get_doc("Atlas Instance", region)
+		try:
+			vms = _inventory(instance, team)
+		except Exception:
+			frappe.log_error(title=f"Atlas inventory sync failed: {region}")
+			stale.append(region)
+			continue
+		for vm in vms:
+			_upsert_asset(team, region, vm, now)
+		synced.append(region)
+	return {"synced": synced, "stale": stale}
+
+
+def _resolve_team(user: str, team: str | None) -> str:
+	if team:
+		return team
+	teams = get_user_team_names(user)
+	if len(teams) != 1:
+		frappe.throw("Specify a team.", frappe.ValidationError)
+	return teams[0]
+
+
+@frappe.whitelist(methods=["GET"])
+def registry(team: str | None = None) -> dict:
+	"""The team's asset registry (clusters → VMs), refreshed on demand from Atlas.
+
+	Gated on `cluster:view`. Returns the mirrored assets plus which clusters were
+	freshly synced vs. served stale (Atlas unreachable)."""
+	user = frappe.session.user
+	team = _resolve_team(user, team)
+	if not can(user, team, "cluster:view"):
+		frappe.throw("You can't view this team's clusters.", frappe.PermissionError)
+	freshness = sync_team_assets(team)
+	assets = frappe.get_all(
+		"Asset",
+		filters={"team": team},
+		fields=["resource_id", "cluster", "status", "gateway_url", "last_synced_at"],
+		order_by="cluster asc, resource_id asc",
+	)
+	return {"team": team, "assets": assets, **freshness}

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -1,0 +1,69 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from central.atlas import registry, sync_team_assets
+from central.tests.test_iam import ensure_user
+
+
+class TestAtlasSync(IntegrationTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self._orig_stub = frappe.conf.get("atlas_use_stub_inventory")
+		frappe.conf.atlas_use_stub_inventory = 1
+		self.owner = ensure_user("sync.owner@example.test")
+		self.outsider = ensure_user("sync.outsider@example.test")
+		self.team = frappe.get_doc(
+			{
+				"doctype": "Team",
+				"team_name": "Sync Team",
+				"owner_user": self.owner,
+				"members": [{"user": self.owner, "role": "Owner", "status": "Active"}],
+			}
+		).insert()
+		self.region = "blr-sync"
+		if not frappe.db.exists("Atlas Instance", self.region):
+			frappe.get_doc(
+				{
+					"doctype": "Atlas Instance",
+					"region": self.region,
+					"base_url": "https://atlas.example.test",
+					"status": "Active",
+					"api_key": "k",
+					"api_secret": "s",
+				}
+			).insert()
+
+	def tearDown(self):
+		frappe.conf.atlas_use_stub_inventory = self._orig_stub
+		frappe.set_user("Administrator")
+
+	def test_sync_mirrors_inventory_into_assets(self):
+		freshness = sync_team_assets(self.team.name)
+		self.assertIn(self.region, freshness["synced"])
+		self.assertEqual(freshness["stale"], [])
+
+		vm = frappe.get_doc("Asset", "vm-blr-1")
+		self.assertEqual(vm.team, self.team.name)
+		self.assertEqual(vm.cluster, self.region)
+		self.assertEqual(vm.status, "Running")
+		self.assertTrue(vm.last_synced_at)
+
+	def test_registry_returns_team_assets(self):
+		result = registry(team=self.team.name)
+		ids = {a["resource_id"] for a in result["assets"]}
+		self.assertIn("vm-blr-1", ids)
+		self.assertIn(self.region, result["synced"])
+
+	def test_sync_is_failsoft_when_atlas_unreachable(self):
+		frappe.conf.atlas_use_stub_inventory = 0
+		with patch("central.atlas.AtlasClient.list_vms", side_effect=Exception("unreachable")):
+			freshness = sync_team_assets(self.team.name)
+		self.assertIn(self.region, freshness["stale"])
+		self.assertEqual(freshness["synced"], [])
+
+	def test_registry_blocked_for_non_member(self):
+		frappe.set_user(self.outsider)
+		with self.assertRaises(frappe.PermissionError):
+			registry(team=self.team.name)


### PR DESCRIPTION
The registry now works end to end against a (stub or real) Atlas: a team's VMs are pulled over Edge B (#44) and mirrored into `Asset` rows (#20), then served to the dashboard.

### What's here (`central/atlas.py`)
- `sync_team_assets(team)` — upserts the team's VMs from **every Active Atlas** into `Asset` rows, stamping `last_synced_at`. **Fail-soft**: a cluster that errors is reported in `stale` with its last-known mirror left intact — never a 500.
- `registry(team)` — the dashboard's entry point. `cluster:view`-gated, pulls on demand, returns `{assets, synced, stale}` so the UI can show freshness.
- Dev stub via the `atlas_use_stub_inventory` flag; **prod never serves fabricated data** (real `AtlasClient.list_vms`, fail-soft on error).

### Verification
`central.tests.test_atlas_sync` (4) — mirror from stub, registry shape, fail-soft when Atlas unreachable, non-member blocked. Green locally.

### Scope / next
- Frontend: replace `mock.js` with this `registry` call → #30.
- The other Atlas pages' endpoints (`list_vms`/`current_region`/`list_access_requests`) and the doctype-level `permission_query_conditions` → #26.
- The "Open" → bench SSO from the VM leaf → #28.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)