### PR TITLE
fix(dashboard): remove the billing onboarding gate

### DIFF
--- a/dashboard/src/components/AppLayout.vue
+++ b/dashboard/src/components/AppLayout.vue
@@ -3,12 +3,8 @@ import { ref } from 'vue'
 import NavLink from '@/components/NavLink.vue'
 import TeamSwitcher from '@/components/TeamSwitcher.vue'
 import { useCapabilities } from '@/composables/useCapabilities'
-import { useBillingSetup } from '@/composables/useBillingSetup'
 
 const { canView, canViewTeam, canViewAtlas } = useCapabilities()
-// Until the billing profile is complete, EVERY nav option is locked and the
-// onboarding view fills the content area (the router funnels all routes there).
-const { complete: setupComplete } = useBillingSetup()
 
 // Below sm: the sidebar collapses to a toggled drawer (slides from the left).
 const drawerOpen = ref(false)
@@ -61,28 +57,28 @@ const atlas = [
         <div v-if="canViewAtlas">
           <p class="px-2 pb-1 text-sm font-medium text-ink-gray-5">Atlas</p>
           <div class="space-y-0.5">
-            <NavLink v-for="i in atlas" :key="i.to" v-bind="i" :disabled="!setupComplete" />
+            <NavLink v-for="i in atlas" :key="i.to" v-bind="i" />
           </div>
         </div>
 
         <div v-if="canViewTeam">
           <p class="px-2 pb-1 text-sm font-medium text-ink-gray-5">Team</p>
           <div class="space-y-0.5">
-            <NavLink v-for="i in team" :key="i.to" v-bind="i" :disabled="!setupComplete" />
+            <NavLink v-for="i in team" :key="i.to" v-bind="i" />
           </div>
         </div>
 
         <div v-if="canView">
           <p class="px-2 pb-1 text-sm font-medium text-ink-gray-5">Billing</p>
           <div class="space-y-0.5">
-            <NavLink v-for="i in billing" :key="i.to" v-bind="i" :disabled="!setupComplete" />
+            <NavLink v-for="i in billing" :key="i.to" v-bind="i" />
           </div>
         </div>
 
         <div v-if="canView">
           <p class="px-2 pb-1 text-sm font-medium text-ink-gray-5">Settings</p>
           <div class="space-y-0.5">
-            <NavLink v-for="i in settings" :key="i.to" v-bind="i" :disabled="!setupComplete" />
+            <NavLink v-for="i in settings" :key="i.to" v-bind="i" />
           </div>
         </div>
       </nav>

--- a/dashboard/src/router/index.js
+++ b/dashboard/src/router/index.js
@@ -1,8 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import AppLayout from '@/components/AppLayout.vue'
 import GroupGate from '@/components/GroupGate.vue'
-import { fetchBillingSetup } from '@/data/billingSetup'
-import { useTeam, whoReady } from '@/composables/useTeam'
 
 // The SPA is mounted under /dashboard (central/hooks.py website_route_rules).
 const routes = [
@@ -11,10 +9,6 @@ const routes = [
     component: AppLayout,
     children: [
       { path: '', redirect: '/billing' },
-
-      // First-run billing setup — rendered inside the shell (sidebar stays, its
-      // billing/settings options stay locked until the profile is complete).
-      { path: 'onboarding', name: 'Onboarding', component: () => import('@/pages/Onboarding.vue') },
 
       {
         path: 'billing',
@@ -70,25 +64,4 @@ const routes = [
 export const router = createRouter({
   history: createWebHistory('/dashboard/'),
   routes,
-})
-
-// Onboarding gate. Until the billing profile is complete, EVERY route funnels to
-// /onboarding — any click or refresh lands there and nowhere else. A set-up team
-// is conversely kept off /onboarding. The check is awaited before the route paints
-// (and the app mounts only after router.isReady()), so a hard refresh is
-// deterministic and never flashes onboarding away. Cached → one request per
-// session (invalidated on save). Fail-open: if the check errors, navigation
-// proceeds rather than trapping the user.
-router.beforeEach(async (to) => {
-  // Resolve identity first so we gate on the active team, not an empty/default one.
-  await whoReady
-  const { currentTeam } = useTeam()
-  const setup = await fetchBillingSetup(currentTeam.value)
-  const incomplete = setup && setup.complete === false
-
-  if (to.path === '/onboarding') {
-    // A set-up team has no business on onboarding — send it on to its target.
-    return incomplete ? true : to.query.redirect || '/billing'
-  }
-  return incomplete ? { path: '/onboarding', query: { redirect: to.fullPath } } : true
 })


### PR DESCRIPTION
Per product direction we don't want the forced billing onboarding right now, and it was blocking dashboard access (empty currency picker → profile could never be completed).

### What's removed
- The router `beforeEach` that funneled **every** route to `/onboarding` until the billing profile was complete.
- The `AppLayout` nav lock (`:disabled="!setupComplete"`) that disabled every sidebar option until setup.
- The `/onboarding` route entry + now-unused imports.

The dashboard is now reachable directly (lands on `/billing`; Atlas / Team / Settings nav all usable).

### Left in place (reversible)
`Onboarding.vue`, `useBillingSetup`, and the `billingSetup` store stay on disk but unrouted — re-add the route + guard to bring the gate back.

### Verification
`yarn build` clean (2076 modules). Replaces the now-closed #53 (which tried to fix the currency picker instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)