### PR TITLE
dashboard: registry-driven onboarding wizard + action-level billing gate

### DIFF
--- a/central/www/dashboard.html
+++ b/central/www/dashboard.html
@@ -10,8 +10,8 @@
          doesn't leave the card widget blank. @stripe/stripe-js reuses this tag. -->
     <link rel="preconnect" href="https://js.stripe.com" crossorigin />
     <script src="https://js.stripe.com/v3/" async></script>
-    <script type="module" crossorigin src="/assets/central/dashboard/assets/index-BPCoRZzf.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/central/dashboard/assets/index-C-2n0NoW.css">
+    <script type="module" crossorigin src="/assets/central/dashboard/assets/index-COrovK28.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/central/dashboard/assets/index-CT0pRbbf.css">
   </head>
   <body>
     <div id="app"></div>

--- a/dashboard/src/components/onboarding/BillingProfileStep.vue
+++ b/dashboard/src/components/onboarding/BillingProfileStep.vue
@@ -1,0 +1,164 @@
+<script setup>
+import { computed, reactive, watch } from 'vue'
+import { useCall } from 'frappe-ui'
+import { Button, FormControl, LoadingText } from 'frappe-ui'
+import { API, m } from '@/api/endpoints'
+import { useTeam } from '@/composables/useTeam'
+import { useBillingSetup } from '@/composables/useBillingSetup'
+import { successToast, errorToast } from '@/utils/toast'
+
+// Step 1 — currency + legal name + address (+ tax). Saving completes the billing
+// profile, which is what unlocks every money-moving action. Currency is chosen
+// here and locks once activity begins, so it can never be guessed wrong later.
+defineProps({ active: Boolean, complete: Boolean })
+const emit = defineEmits(['update:complete', 'advance'])
+
+const { currentTeam } = useTeam()
+const { complete: setupComplete, supportedCurrencies, reload: reloadSetup } = useBillingSetup()
+
+// Mirror the shared completion flag up to the wizard (immediate handles revisits
+// where the profile is already complete).
+watch(setupComplete, (v) => emit('update:complete', v), { immediate: true })
+
+const profile = useCall({
+  url: m(API.billingProfile),
+  params: () => ({ team: currentTeam.value }),
+  refetch: true,
+})
+const geo = useCall({ url: m(API.billingGeo) })
+
+const FIELDS = [
+  'currency', 'legal_name', 'email', 'gstin',
+  'address_line1', 'address_line2', 'city', 'state', 'country', 'pincode',
+]
+const form = reactive({})
+watch(
+  () => profile.data,
+  (d) => {
+    if (!d) return
+    for (const f of FIELDS) form[f] = d[f] ?? ''
+  },
+  { immediate: true },
+)
+
+const currencyOptions = computed(() => supportedCurrencies.value.map((c) => ({ label: c, value: c })))
+const countryOptions = computed(() => (geo.data?.countries ?? []).map((c) => ({ label: c, value: c })))
+const stateOptions = computed(() => (geo.data?.india_states ?? []).map((s) => ({ label: s, value: s })))
+// India drives the state dropdown — its value's GST code is what validates the GSTIN.
+const isIndia = computed(() => form.country === 'India')
+
+// Autocomplete works in {label, value} options; the profile stores plain strings,
+// so proxy between the two.
+function optionModel(field) {
+  return computed({
+    get: () => (form[field] ? { label: form[field], value: form[field] } : null),
+    set: (opt) => {
+      form[field] = opt?.value ?? ''
+    },
+  })
+}
+const countryModel = optionModel('country')
+const stateModel = optionModel('state')
+
+const required = ['currency', 'legal_name', 'address_line1', 'city', 'state', 'country', 'pincode']
+const canSubmit = computed(() => required.every((f) => String(form[f] || '').trim()))
+
+const save = useCall({ url: m(API.saveBillingProfile), method: 'POST', immediate: false })
+async function submit() {
+  try {
+    await save.submit({ team: currentTeam.value, ...form })
+    await reloadSetup() // refresh shared state → flips completion, unlocks actions
+    successToast('Billing profile saved.')
+    emit('advance') // let the wizard open the next step
+  } catch (e) {
+    errorToast(e)
+  }
+}
+</script>
+
+<template>
+  <div v-if="profile.loading && !profile.data" class="space-y-3">
+    <LoadingText :lines="6" />
+  </div>
+
+  <form v-else class="space-y-4" @submit.prevent="submit">
+    <!-- Grouped into Currency / Contact / Address / Tax for hierarchy — mirrors the
+         Settings billing profile. Once complete the fieldset disables every control
+         and the Save action is hidden; edits happen later in Settings. -->
+    <fieldset :disabled="complete" class="space-y-6">
+      <div class="space-y-3">
+        <h3 class="text-sm font-medium text-ink-gray-8">Billing currency</h3>
+        <div class="grid gap-4 sm:grid-cols-2">
+          <FormControl
+            type="select"
+            v-model="form.currency"
+            label="Currency *"
+            :options="currencyOptions"
+          />
+          <p v-if="!currencyOptions.length" class="self-end text-p-sm text-ink-amber-3">
+            No billing currencies are available yet — ask an admin to enable a payment gateway
+            with a default currency.
+          </p>
+        </div>
+      </div>
+
+      <div class="space-y-3">
+        <h3 class="text-sm font-medium text-ink-gray-8">Contact</h3>
+        <div class="grid gap-4 sm:grid-cols-2">
+          <FormControl v-model="form.legal_name" label="Legal name *" />
+          <FormControl v-model="form.email" type="email" label="Billing email" />
+        </div>
+      </div>
+
+      <div class="space-y-3">
+        <h3 class="text-sm font-medium text-ink-gray-8">Address</h3>
+        <div class="grid gap-4 sm:grid-cols-2">
+          <FormControl v-model="form.address_line1" label="Address line 1 *" />
+          <FormControl v-model="form.address_line2" label="Address line 2" />
+          <FormControl v-model="form.city" label="City *" />
+          <FormControl
+            type="autocomplete"
+            v-model="countryModel"
+            label="Country *"
+            placeholder="Select country"
+            :options="countryOptions"
+          />
+          <FormControl
+            v-if="isIndia"
+            type="autocomplete"
+            v-model="stateModel"
+            label="State *"
+            placeholder="Select state"
+            :options="stateOptions"
+          />
+          <FormControl v-else v-model="form.state" label="State *" />
+          <FormControl v-model="form.pincode" label="PIN code *" />
+        </div>
+      </div>
+
+      <div v-if="isIndia" class="space-y-3">
+        <h3 class="text-sm font-medium text-ink-gray-8">Tax details</h3>
+        <div class="grid gap-4 sm:grid-cols-2">
+          <FormControl
+            v-model="form.gstin"
+            label="GSTIN"
+            :description="isIndia ? 'Its first two digits must match the selected state.' : ''"
+          />
+        </div>
+      </div>
+    </fieldset>
+
+    <div v-if="!complete" class="flex items-center gap-3 pt-1">
+      <Button
+        variant="solid"
+        label="Save & continue"
+        type="submit"
+        :loading="save.loading"
+        :disabled="!canSubmit"
+      />
+      <span v-if="!canSubmit" class="text-p-sm text-ink-gray-5">
+        Fill the fields marked * to continue.
+      </span>
+    </div>
+  </form>
+</template>

