### PR TITLE
feat(sso): open a VM's bench via get_bench_link asset resolution (#28)

### DIFF
--- a/central/sso.py
+++ b/central/sso.py
@@ -94,15 +94,18 @@ def mint_bench_assertion(user: str, team: str) -> str:
 
 
 @frappe.whitelist(methods=["GET"])
-def get_bench_link(team: str | None = None, gateway_url: str | None = None) -> dict:
+def get_bench_link(asset: str | None = None, team: str | None = None, gateway_url: str | None = None) -> dict:
 	"""Mint a scoped SSO assertion and return the bench URL to redirect to.
 
-	`vm:open` on the team is the gate. The target bench is passed in (the VM's
-	gateway_url, wired in #28) or falls back to the `bench_sso_redirect` config.
-	"""
+	Pass `asset` (a VM resource_id) to open that VM's bench — its team and
+	gateway are resolved and validated (Running, has a gateway, Active cluster).
+	`vm:open` on the team is the gate. `gateway_url` is the dev path used until the
+	registry "Open" wires `asset` in (#30)."""
 	user = frappe.session.user
 	if not user or user == "Guest":
 		frappe.throw("Sign in first.", frappe.PermissionError)
+	if asset:
+		team, gateway_url = _resolve_asset_target(asset, team)
 	team = team or _only_team(user)
 	if not can(user, team, "vm:open"):
 		frappe.throw("You can't open benches for this team.", frappe.PermissionError)
@@ -110,6 +113,22 @@ def get_bench_link(team: str | None = None, gateway_url: str | None = None) -> d
 	if not target.endswith("/sso"):
 		target += "/sso"
 	return {"url": f"{target}?assertion={mint_bench_assertion(user, team)}"}
+
+
+def _resolve_asset_target(asset: str, team: str | None) -> tuple[str, str]:
+	"""Resolve a VM Asset to (team, gateway_url), refusing anything not openable.
+	get_doc enforces the team-scoped Asset read perm, so a user who can't see the
+	VM can't probe it here either."""
+	doc = frappe.get_doc("Asset", asset)
+	if team and team != doc.team:
+		frappe.throw("That VM isn't in this team.", frappe.PermissionError)
+	if doc.status != "Running":
+		frappe.throw(f"VM is {doc.status.lower()}, not running.", frappe.ValidationError)
+	if not doc.gateway_url:
+		frappe.throw("VM has no gateway yet.", frappe.ValidationError)
+	if frappe.db.get_value("Atlas Instance", doc.cluster, "status") != "Active":
+		frappe.throw("That cluster is not active.", frappe.ValidationError)
+	return doc.team, doc.gateway_url
 
 
 def _only_team(user: str) -> str:

--- a/central/tests/test_open_bench.py
+++ b/central/tests/test_open_bench.py
@@ -1,0 +1,114 @@
+import frappe
+import jwt
+from frappe.tests import IntegrationTestCase
+
+from central.sso import _central_url, _ensure_oauth_client, get_bench_link
+from central.tests.test_iam import ensure_user
+
+
+class TestOpenBench(IntegrationTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self._orig = frappe.conf.get("sso_allow_insecure_hs256")
+		frappe.conf.sso_allow_insecure_hs256 = 1
+		self.owner = ensure_user("open.owner@example.test")
+		self.dev = ensure_user("open.dev@example.test")
+		self.viewer = ensure_user("open.viewer@example.test")
+		self.team = self._team()
+		self.cluster = self._cluster("blr-open")
+		self.asset = self._asset("vm-open-1", "Running", "http://localhost:3030")
+
+	def tearDown(self):
+		frappe.conf.sso_allow_insecure_hs256 = self._orig
+		frappe.set_user("Administrator")
+
+	def _team(self):
+		name = "Open Bench Team"
+		existing = frappe.db.get_value("Team", {"team_name": name})
+		if existing:
+			frappe.delete_doc("Team", existing, force=True, ignore_permissions=True)
+		return frappe.get_doc(
+			{
+				"doctype": "Team",
+				"team_name": name,
+				"owner_user": self.owner,
+				"members": [
+					{"user": self.owner, "role": "Owner", "status": "Active"},
+					{"user": self.dev, "role": "Developer", "status": "Active"},
+					{"user": self.viewer, "role": "Viewer", "status": "Active"},
+				],
+			}
+		).insert()
+
+	def _cluster(self, region):
+		if frappe.db.exists("Atlas Instance", region):
+			frappe.delete_doc("Atlas Instance", region, force=True)
+		frappe.get_doc(
+			{
+				"doctype": "Atlas Instance",
+				"region": region,
+				"base_url": "https://atlas.example.test",
+				"status": "Active",
+				"api_key": "k",
+				"api_secret": "s",
+			}
+		).insert()
+		return region
+
+	def _asset(self, rid, status, gateway):
+		if frappe.db.exists("Asset", rid):
+			frappe.delete_doc("Asset", rid, force=True, ignore_permissions=True)
+		return frappe.get_doc(
+			{
+				"doctype": "Asset",
+				"resource_id": rid,
+				"team": self.team.name,
+				"cluster": self.cluster,
+				"status": status,
+				"gateway_url": gateway or None,
+			}
+		).insert(ignore_permissions=True)
+
+	def _verify(self, token):
+		client = _ensure_oauth_client()
+		return jwt.decode(
+			token,
+			client.client_secret,
+			algorithms=["HS256"],
+			audience=client.client_id,
+			issuer=_central_url(),
+			options={"require": ["exp", "aud", "iss", "sub"]},
+		)
+
+	def _as(self, user, fn):
+		frappe.set_user(user)
+		try:
+			return fn()
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_open_running_vm_mints_for_its_gateway(self):
+		link = self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
+		self.assertTrue(link["url"].startswith("http://localhost:3030/sso?assertion="))
+		claims = self._verify(link["url"].split("assertion=", 1)[1])
+		self.assertEqual(claims["sub"], self.dev)
+		self.assertEqual(claims["team"], self.team.name)
+
+	def test_viewer_without_vm_open_is_blocked(self):
+		with self.assertRaises(frappe.PermissionError):
+			self._as(self.viewer, lambda: get_bench_link(asset="vm-open-1"))
+
+	def test_stopped_vm_refused(self):
+		self._asset("vm-open-1", "Stopped", "http://localhost:3030")
+		with self.assertRaises(frappe.ValidationError):
+			self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
+
+	def test_missing_gateway_refused(self):
+		self._asset("vm-open-1", "Running", "")
+		with self.assertRaises(frappe.ValidationError):
+			self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
+
+	def test_disabled_cluster_refused(self):
+		frappe.db.set_value("Atlas Instance", self.cluster, "status", "Disabled")
+		with self.assertRaises(frappe.ValidationError):
+			self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))


### PR DESCRIPTION
The journey's last hop on the backend: clicking a VM mints a scoped token into *that* VM's bench.

### What's here
- `get_bench_link(asset=<resource_id>)` resolves the VM's `team` + `gateway_url` from the `Asset` and validates it's openable:
  - **Running** (else "VM is stopped/…"), has a **gateway_url**, and its owning **cluster is Active**.
  - `vm:open` on the team is the gate; `get_doc` enforces the team-scoped Asset read perm (#26), so a user who can't see the VM can't probe it.
- The explicit `gateway_url` dev path is retained (back-compat) until the registry "Open" button passes `asset` (#30).

### Verification
`central.tests.test_open_bench` (5) — running VM mints for its gateway (token bench-verifiable, correct sub/team), Viewer (no `vm:open`) blocked, and stopped / missing-gateway / disabled-cluster all refused. `test_sso` back-compat green.

### Next
- `#30` — wire the dashboard registry "Open" to call `get_bench_link(asset=…)` and retire `mock.js`. That closes the full journey.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)