### PR TITLE
feat(asset): team-scoped Asset read permissions (#26)

### DIFF
--- a/central/central/doctype/asset/asset.json
+++ b/central/central/doctype/asset/asset.json
@@ -85,6 +85,12 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "export": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Central User"
   }
  ],
  "sort_field": "resource_id",

--- a/central/hooks.py
+++ b/central/hooks.py
@@ -261,12 +261,14 @@ permission_query_conditions = {
 	"Team": "central.permissions.team_query_conditions",
 	"Team Invitation": "central.permissions.team_invitation_query_conditions",
 	"Team Role": "central.permissions.team_role_query_conditions",
+	"Asset": "central.permissions.asset_query_conditions",
 }
 
 has_permission = {
 	"Team": "central.permissions.team_has_permission",
 	"Team Invitation": "central.permissions.team_invitation_has_permission",
 	"Team Role": "central.permissions.team_role_has_permission",
+	"Asset": "central.permissions.asset_has_permission",
 }
 
 override_whitelisted_methods = {

--- a/central/permissions.py
+++ b/central/permissions.py
@@ -78,3 +78,24 @@ def team_invitation_has_permission(doc, user: str | None = None, ptype: str | No
 	if ptype == "create":
 		return can(user, doc.team, "team:manage_members")
 	return doc.email == user or can(user, doc.team, "team:manage_members")
+
+
+def asset_query_conditions(user: str | None = None) -> str:
+	user = user or frappe.session.user
+	if user_has_operator_bypass(user):
+		return ""
+	teams = get_user_team_names_with_capability(user, "vm:view")
+	if not teams:
+		return "1 = 0"
+	escaped = ", ".join(frappe.db.escape(team) for team in teams)
+	return f"`tabAsset`.`team` in ({escaped})"
+
+
+def asset_has_permission(doc, user: str | None = None, ptype: str | None = None, **kwargs) -> bool:
+	user = user or frappe.session.user
+	if user_has_operator_bypass(user):
+		return True
+	# Assets are a read-only mirror of Atlas; only the sync (operator) writes them.
+	if ptype in ("create", "write", "delete"):
+		return False
+	return can(user, doc.team, "vm:view")

--- a/central/tests/test_asset_permissions.py
+++ b/central/tests/test_asset_permissions.py
@@ -1,0 +1,76 @@
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from central.tests.test_iam import ensure_user
+
+
+class TestAssetPermissions(IntegrationTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.owner = ensure_user("assetperm.owner@example.test")
+		self.viewer = ensure_user("assetperm.viewer@example.test")
+		self.team_a = self._team("Asset Perm A", self.viewer, "Viewer")
+		self.team_b = self._team("Asset Perm B", self.owner, "Owner")
+		self.cluster = self._cluster("blr-perm")
+		self.asset_a = self._asset("vm-perm-a", self.team_a.name)
+		self.asset_b = self._asset("vm-perm-b", self.team_b.name)
+
+	def _team(self, name, user, role):
+		existing = frappe.db.get_value("Team", {"team_name": name})
+		if existing:
+			return frappe.get_doc("Team", existing)
+		members = [{"user": self.owner, "role": "Owner", "status": "Active"}]
+		if user != self.owner:
+			members.append({"user": user, "role": role, "status": "Active"})
+		return frappe.get_doc(
+			{"doctype": "Team", "team_name": name, "owner_user": self.owner, "members": members}
+		).insert()
+
+	def _cluster(self, region):
+		if not frappe.db.exists("Atlas Instance", region):
+			frappe.get_doc(
+				{
+					"doctype": "Atlas Instance",
+					"region": region,
+					"base_url": "https://atlas.example.test",
+					"status": "Active",
+					"api_key": "k",
+					"api_secret": "s",
+				}
+			).insert()
+		return region
+
+	def _asset(self, rid, team):
+		if frappe.db.exists("Asset", rid):
+			frappe.delete_doc("Asset", rid, force=True, ignore_permissions=True)
+		return frappe.get_doc(
+			{
+				"doctype": "Asset",
+				"resource_id": rid,
+				"team": team,
+				"cluster": self.cluster,
+				"status": "Running",
+			}
+		).insert(ignore_permissions=True)
+
+	def test_member_sees_only_their_team_assets(self):
+		frappe.set_user(self.viewer)
+		try:
+			names = set(frappe.get_list("Asset", pluck="name"))
+		finally:
+			frappe.set_user("Administrator")
+		self.assertIn("vm-perm-a", names)
+		self.assertNotIn("vm-perm-b", names)
+
+	def test_member_can_read_but_not_write(self):
+		frappe.set_user(self.viewer)
+		try:
+			self.assertTrue(frappe.has_permission("Asset", "read", self.asset_a.name))
+			self.assertFalse(frappe.has_permission("Asset", "write", self.asset_a.name))
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_operator_sees_all_assets(self):
+		names = set(frappe.get_list("Asset", pluck="name"))
+		self.assertIn("vm-perm-a", names)
+		self.assertIn("vm-perm-b", names)


### PR DESCRIPTION
Locks down the `Asset` registry (built in #20, populated in #27) so a user sees only their own team's VMs.

### What's here
- `asset_query_conditions` + `asset_has_permission` (`central/permissions.py`, registered in `hooks.py`): reads scoped to teams where the user holds **`vm:view`**; operator (System Manager) sees all.
- Assets are a **read-only mirror** — create/write/delete denied for non-operators (the #27 sync writes with `ignore_permissions`).
- `Central User` granted scoped read on the DocType.

### Verification
`central.tests.test_asset_permissions` (3) — member sees only their team's assets, can read but not write, operator sees all. Re-ran the whole IAM/asset/atlas suite (24 tests) — no regressions.

### Next
- `#28` — "Open" on a VM leaf → mint token → bench SSO.
- `#30` — retire dashboard `mock.js`, wire to `registry`.

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)