--- a/dashboard/src/components/onboarding/OnboardingSection.vue
+++ b/dashboard/src/components/onboarding/OnboardingSection.vue
@@ -1,0 +1,84 @@
+<script setup>
+import { computed } from 'vue'
+
+// One accordion section of the onboarding wizard. Purely presentational: the
+// parent decides the `state` (complete | active | locked) and whether it's `open`;
+// this renders the header (status circle, title, status label, chevron) and a
+// collapsible body. The body always stays mounted so the step inside can report
+// its completion — it's just height-collapsed when closed.
+const props = defineProps({
+  index: { type: Number, required: true },
+  title: { type: String, required: true },
+  description: { type: String, default: '' },
+  optional: { type: Boolean, default: false },
+  state: { type: String, default: 'locked' }, // 'complete' | 'active' | 'locked'
+  open: { type: Boolean, default: false },
+})
+defineEmits(['toggle'])
+
+const circleClass = computed(() => ({
+  complete: 'border-outline-gray-3 text-ink-green-3',
+  active: 'border-outline-gray-4 text-ink-gray-9',
+  locked: 'border-outline-gray-2 text-ink-gray-4',
+}[props.state]))
+
+const statusLabel = computed(() => {
+  if (props.state === 'complete') return 'Completed'
+  if (props.state === 'locked') return 'Locked'
+  return props.optional ? 'Optional' : 'Required'
+})
+const statusClass = computed(() =>
+  props.state === 'complete' ? 'text-ink-green-3' : 'text-ink-gray-5',
+)
+</script>
+
+<template>
+  <section
+    class="overflow-hidden rounded-lg border transition-colors"
+    :class="state === 'active'
+      ? 'border-outline-gray-3 bg-surface-white shadow-sm'
+      : 'border-outline-gray-1 bg-surface-gray-1'"
+  >
+    <button
+      type="button"
+      class="flex w-full items-center gap-3 px-4 py-3.5 text-left transition-colors"
+      :class="state === 'locked' ? 'cursor-not-allowed' : 'hover:bg-surface-gray-2'"
+      :disabled="state === 'locked'"
+      @click="$emit('toggle')"
+    >
+      <span
+        class="flex size-7 shrink-0 items-center justify-center rounded-full border text-p-sm transition-colors"
+        :class="circleClass"
+      >
+        <span v-if="state === 'complete'" class="lucide-check size-4" />
+        <span v-else-if="state === 'locked'" class="lucide-lock size-3.5" />
+        <template v-else>{{ index + 1 }}</template>
+      </span>
+
+      <div class="min-w-0 flex-1">
+        <span class="text-base text-ink-gray-9">{{ title }}</span>
+        <p class="mt-0.5 truncate text-p-sm text-ink-gray-5">{{ description }}</p>
+      </div>
+
+      <span class="shrink-0 text-p-sm" :class="statusClass">{{ statusLabel }}</span>
+      <span
+        v-if="state !== 'locked'"
+        class="lucide-chevron-down size-4 shrink-0 text-ink-gray-5 transition-transform duration-200"
+        :class="open && 'rotate-180'"
+      />
+    </button>
+
+    <!-- Collapsible body. The 0fr→1fr grid trick animates height without
+         measuring; the inner div clips the content while collapsed. -->
+    <div
+      class="grid transition-[grid-template-rows] duration-200 ease-out"
+      :class="open ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'"
+    >
+      <div class="overflow-hidden">
+        <div class="border-t border-outline-gray-1 px-4 py-4">
+          <slot />
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/dashboard/src/components/onboarding/PaymentMethodStep.vue
+++ b/dashboard/src/components/onboarding/PaymentMethodStep.vue
@@ -1,0 +1,73 @@
+<script setup>
+import { ref, watch } from 'vue'
+import { useCall } from 'frappe-ui'
+import { Button, LoadingText } from 'frappe-ui'
+import AddMethodDialog from '@/components/AddMethodDialog.vue'
+import { API, m } from '@/api/endpoints'
+import { useTeam } from '@/composables/useTeam'
+
+// Step 2 (optional) — a saved card/UPI Autopay so invoices are charged
+// automatically. It needs the saved currency + gateway customer from step 1, so
+// the wizard keeps it locked until the billing profile is complete. Completion
+// here simply means "at least one method on file".
+defineProps({ active: Boolean, complete: Boolean })
+const emit = defineEmits(['update:complete', 'advance'])
+
+const { currentTeam } = useTeam()
+const methods = useCall({
+  url: m(API.paymentMethods),
+  params: () => ({ team: currentTeam.value }),
+  refetch: true,
+})
+watch(() => methods.data, (d) => emit('update:complete', !!d?.length), { immediate: true })
+
+const showAdd = ref(false)
+function onAdded() {
+  methods.reload()
+  emit('advance')
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div v-if="methods.loading && !methods.data" class="space-y-3">
+      <LoadingText :lines="3" />
+    </div>
+
+    <ul v-else-if="methods.data?.length" class="space-y-2">
+      <li
+        v-for="pm in methods.data"
+        :key="pm.name"
+        class="flex items-center gap-3 rounded border border-outline-gray-1 px-4 py-3"
+      >
+        <span
+          :class="[
+            pm.method_type === 'Card' ? 'lucide-credit-card' : 'lucide-smartphone',
+            'size-5 text-ink-gray-5',
+          ]"
+        />
+        <p class="truncate text-sm text-ink-gray-8">
+          {{ pm.display_label || pm.method_type }}
+        </p>
+      </li>
+    </ul>
+
+    <div
+      v-else
+      class="rounded border border-dashed border-outline-gray-2 px-6 py-8 text-center"
+    >
+      <p class="text-p-base text-ink-gray-6">No payment method yet.</p>
+      <p class="mt-1 text-p-sm text-ink-gray-5">
+        Add a card or UPI Autopay so invoices can be charged automatically — or skip this and
+        add one later from Settings.
+      </p>
+    </div>
+
+    <Button v-if="!methods.data?.length" variant="solid" @click="showAdd = true">
+      <template #prefix><span class="lucide-plus size-4" aria-hidden="true" /></template>
+      Add payment method
+    </Button>
+
+    <AddMethodDialog v-model="showAdd" @done="onAdded" />
+  </div>
+</template>

--- a/dashboard/src/composables/useBillingSetup.js
+++ b/dashboard/src/composables/useBillingSetup.js
@@ -1,22 +1,37 @@
 // Billing-profile completeness gate, for components.
 //
 // A team must complete its billing profile — currency + legal name + address —
-// before any money moves and before the sidebar's options unlock. This wraps the
-// shared reactive store (data/billingSetup.js) the router guard also reads, scoped
-// to the ACTIVE team: it (re)fetches whenever the team switcher changes teams, so
-// the shell, pages, and guard always reflect the team currently in view.
+// before any money moves. Navigation is open even when it's incomplete; what's
+// gated are the money-moving actions (top-up, credits, payment method), via
+// requireSetup() below. This wraps the shared reactive store (data/billingSetup.js)
+// scoped to the ACTIVE team: it (re)fetches whenever the team switcher changes
+// teams, so the shell and pages always reflect the team currently in view.
 
 import { computed, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { billingSetupState, fetchBillingSetup } from '@/data/billingSetup'
 import { useTeam } from '@/composables/useTeam'
+import { infoToast } from '@/utils/toast'
 
 export function useBillingSetup() {
   const state = billingSetupState()
   const { currentTeam } = useTeam()
+  const router = useRouter()
+  const route = useRoute()
 
   // Fetch for the active team; refetch when it changes. Cached, so this is a
   // no-op once the guard has already fetched the same team.
   watch(currentTeam, (t) => { if (t) fetchBillingSetup(t) }, { immediate: true })
+
+  // Call at the start of a money-moving action. If the profile is incomplete it
+  // diverts the user to onboarding (remembering where they were) and returns
+  // false so the caller bails out; returns true when it's safe to proceed.
+  function requireSetup() {
+    if (state.data?.complete) return true
+    infoToast('Complete your billing setup to continue.')
+    router.push({ path: '/onboarding', query: { redirect: route.fullPath } })
+    return false
+  }
 
   return {
     complete: computed(() => !!state.data?.complete),
@@ -26,5 +41,6 @@ export function useBillingSetup() {
     supportedCurrencies: computed(() => state.data?.supported_currencies || []),
     loading: computed(() => state.loading),
     reload: () => fetchBillingSetup(currentTeam.value, { force: true }),
+    requireSetup,
   }
 }

--- a/dashboard/src/onboarding/steps.js
+++ b/dashboard/src/onboarding/steps.js
@@ -1,0 +1,40 @@
+import { defineAsyncComponent } from 'vue'
+
+// The onboarding wizard is a declarative list of steps, rendered as an accordion.
+// Each entry is a self-contained section whose `component` renders the step body
+// and follows this contract:
+//   • props:  `active`   — whether the section is currently expanded
+//             `complete` — the wizard's current view of its completion
+//   • emits:  `update:complete` (Boolean) — report your completion, reactively
+//             `advance`          — fired when your primary action finishes, so the
+//                                  wizard can open the next step
+// A step is LOCKED (collapsed, non-interactive) until every preceding non-optional
+// step is complete. Mark a step `optional: true` to let the team finish without it.
+//
+// To add a step — e.g. "Choose an Atlas region to subscribe to" — drop a component
+// under components/onboarding/ that honours the contract above and add one entry
+// here. No other file needs to change.
+export const ONBOARDING_STEPS = [
+  {
+    key: 'profile',
+    title: 'Billing profile',
+    description: 'Your billing currency, company details and tax info.',
+    optional: false,
+    component: defineAsyncComponent(() => import('@/components/onboarding/BillingProfileStep.vue')),
+  },
+  {
+    key: 'payment',
+    title: 'Payment method',
+    description: 'Add a card or UPI Autopay so invoices are charged automatically.',
+    optional: true,
+    component: defineAsyncComponent(() => import('@/components/onboarding/PaymentMethodStep.vue')),
+  },
+  // Future, e.g.:
+  // {
+  //   key: 'region',
+  //   title: 'Choose a region',
+  //   description: 'Pick where your resources are provisioned by default.',
+  //   optional: true,
+  //   component: defineAsyncComponent(() => import('@/components/onboarding/RegionStep.vue')),
+  // },
+]

--- a/dashboard/src/pages/Onboarding.vue
+++ b/dashboard/src/pages/Onboarding.vue
@@ -1,108 +1,121 @@
 <script setup>
-import { computed, reactive, watch } from 'vue'
+import { computed, reactive, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { useCall } from 'frappe-ui'
-import { Button, FormControl, LoadingText } from 'frappe-ui'
-import { API, m } from '@/api/endpoints'
-import { useTeam } from '@/composables/useTeam'
-import { useBillingSetup } from '@/composables/useBillingSetup'
-import { successToast, errorToast } from '@/utils/toast'
+import { Button } from 'frappe-ui'
+import OnboardingSection from '@/components/onboarding/OnboardingSection.vue'
+import { ONBOARDING_STEPS } from '@/onboarding/steps'
 
-// First-run billing setup, rendered in the content area while the shell's
-// billing/settings options stay locked. The router sends a team here whenever its
-// billing profile is incomplete; once currency + legal name + address are saved
-// the options unlock and the team proceeds to the dashboard. Currency is chosen
-// here (and locks once money moves), so it can never be guessed wrong later.
+// First-run billing setup, rendered as an accordion of collapsible sections driven
+// entirely by the ONBOARDING_STEPS registry. Each section reports its own
+// completion (v-model:complete); a section stays LOCKED — collapsed and
+// non-interactive — until every preceding non-optional step is complete. The open
+// section follows the first incomplete, unlocked step unless the team manually
+// opens another. Adding a step is a registry-only change (see onboarding/steps.js).
+//
+// Navigation stays open elsewhere; money-moving actions divert here via
+// useBillingSetup.requireSetup(), passing a ?redirect= that finish() returns to.
 const route = useRoute()
 const router = useRouter()
-const { currentTeam } = useTeam()
-const { supportedCurrencies, reload: reloadSetup } = useBillingSetup()
+const steps = ONBOARDING_STEPS
 
-const profile = useCall({
-  url: m(API.billingProfile),
-  params: () => ({ team: currentTeam.value }),
-  refetch: true,
+const done = reactive(Object.fromEntries(steps.map((s) => [s.key, false])))
+
+// A step is locked until every preceding NON-optional step is complete.
+function locked(i) {
+  return steps.slice(0, i).some((s) => !s.optional && !done[s.key])
+}
+function stateOf(i) {
+  if (done[steps[i].key]) return 'complete'
+  return locked(i) ? 'locked' : 'active'
+}
+
+// The open section follows the first incomplete, unlocked step — unless the team
+// manually toggles one (manualKey), which we respect until the next advance.
+const manualKey = ref(undefined)
+const autoKey = computed(() => {
+  const i = steps.findIndex((s, idx) => !done[s.key] && !locked(idx))
+  return i === -1 ? null : steps[i].key
 })
+const openKey = computed(() => (manualKey.value !== undefined ? manualKey.value : autoKey.value))
 
-const FIELDS = [
-  'currency', 'legal_name', 'email', 'gstin',
-  'address_line1', 'address_line2', 'city', 'state', 'country', 'pincode',
-]
-const form = reactive({})
-watch(
-  () => profile.data,
-  (d) => {
-    if (!d) return
-    for (const f of FIELDS) form[f] = d[f] ?? ''
-  },
-  { immediate: true },
-)
+function toggle(i) {
+  if (locked(i)) return
+  manualKey.value = openKey.value === steps[i].key ? null : steps[i].key
+}
+function onComplete(key, val) {
+  done[key] = val
+}
+function onAdvance() {
+  manualKey.value = undefined // hand control back to autoKey → opens the next step
+}
 
-const currencyOptions = computed(() => supportedCurrencies.value.map((c) => ({ label: c, value: c })))
-const required = ['currency', 'legal_name', 'address_line1', 'city', 'state', 'country', 'pincode']
-const canSubmit = computed(() => required.every((f) => String(form[f] || '').trim()))
+const completedCount = computed(() => steps.filter((s) => done[s.key]).length)
+const requiredDone = computed(() => steps.every((s) => s.optional || done[s.key]))
+const allDone = computed(() => completedCount.value === steps.length)
 
-const save = useCall({ url: m(API.saveBillingProfile), method: 'POST', immediate: false })
-async function submit() {
-  try {
-    await save.submit({ team: currentTeam.value, ...form })
-    await reloadSetup() // refresh shared state → unlocks the sidebar options
-    successToast('Billing profile set up.')
-    router.replace(route.query.redirect || '/billing')
-  } catch (e) {
-    errorToast(e)
-  }
+// Leave the wizard for wherever the team was headed (or the dashboard).
+function finish() {
+  router.replace(route.query.redirect || '/billing')
 }
 </script>
 
 <template>
-  <div class="h-full overflow-y-auto">
-    <div class="mx-auto w-full max-w-2xl px-5 py-8">
-      <div class="rounded-lg border border-outline-gray-1 bg-surface-white p-6">
-        <h1 class="text-lg text-ink-gray-9">Set up billing for your team</h1>
-        <p class="mt-1 text-p-sm text-ink-gray-5">
-          Choose your billing currency and add your company details to get started — this is
-          needed before you can add credits or a payment method, and it unlocks the rest of
-          billing. Your currency locks once activity begins, so pick carefully.
+  <div class="h-full overflow-y-auto bg-surface-gray-1">
+    <div class="mx-auto w-full max-w-2xl px-5 py-10">
+      <header class="mb-6">
+        <h1 class="text-xl text-ink-gray-9">Set up billing for your team</h1>
+        <p class="mt-1 text-p-base text-ink-gray-6">
+          A couple of quick steps and you’re ready to add credits, a payment method, and
+          provision resources.
         </p>
 
-        <div v-if="profile.loading && !profile.data" class="mt-6 space-y-3">
-          <LoadingText :lines="6" />
+        <div class="mt-4 flex items-center gap-3">
+          <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-surface-gray-3">
+            <div
+              class="h-full rounded-full bg-surface-green-5 transition-all duration-500 ease-out"
+              :style="{ width: `${(completedCount / steps.length) * 100}%` }"
+            />
+          </div>
+          <span class="shrink-0 text-p-sm text-ink-gray-5">
+            {{ completedCount }} of {{ steps.length }} done
+          </span>
         </div>
+      </header>
 
-        <form v-else class="mt-6 space-y-4" @submit.prevent="submit">
-          <div class="grid gap-4 sm:grid-cols-2">
-            <FormControl
-              type="select"
-              v-model="form.currency"
-              label="Billing currency *"
-              :options="currencyOptions"
-            />
-            <div />
-            <FormControl v-model="form.legal_name" label="Legal name *" />
-            <FormControl v-model="form.gstin" label="GSTIN" />
-            <FormControl v-model="form.email" type="email" label="Billing email" />
-            <FormControl v-model="form.address_line1" label="Address line 1 *" />
-            <FormControl v-model="form.address_line2" label="Address line 2" />
-            <FormControl v-model="form.city" label="City *" />
-            <FormControl v-model="form.state" label="State *" />
-            <FormControl v-model="form.country" label="Country *" />
-            <FormControl v-model="form.pincode" label="PIN code *" />
-          </div>
+      <div class="space-y-3">
+        <OnboardingSection
+          v-for="(s, i) in steps"
+          :key="s.key"
+          :index="i"
+          :title="s.title"
+          :description="s.description"
+          :optional="s.optional"
+          :state="stateOf(i)"
+          :open="openKey === s.key"
+          @toggle="toggle(i)"
+        >
+          <component
+            :is="s.component"
+            :active="openKey === s.key"
+            :complete="done[s.key]"
+            @update:complete="onComplete(s.key, $event)"
+            @advance="onAdvance"
+          />
+        </OnboardingSection>
+      </div>
 
-          <div class="flex items-center gap-3 pt-2">
-            <Button
-              variant="solid"
-              label="Finish setup"
-              type="submit"
-              :loading="save.loading"
-              :disabled="!canSubmit"
-            />
-            <span v-if="!canSubmit" class="text-p-sm text-ink-gray-5">
-              Fill the fields marked * to continue.
-            </span>
-          </div>
-        </form>
+      <div class="mt-6 flex items-center justify-between gap-3">
+        <p class="text-p-sm text-ink-gray-5">
+          <template v-if="allDone">You’re all set.</template>
+          <template v-else-if="requiredDone">Optional steps left — head to the dashboard whenever you’re ready.</template>
+          <template v-else>Complete the required step to continue.</template>
+        </p>
+        <Button
+          variant="solid"
+          label="Go to dashboard"
+          :disabled="!requiredDone"
+          @click="finish"
+        />
       </div>
     </div>
   </div>

--- a/dashboard/src/pages/atlas/AccessRequests.vue
+++ b/dashboard/src/pages/atlas/AccessRequests.vue
@@ -4,6 +4,7 @@ import { Badge, Button, Dialog, FormControl } from 'frappe-ui'
 import PageHeader from '@/components/PageHeader.vue'
 import MockBanner from '@/components/MockBanner.vue'
 import { useCapabilities } from '@/composables/useCapabilities'
+import { useBillingSetup } from '@/composables/useBillingSetup'
 import { requestTheme } from '@/utils/status'
 import { successToast } from '@/utils/toast'
 import { MOCK_ACCESS_REQUESTS, MOCK_CLUSTERS } from './mock'
@@ -12,12 +13,20 @@ import { MOCK_ACCESS_REQUESTS, MOCK_CLUSTERS } from './mock'
 // it auto-resolves on the next trust-tier promotion that widens the set). The
 // approval widens the team's entitlement slice in the real model.
 const { canManageAtlas } = useCapabilities()
+const { requireSetup } = useBillingSetup()
 
 const requests = ref([...MOCK_ACCESS_REQUESTS])
 const lockedClusters = MOCK_CLUSTERS.filter((c) => !c.allowed)
 
 const showNew = ref(false)
 const form = ref({ cluster: '', reason: '' })
+
+// Requesting region access leads to provisioning (which spends money), so it's
+// gated on a complete billing profile: requireSetup() diverts to onboarding
+// (remembering this page) when it isn't.
+function onRequest() {
+  if (requireSetup()) showNew.value = true
+}
 const clusterOptions = lockedClusters.map((c) => ({ label: c.label, value: c.slug }))
 const canSubmit = computed(() => form.value.cluster && form.value.reason.trim())
 
@@ -46,7 +55,7 @@ function submit() {
           variant="solid"
           label="Request access"
           :disabled="!lockedClusters.length"
-          @click="showNew = true"
+          @click="onRequest"
         />
       </template>
     </PageHeader>

--- a/dashboard/src/pages/atlas/VirtualMachines.vue
+++ b/dashboard/src/pages/atlas/VirtualMachines.vue
@@ -5,6 +5,7 @@ import PageHeader from '@/components/PageHeader.vue'
 import SplitView from '@/components/SplitView.vue'
 import MockBanner from '@/components/MockBanner.vue'
 import { useCapabilities } from '@/composables/useCapabilities'
+import { useBillingSetup } from '@/composables/useBillingSetup'
 import { operationalTheme } from '@/utils/status'
 import { infoToast } from '@/utils/toast'
 import { MOCK_VMS, MOCK_CLUSTERS, MOCK_EVENTS, clusterLabel } from './mock'
@@ -12,6 +13,13 @@ import { MOCK_VMS, MOCK_CLUSTERS, MOCK_EVENTS, clusterLabel } from './mock'
 // 🟡 Mock. VM list (split view) + detail tabs. Lifecycle actions are proposed
 // endpoints — they toast a notice instead of mutating (no Atlas API yet).
 const { canManageAtlas } = useCapabilities()
+const { requireSetup } = useBillingSetup()
+
+// Provisioning a VM spends money, so it's gated on a complete billing profile:
+// requireSetup() diverts to onboarding (remembering this page) when it isn't.
+function onNewVM() {
+  if (requireSetup()) action('Create VM')
+}
 
 const vms = ref(MOCK_VMS)
 const search = ref('')
@@ -67,7 +75,7 @@ function rowActions(vm) {
   <div class="flex h-full flex-col">
     <PageHeader :items="[{ label: 'Atlas' }, { label: 'Virtual Machines' }]">
       <template #actions>
-        <Button v-if="canManageAtlas" variant="solid" label="New VM" disabled />
+        <Button v-if="canManageAtlas" variant="solid" label="New VM" @click="onNewVM" />
       </template>
     </PageHeader>
 

--- a/dashboard/src/pages/billing/Credits.vue
+++ b/dashboard/src/pages/billing/Credits.vue
@@ -15,7 +15,7 @@ import { money, signedMoney } from '@/utils/money'
 const router = useRouter()
 const { currentTeam } = useTeam()
 const { canManage } = useCapabilities()
-const { complete: setupComplete } = useBillingSetup()
+const { complete: setupComplete, requireSetup } = useBillingSetup()
 
 const params = () => ({ team: currentTeam.value })
 const balance = useCall({ url: m(API.creditBalance), params, refetch: true })
@@ -23,6 +23,10 @@ const ledger = useCall({ url: m(API.creditLedger), params, refetch: true })
 
 const currency = computed(() => balance.data?.currency || 'INR')
 const showTopup = ref(false)
+
+function onTopup() {
+  if (requireSetup()) showTopup.value = true
+}
 
 function reloadAll() {
   balance.reload()
@@ -43,8 +47,7 @@ function isCredit(entry) {
           v-if="canManage"
           variant="solid"
           label="Top up"
-          :disabled="!setupComplete"
-          @click="showTopup = true"
+          @click="onTopup"
         />
       </template>
     </PageHeader>
@@ -62,7 +65,7 @@ function isCredit(entry) {
           <p class="text-p-sm text-ink-amber-3">
             Set your billing currency and address before topping up your wallet.
           </p>
-          <Button variant="subtle" label="Go to Settings" @click="router.push({ name: 'Address' })" />
+          <Button variant="subtle" label="Complete setup" @click="router.push({ name: 'Onboarding' })" />
         </div>
 
         <StatTile

--- a/dashboard/src/pages/billing/Overview.vue
+++ b/dashboard/src/pages/billing/Overview.vue
@@ -17,7 +17,7 @@ import { billingPeriod } from '@/utils/date'
 const router = useRouter()
 const { currentTeam } = useTeam()
 const { canManage } = useCapabilities()
-const { complete: setupComplete } = useBillingSetup()
+const { requireSetup } = useBillingSetup()
 
 const params = () => ({ team: currentTeam.value })
 const overview = useCall({ url: m(API.teamOverview), params, refetch: true })
@@ -86,6 +86,14 @@ const primaryMethod = computed(
 
 const showTopup = ref(false)
 const showAddMethod = ref(false)
+// Both actions move money, so they're gated on a complete profile: requireSetup()
+// diverts to onboarding when it isn't, and we don't open the dialog.
+function onTopup() {
+  if (requireSetup()) showTopup.value = true
+}
+function onAddMethod() {
+  if (requireSetup()) showAddMethod.value = true
+}
 function editProfile() {
   router.push({ name: 'Address' })
 }
@@ -104,8 +112,7 @@ function onToppedUp() {
           v-if="canManage"
           variant="solid"
           label="Top up"
-          :disabled="!setupComplete"
-          @click="showTopup = true"
+          @click="onTopup"
         />
       </template>
     </PageHeader>
@@ -212,7 +219,7 @@ function onToppedUp() {
                 v-else-if="canManage"
                 variant="subtle"
                 label="Add"
-                @click="showAddMethod = true"
+                @click="onAddMethod"
               >
                 <template #prefix><span class="lucide-plus size-4" /></template>
               </Button>

--- a/dashboard/src/pages/billing/PaymentMethods.vue
+++ b/dashboard/src/pages/billing/PaymentMethods.vue
@@ -14,7 +14,7 @@ import { successToast, errorToast } from '@/utils/toast'
 const router = useRouter()
 const { currentTeam } = useTeam()
 const { canManage } = useCapabilities()
-const { complete: setupComplete } = useBillingSetup()
+const { complete: setupComplete, requireSetup } = useBillingSetup()
 
 const methods = useCall({
   url: m(API.paymentMethods),
@@ -87,6 +87,10 @@ function rowActions(pm, index) {
 
 const showAdd = ref(false)
 
+function onAdd() {
+  if (requireSetup()) showAdd.value = true
+}
+
 function methodIcon(type) {
   return type === 'Card' ? 'lucide-credit-card' : 'lucide-smartphone'
 }
@@ -100,8 +104,7 @@ function methodIcon(type) {
           v-if="canManage"
           variant="solid"
           label="Add method"
-          :disabled="!setupComplete"
-          @click="showAdd = true"
+          @click="onAdd"
         />
       </template>
     </PageHeader>
@@ -114,7 +117,7 @@ function methodIcon(type) {
         <p class="text-p-sm text-ink-amber-3">
           Set your billing currency and address before adding a payment method.
         </p>
-        <Button variant="subtle" label="Go to Settings" @click="router.push({ name: 'Address' })" />
+        <Button variant="subtle" label="Complete setup" @click="router.push({ name: 'Onboarding' })" />
       </div>
 
       <div v-if="methods.loading && !methods.data" class="space-y-3">

--- a/dashboard/src/pages/billing/Settings.vue
+++ b/dashboard/src/pages/billing/Settings.vue
@@ -74,7 +74,7 @@ async function submitProfile() {
         <Button
           v-if="canManage"
           variant="solid"
-          label="Save details"
+          label="Save"
           :loading="saveProfile.loading"
           @click="submitProfile"
         />
@@ -161,15 +161,15 @@ async function submitProfile() {
           </div>
         </div>
 
-        <!-- Tax details -->
-        <div class="space-y-3">
+        <!-- Tax details — GSTIN is India-only. -->
+        <div v-if="isIndia" class="space-y-3">
           <h3 class="text-sm font-medium text-ink-gray-8">Tax details</h3>
           <div class="grid gap-4 sm:grid-cols-2">
             <FormControl
               v-model="form.gstin"
               label="GSTIN"
               :disabled="!canManage"
-              :description="isIndia ? 'Its first two digits must match the selected state.' : ''"
+              description="Its first two digits must match the selected state."
             />
           </div>
         </div>

--- a/dashboard/src/router/index.js
+++ b/dashboard/src/router/index.js
@@ -1,6 +1,8 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import AppLayout from '@/components/AppLayout.vue'
 import GroupGate from '@/components/GroupGate.vue'
+import { fetchBillingSetup } from '@/data/billingSetup'
+import { useTeam, whoReady } from '@/composables/useTeam'
 
 // The SPA is mounted under /dashboard (central/hooks.py website_route_rules).
 const routes = [
@@ -9,6 +11,11 @@ const routes = [
     component: AppLayout,
     children: [
       { path: '', redirect: '/billing' },
+
+      // First-run billing setup wizard — rendered inside the shell. Navigation
+      // stays open; money-moving actions divert here via requireSetup() until the
+      // billing profile is complete, passing a ?redirect= back to where they were.
+      { path: 'onboarding', name: 'Onboarding', component: () => import('@/pages/Onboarding.vue') },
 
       {
         path: 'billing',
@@ -64,4 +71,17 @@ const routes = [
 export const router = createRouter({
   history: createWebHistory('/dashboard/'),
   routes,
+})
+
+// Navigation is open regardless of billing-profile completeness — a team with an
+// incomplete profile can browse every tab. The profile is only enforced at the
+// point of a money-moving action (top-up, credits, payment method), where
+// useBillingSetup().requireSetup() diverts to /onboarding. Here we just warm the
+// shared setup cache for the active team so those pages render their state without
+// a flash. Identity is resolved first so we key on the active team, not a default.
+router.beforeEach(async () => {
+  await whoReady
+  const { currentTeam } = useTeam()
+  fetchBillingSetup(currentTeam.value) // non-blocking: warm cache, never redirect
+  return true
 })


### PR DESCRIPTION
Replace the removed all-or-nothing onboarding gate with a non-blocking, guided setup. Navigation stays open; money-moving actions divert to the wizard via useBillingSetup.requireSetup() and return via ?redirect=.

- Onboarding is now an accordion of collapsible sections driven by a declarative registry (onboarding/steps.js): each step reports its own completion and a section stays locked until every preceding mandatory step is complete. Adding a step (e.g. choose Atlas region) is a registry-only change.
- Steps extracted into self-contained components: BillingProfileStep, PaymentMethodStep, wrapped by OnboardingSection.
- Completed steps are read-only with no data-mutating action; the sole action once mandatory steps are done is "Go to dashboard".
- Billing profile grouped into Currency / Contact / Address / Tax; GSTIN/Tax shown only for India (onboarding + Settings).
- Gate top-up, credits, payment method, New VM, and Request access on a complete profile; re-route /onboarding with a non-blocking cache warm.

<img width="2768" height="1708" alt="screencapture-central-local-8011-dashboard-onboarding-2026-06-17-07_43_11" src="https://github.com/user-attachments/assets/b83c2d1e-8e20-4ed3-ac42-c845fdbfd84d" />

