### PR TITLE
E2e billing tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,152 @@
+name: E2E
+
+# No-mock Playwright billing suite (apps/central/e2e). It drives the real
+# dashboard against a real bench and the real Stripe/Razorpay TEST sandboxes, so it
+# needs test-mode gateway keys. Those are repo secrets and aren't exposed to fork
+# PRs, so this runs on push to develop and on manual dispatch — not on PRs.
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-central-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    name: Playwright (no mocks)
+
+    services:
+      redis-cache:
+        image: redis:alpine
+        ports:
+          - 13000:6379
+      redis-queue:
+        image: redis:alpine
+        ports:
+          - 11000:6379
+      mariadb:
+        image: mariadb:11.8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+
+    env:
+      # The suite needs real test-mode gateway keys. Set these as repo secrets.
+      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+      STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
+      RAZORPAY_KEY_ID: ${{ secrets.RAZORPAY_KEY_ID }}
+      RAZORPAY_KEY_SECRET: ${{ secrets.RAZORPAY_KEY_SECRET }}
+      SITE: test_site
+      BENCH: /home/runner/frappe-bench
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v6
+
+      - name: Require gateway test keys
+        run: |
+          if [ -z "$STRIPE_SECRET_KEY" ] || [ -z "$RAZORPAY_KEY_ID" ]; then
+            echo "::error::E2E needs test-mode gateway keys. Set STRIPE_SECRET_KEY," \
+                 "STRIPE_PUBLISHABLE_KEY, RAZORPAY_KEY_ID and RAZORPAY_KEY_SECRET as repo secrets."
+            exit 1
+          fi
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          check-latest: true
+
+      - name: Install MariaDB client
+        run: |
+          sudo apt update
+          sudo apt-get install -y mariadb-client
+
+      - name: Init bench
+        run: |
+          pip install frappe-bench
+          bench init --skip-redis-config-generation --skip-assets --python "$(which python)" "$BENCH"
+
+      - name: Install app + site
+        working-directory: /home/runner/frappe-bench
+        run: |
+          bench get-app central "$GITHUB_WORKSPACE"
+          bench setup requirements --dev
+          bench new-site --db-root-password root --admin-password admin "$SITE"
+          bench --site "$SITE" install-app central
+        env:
+          CI: 'Yes'
+
+      - name: Build dashboard SPA + assets
+        working-directory: /home/runner/frappe-bench
+        run: |
+          cd apps/central/dashboard && yarn install --frozen-lockfile && yarn build
+          cd /home/runner/frappe-bench && bench build --app central
+        env:
+          CI: 'Yes'
+
+      - name: Configure site (test mode + real test-mode gateway keys)
+        working-directory: /home/runner/frappe-bench
+        run: |
+          bench --site "$SITE" set-config allow_tests true
+          bench --site "$SITE" set-config developer_mode 0
+          bench --site "$SITE" set-config stripe_secret_key "$STRIPE_SECRET_KEY"
+          bench --site "$SITE" set-config stripe_publishable_key "$STRIPE_PUBLISHABLE_KEY"
+          bench --site "$SITE" set-config razorpay_key_id "$RAZORPAY_KEY_ID"
+          bench --site "$SITE" set-config razorpay_key_secret "$RAZORPAY_KEY_SECRET"
+
+      - name: Seed catalog + payment gateways
+        working-directory: /home/runner/frappe-bench
+        # The demo seed builds the plan catalog, trust tiers and the Stripe/Razorpay
+        # gateways the suite charges against. Their stored keys are placeholders; the
+        # adapters prefer the real test keys we just put in site config at runtime.
+        run: bench --site "$SITE" execute central.billing.demo.demo.seed
+
+      - name: Serve bench
+        working-directory: /home/runner/frappe-bench
+        run: |
+          echo "127.0.0.1 $SITE" | sudo tee -a /etc/hosts
+          nohup bench serve --port 8000 > "$BENCH/logs/web.log" 2>&1 &
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" -H "Host: $SITE" http://localhost:8000/api/method/ping || true)
+            [ "$code" = "200" ] && { echo "web up"; break; }
+            sleep 1
+          done
+          curl -sf -H "Host: $SITE" http://localhost:8000/api/method/ping
+
+      - name: Install Playwright
+        working-directory: /home/runner/frappe-bench/apps/central
+        # --ignore-scripts skips the dashboard postinstall (already built above).
+        run: |
+          npm ci --ignore-scripts
+          npx playwright install --with-deps chromium
+
+      - name: Run E2E
+        working-directory: /home/runner/frappe-bench/apps/central
+        run: npx playwright test
+        env:
+          E2E_BASE_URL: http://${{ env.SITE }}:8000
+          CI: 'Yes'
+
+      - name: Upload report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: /home/runner/frappe-bench/apps/central/playwright-report
+          retention-days: 14
+
+      - name: Web log on failure
+        if: failure()
+        run: tail -n 200 "$BENCH/logs/web.log" || true

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,9 @@ jspm_packages/
 central/public/dashboard/
 central/www/dashboard.html
 central/public/node_modules
+
+# Playwright e2e suite artifacts (see e2e/README.md)
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/central/billing/catalog/subscriptions.py
+++ b/central/billing/catalog/subscriptions.py
@@ -2,16 +2,18 @@
 # For license information, please see license.txt
 """Subscription intent + the two-axis state model (issue #04).
 
-A Central Subscription is the customer's *intent/contract*, not billing truth —
-the authoritative runtime record is born at the cluster and reported by the
-Agent (#03). State lives on two orthogonal axes, never one enum:
+A Central Subscription is the customer's *intent/contract*. Agentless (ADR 0006):
+Central provisions via the cluster manager and writes the authoritative runtime
+record (the price-lock) itself, at provision time — see `provision_subscription`.
+State lives on two orthogonal axes, never one enum:
 
-  - operational (running / stopped / terminated) — owned by the Agent
+  - operational (running / stopped / terminated) — Central's record of cluster-
+    manager state (read from / reported by the cluster manager)
   - account standing (current / past_due / suspended) — owned by Central, here
 
-Central never stores the operational axis: a resource can be `running` and
-`past_due` at once (normal grace), so collapsing them would lose information.
-Every transition writes an append-only Subscription Change.
+Central never collapses the axes: a resource can be `running` and `past_due` at
+once (normal grace), so one enum would lose information. Every standing transition
+writes an append-only Subscription Change.
 """
 
 import frappe
@@ -63,9 +65,10 @@ def create_subscription(
 	gateway: str | None = None,
 	changed_by: str | None = None,
 ):
-	"""Record a subscription INTENT. Provisioning happens at the cluster; the
-	authoritative event (resource_id, shown_rate) is born there and reported by
-	the Agent. This only captures what the customer asked for."""
+	"""Record a subscription INTENT — what the customer asked for. The actual
+	provisioning (calling the cluster manager and writing the price-lock) is
+	`provision_subscription`; this captures the contract only, so it stays usable
+	for fixtures and intent-only flows."""
 	doc = frappe.get_doc(
 		{
 			"doctype": "Subscription",
@@ -84,9 +87,52 @@ def create_subscription(
 	return doc
 
 
+def provision_subscription(
+	team: str,
+	cluster: str,
+	plan: str,
+	billing_cycle: str = "Monthly",
+	start_date=None,
+	resource_id: str | None = None,
+	default_payment_method: str | None = None,
+	gateway: str | None = None,
+	changed_by: str | None = None,
+):
+	"""Provision a subscription the agentless way (ADR 0006): record the intent,
+	then — as the *same* component — write the authoritative runtime record.
+
+	Central calls the cluster manager to create the resource (here the seam mints a
+	`resource_id`; a real impl uses the id the cluster manager returns), then writes
+	the price-lock at the catalog rate for the team's currency + cluster. Because the
+	one component both provisions and locks, the rate shown is the rate locked — no
+	agent push, no reconciliation gap. Returns the subscription + the locked handles.
+	"""
+	from central.billing.platform.sync import record_usage_events
+
+	sub = create_subscription(
+		team, cluster, plan, billing_cycle=billing_cycle, start_date=start_date,
+		default_payment_method=default_payment_method, gateway=gateway, changed_by=changed_by,
+	)
+
+	currency = frappe.db.get_value("Billing Profile", team, "currency") or "INR"
+	shown_rate = frappe.get_doc("Plan", plan).get_rate(currency, cluster)
+	resource_id = resource_id or f"res-{frappe.generate_hash(length=10)}"
+	effective_from = f"{sub.start_date} 00:00:00"
+
+	record_usage_events([{
+		"event_id": f"prov-{sub.name}-{resource_id}",
+		"team": team, "resource_id": resource_id, "cluster": cluster, "plan": plan,
+		"shown_rate": shown_rate, "currency": currency,
+		"event_type": "subscribed", "effective_from": effective_from, "effective_to": None,
+	}])
+
+	return {"subscription": sub.name, "resource_id": resource_id,
+			"shown_rate": shown_rate, "currency": currency}
+
+
 def change_plan(subscription: str, new_plan: str, changed_by: str | None = None):
-	"""Change the requested plan (intent). A new price-lock is created at the
-	cluster on reprovision (#03) — this records the contract change only."""
+	"""Change the requested plan (intent). Central writes a new price-lock segment
+	when it reprovisions (ADR 0006); this records the contract change only."""
 	doc = frappe.get_doc("Subscription", subscription)
 	old_plan = doc.plan
 	if new_plan == old_plan:
@@ -108,8 +154,8 @@ def change_payment_method(subscription: str, new_method: str, changed_by: str | 
 
 def cancel_subscription(subscription: str, changed_by: str | None = None):
 	"""Cancel the subscription intent. The contract record is kept; the
-	cancellation is logged. Stopping/terminating running resources is a separate
-	operational concern owned by the Agent."""
+	cancellation is logged. Stopping/terminating the running resource is a separate
+	operational step Central drives via the cluster manager (ADR 0006)."""
 	_record_change(subscription, "Cancelled", changed_by=changed_by)
 	return frappe.get_doc("Subscription", subscription)
 
@@ -141,13 +187,11 @@ def set_standing(subscription: str, new_standing: str, changed_by: str | None = 
 	return doc
 
 
-def reconcile_with_agent_event(subscription: str, resource_id: str) -> dict:
-	"""Reconcile a subscription's intent against the authoritative cluster event.
-
-	The real subscription event is born at the cluster; Central holds the price
-	lock keyed by `resource_id` (#03). This compares the intended plan with the
-	plan actually locked: a missing lock means the cluster has not yet reported
-	(intent outstanding); a plan mismatch is surfaced for follow-up.
+def reconcile_subscription_resource(subscription: str, resource_id: str) -> dict:
+	"""Reconcile a subscription's intent against the price-lock Central wrote when it
+	provisioned the resource (keyed by `resource_id`). A missing lock means the
+	resource hasn't been provisioned yet (intent outstanding); a plan mismatch is
+	surfaced for follow-up.
 	"""
 	from central.billing.revenue.pricelock import _open_lock
 
@@ -163,3 +207,7 @@ def reconcile_with_agent_event(subscription: str, resource_id: str) -> dict:
 		"locked_plan": locked_plan,
 		"resource_id": resource_id,
 	}
+
+
+# Deprecated agent-era name — agentless, Central writes the lock at provision time.
+reconcile_with_agent_event = reconcile_subscription_resource

--- a/central/billing/platform/sync.py
+++ b/central/billing/platform/sync.py
@@ -1,94 +1,62 @@
 # Copyright (c) 2026, Frappe and contributors
 # For license information, please see license.txt
-"""Central -> Agent synchronisation.
+"""Usage recording — Central writes the runtime it bills from.
 
-Central pushes plan definitions plus a display price to each regional Agent's
-Plan Cache. The communication surface is intentionally tiny; this module owns
-the Central side of the plan push.
+Agentless (ADR 0006): there is no Subscription Agent and no push/pull sync.
+Central provisions and meters via the cluster manager and records what it drives
+directly — the event log (subscribed / changed / cancelled, per `resource_id`
+with `shown_rate` + currency) into the price-lock ledger, and metered-usage
+rollups into the bounded rollup store. These are *internal* recording calls made
+by the provisioning/metering paths, not whitelisted endpoints an external party
+posts to (which would let any caller forge usage and so a price lock).
 """
 
 import frappe
-import requests
-
-RECEIVE_PLANS_PATH = "/api/method/press_billing_agent.sync.receive_plans"
 
 
-def _agent_auth_headers() -> dict:
-	"""Authorization header for the cluster-scoped Agent API key.
+def record_usage_events(events: list | str) -> dict:
+	"""Record provisioning events into the price-lock ledger as Central drives them.
 
-	Credentials live in site config (agent_api_key / agent_api_secret) and are
-	never exposed through any customer or admin API.
-	"""
-	key = frappe.conf.get("agent_api_key")
-	secret = frappe.conf.get("agent_api_secret")
-	if key and secret:
-		return {"Authorization": f"token {key}:{secret}"}
-	return {}
-
-
-@frappe.whitelist()
-def push_plans_to_agent(agent_url: str, plans: list | str) -> dict:
-	"""Push plan identity + composition + display price to an Agent's Plan Cache.
-
-	Cheap and rare (few clusters). The Agent stores these display-only; it
-	computes nothing with them.
-	"""
-	if isinstance(plans, str):
-		plans = frappe.parse_json(plans)
-
-	payload = [frappe.get_doc("Plan", name).as_pricing() for name in plans]
-
-	url = agent_url.rstrip("/") + RECEIVE_PLANS_PATH
-	response = requests.post(
-		url=url,
-		json={"plans": payload},
-		headers=_agent_auth_headers(),
-		timeout=30,
-	)
-	response.raise_for_status()
-	return response.json().get("message")
-
-
-@frappe.whitelist()
-def receive_usage_events(events: list | str) -> dict:
-	"""Agent -> Central: ingest reported plan-change events into the lock ledger.
-
-	Each event carries a stable `event_id`; locking is idempotent on it, so the
-	Agent can safely re-push. Only acknowledged event_ids are returned — the
-	Agent marks exactly those `synced_to_central`, so a partial failure is
-	retried on the next push rather than silently dropped.
+	Each event carries a stable `event_id`; locking is idempotent on it, so a
+	replay (e.g. a metering refresh from the cluster manager) is a safe no-op.
+	Returns the handled event_ids.
 	"""
 	from central.billing.revenue.pricelock import lock_from_event
 
 	if isinstance(events, str):
 		events = frappe.parse_json(events)
 
-	acknowledged = []
+	recorded = []
 	for event in events:
 		event_id = lock_from_event(event)
 		if event_id:
-			acknowledged.append(event_id)
+			recorded.append(event_id)
 
-	return {"acknowledged": acknowledged}
+	# `acknowledged` kept alongside `recorded` for back-compat with existing callers.
+	return {"recorded": recorded, "acknowledged": recorded}
 
 
-@frappe.whitelist()
-def receive_meter_rollups(meters: list | str) -> dict:
-	"""Agent -> Central: ingest metered rollups into the bounded rollup store.
+def record_meter_rollups(meters: list | str) -> dict:
+	"""Record metered rollups into the bounded rollup store as Central meters.
 
-	Idempotent on each rollup's idempotency_key; a re-push replaces the period
-	figure rather than adding. Returns the acknowledged keys so the Agent marks
-	exactly those synced.
+	Idempotent on each rollup's idempotency_key; a refresh replaces the period
+	figure rather than adding. Returns the handled keys.
 	"""
 	from central.billing.revenue.metering import ingest_rollup
 
 	if isinstance(meters, str):
 		meters = frappe.parse_json(meters)
 
-	acknowledged = []
+	recorded = []
 	for meter in meters:
 		key = ingest_rollup(meter)
 		if key:
-			acknowledged.append(key)
+			recorded.append(key)
 
-	return {"acknowledged": acknowledged}
+	return {"recorded": recorded, "acknowledged": recorded}
+
+
+# Deprecated agent-era names — kept so existing callers/tests keep working while
+# they migrate to record_*. The "Agent → Central push" they implied is gone.
+receive_usage_events = record_usage_events
+receive_meter_rollups = record_meter_rollups

--- a/central/billing/revenue/invoicing/generate.py
+++ b/central/billing/revenue/invoicing/generate.py
@@ -14,13 +14,14 @@ from central.billing.revenue.invoicing.lines import compute_line_items
 
 
 def reconcile_subscription(subscription_doc):
-	"""Pull from the Agent only if the local data is stale.
+	"""Refresh the current period's metered figures from the cluster manager if stale.
 
-	Sync is push-primary (#03), so in the common case the event-log segments are
-	already on Central and this is a no-op. A real pull would call the Agent's
-	get_team_usage; wired here as the seam, exercised by the reconciliation job.
+	Agentless (ADR 0006): Central wrote the event-log segments itself at provision
+	time, so in the common case they're already local and this is a no-op. A real
+	refresh would read live usage from the cluster manager; wired here as the seam,
+	exercised by the reconciliation job.
 	"""
-	return False  # not stale — use what was pushed
+	return False  # not stale — use what Central already recorded
 
 
 def generate_draft_invoice(subscription: str, period_start, period_end):

--- a/central/billing/tests/e2e.py
+++ b/central/billing/tests/e2e.py
@@ -279,6 +279,24 @@ def deliver_webhook(attempt: str) -> dict:
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
+def refund(payment_attempt: str, amount: float | None = None, destination: str = "Source") -> dict:
+	"""Refund a captured Payment Attempt (issue #15). `destination=Source` issues a
+	**real** Stripe refund of the captured PaymentIntent and marks a full refund's
+	attempt Refunded; `Wallet` books the amount as a wallet credit (an overcharge
+	correction). The invoice stays Paid either way."""
+	_enter_test_mode()
+	from central.billing.payments import refunds
+
+	doc = refunds.issue_refund(
+		payment_attempt, amount=frappe.utils.flt(amount) if amount else None,
+		destination=destination, reason=None,  # wallet note defaults to "Overcharge refund for …"
+	)
+	frappe.db.commit()
+	return {"refund": doc.name, "status": doc.status, "destination": destination,
+			"amount": frappe.utils.flt(doc.amount)}
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
 def dun(invoice: str, days: int = 7) -> dict:
 	"""Run one day of the real dunning state machine for an invoice, as if `days`
 	had elapsed past its due date (process_invoice_dunning with a simulated `now`).

--- a/central/billing/tests/e2e.py
+++ b/central/billing/tests/e2e.py
@@ -86,8 +86,9 @@ def teardown(team: str | None = None, email: str | None = None) -> dict:
 	if team and frappe.db.exists("Team", team):
 		owner = frappe.db.get_value("Team", team, "owner_user")
 		for dt in (
-			"Invoice", "Payment Attempt", "Payment Method", "Credit Ledger Entry",
-			"Gateway Customer", "Billing Profile", "Trust Tier", "Tax Profile",
+			"Invoice", "Payment Attempt", "Subscription", "Payment Method",
+			"Credit Ledger Entry", "Gateway Customer", "Billing Profile",
+			"Trust Tier", "Tax Profile",
 		):
 			frappe.db.delete(dt, {"team": team})
 		frappe.db.delete("Credit Wallet", {"team": team})
@@ -132,6 +133,144 @@ def finish_razorpay_topup(team: str, gateway: str, order_id: str, amount: float)
 		team=team, amount=amount, gateway=gateway,
 		razorpay_order_id=order_id, razorpay_payment_id=payment_id, razorpay_signature=signature,
 	)
+
+
+# --- settlement helpers (invoice charge + credits waterfall) -----------------
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def add_credits(team: str, amount: float, currency: str | None = None) -> dict:
+	"""Fund the team's wallet through the real credit ledger (credits.purchase) —
+	the same append-only Credit Ledger Entry a confirmed top-up books. Lets a
+	settlement spec arrange a known balance without driving a gateway top-up."""
+	_enter_test_mode()
+	from central.billing.revenue import credits
+
+	currency = currency or frappe.db.get_value("Billing Profile", team, "currency") or "USD"
+	credits.purchase(team, frappe.utils.flt(amount), currency, note="e2e wallet funding")
+	frappe.db.commit()
+	return {"team": team, "balance": credits.get_balance(team)["balance"]}
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def save_test_card(team: str) -> dict:
+	"""Attach a **real** Stripe test card to the team so invoice charges hit the real
+	off-session PaymentIntent path (no mock). Builds a PaymentMethod from `tok_visa`
+	on the team's real gateway customer, then records the active Payment Method the
+	collection loop charges. Card teams are USD (USD's default gateway is Stripe)."""
+	_enter_test_mode()
+	import stripe
+
+	from central.billing.gateways.registry import get_adapter, resolve_gateway_for_currency
+	from central.billing.payments.payments import densify_priorities, ensure_gateway_customer
+
+	currency = frappe.db.get_value("Billing Profile", team, "currency") or "USD"
+	gateway = resolve_gateway_for_currency(currency)
+	adapter = get_adapter(frappe.get_doc("Payment Gateway", gateway))
+	customer_id = ensure_gateway_customer(team, gateway, adapter)
+
+	stripe.api_key = adapter.get_credential("api_secret")
+	pm = stripe.PaymentMethod.create(type="card", card={"token": "tok_visa"})
+	stripe.PaymentMethod.attach(pm.id, customer=customer_id)
+
+	name = frappe.get_doc({
+		"doctype": "Payment Method", "team": team, "gateway": gateway, "method_type": "Card",
+		"status": "Active", "display_label": "Visa ····4242", "is_default": 1,
+		"gateway_method_id": pm.id, "gateway_customer_id": customer_id,
+		"expiry_month": 12, "expiry_year": 2034, "validated_at": frappe.utils.now_datetime(),
+	}).insert(ignore_permissions=True).name
+	densify_priorities(team)
+	frappe.db.commit()
+	return {"payment_method": name, "gateway": gateway, "gateway_method_id": pm.id}
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def make_invoice(team: str, total: float = 1180, currency: str | None = None,
+				 link_card: int = 0) -> dict:
+	"""Create a Draft Billable invoice (subtotal + tax = total) the waterfall can
+	open and collect. Returns its name.
+
+	With `link_card`, attach a minimal Subscription whose `default_payment_method`
+	is the team's active card — real invoices always come from a subscription, and
+	the manual 'Pay' button (`pay_invoice`) resolves the method through it."""
+	_enter_test_mode()
+	currency = currency or frappe.db.get_value("Billing Profile", team, "currency") or "USD"
+	total = frappe.utils.flt(total)
+	tax = frappe.utils.flt(total - total / 1.18, 2)  # treat total as tax-inclusive at 18%
+	subtotal = frappe.utils.flt(total - tax, 2)
+
+	subscription = None
+	if int(link_card):
+		card = frappe.db.get_value(
+			"Payment Method", {"team": team, "status": "Active"}, ["name", "gateway"], as_dict=True
+		)
+		if card:
+			subscription = frappe.get_doc({
+				"doctype": "Subscription", "team": team, "status": "Active",
+				"default_payment_method": card.name, "gateway": card.gateway,
+			}).insert(ignore_permissions=True).name
+
+	name = frappe.get_doc({
+		"doctype": "Invoice", "team": team, "invoice_type": "Billable", "status": "Draft",
+		"subscription": subscription,
+		"period_start": "2026-06-01", "period_end": "2026-06-30", "currency": currency,
+		"subtotal": subtotal, "output_tax_type": "GST" if currency == "INR" else "VAT",
+		"output_tax_amount": tax, "total": total, "tds_amount": 0, "expected_collection": total,
+		"items": [{"resource_type": "bundle", "rate": subtotal, "days": 30, "amount": subtotal}],
+	}).insert(ignore_permissions=True).name
+	frappe.db.commit()
+	return {"invoice": name, "total": total, "currency": currency, "subscription": subscription}
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def settle(team: str, invoice: str, collect: int = 1) -> dict:
+	"""Run the real credits-then-card waterfall (open_and_collect): apply wallet
+	credits, then — if `collect` — charge the remainder to the team's card via the
+	real off-session PaymentIntent. With `collect=0` the invoice is opened (credits
+	applied) but left for the UI 'Pay' button to charge. Returns the waterfall
+	result, plus the in-flight attempt name so the spec can deliver its webhook."""
+	_enter_test_mode()
+	from central.billing.revenue.invoicing.lifecycle import open_and_collect
+
+	result = open_and_collect(invoice, collect=bool(int(collect)))
+	attempt = frappe.db.get_value(
+		"Payment Attempt", {"invoice": invoice, "status": "Captured"}, "name"
+	)
+	frappe.db.commit()
+	return {**result, "attempt": attempt}
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def deliver_webhook(attempt: str) -> dict:
+	"""Deliver the gateway success webhook for a captured attempt — the only path
+	that flips an Open invoice to Paid (charges.apply_webhook → _settle_invoice).
+
+	Stripe/Razorpay webhooks can't reach a local bench, so we build the Webhook
+	Event from the attempt's **real** captured transaction id and run the **real**
+	apply_webhook. Only the HTTP signature check (a separate security gate covered
+	by unit tests) is skipped; the settlement logic and the txn id are real."""
+	_enter_test_mode()
+	from central.billing.payments import charges
+
+	att = frappe.get_doc("Payment Attempt", attempt)
+	adapter_key = frappe.db.get_value("Payment Gateway", att.gateway, "adapter_key")
+	if adapter_key == "Stripe":
+		event_type = "payment_intent.succeeded"
+		payload = {"id": f"evt_e2e{frappe.generate_hash(10)}", "type": event_type,
+				   "data": {"object": {"id": att.gateway_transaction_id}}}
+	else:
+		event_type = "payment.captured"
+		payload = {"event": event_type,
+				   "payload": {"payment": {"entity": {"id": att.gateway_transaction_id}}}}
+
+	event = frappe.get_doc({
+		"doctype": "Webhook Event", "gateway": att.gateway, "event_type": event_type,
+		"gateway_event_id": payload.get("id") or frappe.generate_hash(12),
+		"status": "Received", "raw_payload": frappe.as_json(payload),
+	}).insert(ignore_permissions=True)
+	result = charges.apply_webhook(event.name)
+	frappe.db.commit()
+	return result
 
 
 # --- scenario builders -------------------------------------------------------

--- a/central/billing/tests/e2e.py
+++ b/central/billing/tests/e2e.py
@@ -153,11 +153,14 @@ def add_credits(team: str, amount: float, currency: str | None = None) -> dict:
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
-def save_test_card(team: str) -> dict:
+def save_test_card(team: str, token: str = "tok_visa") -> dict:
 	"""Attach a **real** Stripe test card to the team so invoice charges hit the real
-	off-session PaymentIntent path (no mock). Builds a PaymentMethod from `tok_visa`
-	on the team's real gateway customer, then records the active Payment Method the
-	collection loop charges. Card teams are USD (USD's default gateway is Stripe)."""
+	off-session PaymentIntent path (no mock). Builds a PaymentMethod from `token` on
+	the team's real gateway customer, then records the active Payment Method the
+	collection loop charges. Card teams are USD (USD's default gateway is Stripe).
+
+	`token="tok_chargeCustomerFail"` attaches a card that Stripe declines on the real
+	off-session charge (but attaches cleanly) — for the dunning/decline path."""
 	_enter_test_mode()
 	import stripe
 
@@ -170,13 +173,14 @@ def save_test_card(team: str) -> dict:
 	customer_id = ensure_gateway_customer(team, gateway, adapter)
 
 	stripe.api_key = adapter.get_credential("api_secret")
-	pm = stripe.PaymentMethod.create(type="card", card={"token": "tok_visa"})
+	pm = stripe.PaymentMethod.create(type="card", card={"token": token})
 	stripe.PaymentMethod.attach(pm.id, customer=customer_id)
 
+	declined = token != "tok_visa"
 	name = frappe.get_doc({
 		"doctype": "Payment Method", "team": team, "gateway": gateway, "method_type": "Card",
-		"status": "Active", "display_label": "Visa ····4242", "is_default": 1,
-		"gateway_method_id": pm.id, "gateway_customer_id": customer_id,
+		"status": "Active", "display_label": "Visa ····0341" if declined else "Visa ····4242",
+		"is_default": 1, "gateway_method_id": pm.id, "gateway_customer_id": customer_id,
 		"expiry_month": 12, "expiry_year": 2034, "validated_at": frappe.utils.now_datetime(),
 	}).insert(ignore_permissions=True).name
 	densify_priorities(team)
@@ -207,6 +211,7 @@ def make_invoice(team: str, total: float = 1180, currency: str | None = None,
 		if card:
 			subscription = frappe.get_doc({
 				"doctype": "Subscription", "team": team, "status": "Active",
+				"account_standing": "Current",
 				"default_payment_method": card.name, "gateway": card.gateway,
 			}).insert(ignore_permissions=True).name
 
@@ -269,6 +274,22 @@ def deliver_webhook(attempt: str) -> dict:
 		"status": "Received", "raw_payload": frappe.as_json(payload),
 	}).insert(ignore_permissions=True)
 	result = charges.apply_webhook(event.name)
+	frappe.db.commit()
+	return result
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def dun(invoice: str, days: int = 7) -> dict:
+	"""Run one day of the real dunning state machine for an invoice, as if `days`
+	had elapsed past its due date (process_invoice_dunning with a simulated `now`).
+	`days=7` → invoice Overdue + standing Past Due; `days=14` → Suspended. Lets the
+	spec walk the escalation without waiting real calendar days."""
+	_enter_test_mode()
+	from central.billing.revenue import dunning
+
+	due = frappe.db.get_value("Invoice", invoice, "due_date")
+	now = frappe.utils.add_days(frappe.utils.getdate(due), int(days))
+	result = dunning.process_invoice_dunning(invoice, now=now)
 	frappe.db.commit()
 	return result
 

--- a/central/billing/tests/e2e.py
+++ b/central/billing/tests/e2e.py
@@ -77,22 +77,22 @@ def seed(scenario: str = "profile_pending", currency: str = "INR") -> dict:
 @frappe.whitelist(allow_guest=True, methods=["POST"])
 def teardown(team: str | None = None, email: str | None = None) -> dict:
 	"""Delete everything `seed()` created for one spec. Best-effort and idempotent:
-	a spec calls this in its afterEach, so it must never raise on partially-built
-	state. Billing rows go first (they link the team), then the team, then the user
-	(who is the team's owner). `email` is also deleted directly in case the team was
-	never created."""
+	a spec calls this in its afterEach, so it must never raise — and must always
+	reach the user deletion even if one row delete fails (a single failing step must
+	never leak a team/user). Each delete runs in its own savepoint; the team and its
+	users go last."""
 	_enter_test_mode()
 
 	if team and frappe.db.exists("Team", team):
 		owner = frappe.db.get_value("Team", team, "owner_user")
 		for dt in (
 			"Invoice", "Payment Attempt", "Subscription", "Payment Method",
-			"Credit Ledger Entry", "Gateway Customer", "Billing Profile",
+			"Credit Ledger Entry", "Credit Wallet", "Gateway Customer",
+			"Billing Notification Log", "Notification Preference", "Billing Profile",
 			"Trust Tier", "Tax Profile",
 		):
-			frappe.db.delete(dt, {"team": team})
-		frappe.db.delete("Credit Wallet", {"team": team})
-		frappe.delete_doc("Team", team, force=True, ignore_permissions=True)
+			_safe(frappe.db.delete, dt, {"team": team})
+		_safe(frappe.delete_doc, "Team", team, force=True, ignore_permissions=True)
 		_delete_user(owner)
 
 	_delete_user(email)
@@ -273,6 +273,81 @@ def deliver_webhook(attempt: str) -> dict:
 	return result
 
 
+# --- INR rails (e-mandate + UPI Autopay mandate) -----------------------------
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def set_trust_tier(team: str, max_spend: float = 50000) -> dict:
+	"""Give the team a trust tier with a spend cap — the UPI Autopay mandate ceiling
+	is this cap, and UPI is only eligible below the ₹1,00,000 recurring limit."""
+	_enter_test_mode()
+	if frappe.db.exists("Trust Tier", team):
+		frappe.delete_doc("Trust Tier", team, force=True, ignore_permissions=True)
+	frappe.get_doc({
+		"doctype": "Trust Tier", "team": team, "tier": "t1",
+		"max_spend": frappe.utils.flt(max_spend), "manual_override": 1,
+	}).insert(ignore_permissions=True)
+	frappe.db.commit()
+	return {"team": team, "max_spend": frappe.utils.flt(max_spend)}
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def set_collection_mode(team: str, mode: str) -> dict:
+	"""Set the team's collection mode directly (e.g. `emandate`). The customer-facing
+	endpoint only allows manual_checkout/prepaid; `emandate` is a system default, so
+	tests set it on the profile."""
+	_enter_test_mode()
+	frappe.db.set_value("Billing Profile", team, "collection_mode", mode, update_modified=False)
+	frappe.db.commit()
+	return {"team": team, "collection_mode": mode}
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def predebit(invoice: str) -> dict:
+	"""Run the e-mandate pre-debit step for an Open invoice: send the RBI pre-debit
+	notice and arm the 24h debit window, or fork to Action Required if it's over the
+	₹15,000 silent ceiling (emandate.schedule_predebit — all real, no gateway)."""
+	_enter_test_mode()
+	from central.billing.payments import emandate
+
+	result = emandate.schedule_predebit(invoice)
+	frappe.db.commit()
+	return result
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def finish_mandate(payment_method: str, order_id: str) -> dict:
+	"""Confirm a UPI Autopay / card mandate at the gateway boundary — the spec drives
+	the real UI until the genuine Razorpay recurring sheet opens against a *real*
+	order (setup_payment_method_order), then this finishes the authorisation the
+	hosted sheet can't be automated through. It signs the real order with the real
+	test secret (the checkout-callback HMAC `confirm_mandate` verifies) and supplies
+	a token id — the one synthetic value, since a Razorpay-issued recurring token
+	needs the bank/UPI auth flow. Flips the Payment Method to Active."""
+	import hashlib
+	import hmac
+
+	_enter_test_mode()
+	from central.billing.gateways.registry import get_adapter
+	from central.billing.payments import mandates
+
+	method = frappe.get_doc("Payment Method", payment_method)
+	adapter = get_adapter(frappe.get_doc("Payment Gateway", method.gateway))
+	secret = adapter.get_credential("api_secret")
+	payment_id = f"pay_e2e{frappe.generate_hash(length=14)}"
+	signature = hmac.new(
+		secret.encode(), f"{order_id}|{payment_id}".encode(), hashlib.sha256
+	).hexdigest()
+
+	confirmed = mandates.confirm_mandate(payment_method, {
+		"razorpay_order_id": order_id, "razorpay_payment_id": payment_id,
+		"razorpay_signature": signature, "razorpay_token_id": f"token_e2e{frappe.generate_hash(12)}",
+	})
+	frappe.db.commit()
+	return {"payment_method": confirmed.name, "status": confirmed.status,
+			"mandate_max_amount": confirmed.mandate_max_amount}
+
+
 # --- scenario builders -------------------------------------------------------
 
 
@@ -296,6 +371,18 @@ def _seed_invoices(team: str, currency: str) -> None:
 # --- helpers -----------------------------------------------------------------
 
 
+def _safe(fn, *args, **kwargs) -> None:
+	"""Run a teardown delete in its own savepoint, swallowing any failure (and
+	rolling that step back) so one bad delete can't abort the rest of teardown —
+	the team and user must always get cleaned up."""
+	sp = f"sp{frappe.generate_hash(8)}"
+	frappe.db.savepoint(sp)
+	try:
+		fn(*args, **kwargs)
+	except Exception:
+		frappe.db.rollback(save_point=sp)
+
+
 def _delete_user(email: str | None) -> None:
 	if email and frappe.db.exists("User", email):
-		frappe.delete_doc("User", email, force=True, ignore_permissions=True)
+		_safe(frappe.delete_doc, "User", email, force=True, ignore_permissions=True)

--- a/central/billing/tests/e2e.py
+++ b/central/billing/tests/e2e.py
@@ -86,10 +86,10 @@ def teardown(team: str | None = None, email: str | None = None) -> dict:
 	if team and frappe.db.exists("Team", team):
 		owner = frappe.db.get_value("Team", team, "owner_user")
 		for dt in (
-			"Invoice", "Payment Attempt", "Subscription", "Payment Method",
+			"Refund", "Invoice", "Payment Attempt", "Subscription", "Payment Method",
 			"Credit Ledger Entry", "Credit Wallet", "Gateway Customer",
-			"Billing Notification Log", "Notification Preference", "Billing Profile",
-			"Trust Tier", "Tax Profile",
+			"Price Lock", "Usage Rollup", "Billing Notification Log",
+			"Notification Preference", "Billing Profile", "Trust Tier", "Tax Profile",
 		):
 			_safe(frappe.db.delete, dt, {"team": team})
 		_safe(frappe.delete_doc, "Team", team, force=True, ignore_permissions=True)
@@ -310,6 +310,31 @@ def dun(invoice: str, days: int = 7) -> dict:
 	result = dunning.process_invoice_dunning(invoice, now=now)
 	frappe.db.commit()
 	return result
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def generate_invoice(team: str, monthly_rate: float = 3000,
+					 period_start: str = "2026-06-01", period_end: str = "2026-06-30") -> dict:
+	"""Generate an invoice through the **real agentless pipeline** (no fabrication):
+	provision a subscription (which writes the price-lock at the catalog rate, ADR
+	0006) → `generate_draft_invoice` computes line items from that lock over the
+	period. Returns the Draft invoice + its computed subtotal so the spec can
+	cross-check the rendered amount."""
+	_enter_test_mode()
+	from central.billing.catalog import subscriptions
+	from central.billing.revenue import invoicing
+	from central.billing.tests.utils import make_plan
+
+	currency = frappe.db.get_value("Billing Profile", team, "currency") or "INR"
+	rate = frappe.utils.flt(monthly_rate)
+	plan = make_plan("e2e-gen-plan", rates=[{"cluster": "", "currency": currency, "rate": rate}])
+	prov = subscriptions.provision_subscription(team, "e2e-cluster", plan, start_date=period_start)
+	invoice = invoicing.generate_draft_invoice(prov["subscription"], period_start, period_end)
+	doc = frappe.get_doc("Invoice", invoice)
+	frappe.db.commit()
+	return {"invoice": invoice, "subscription": prov["subscription"],
+			"resource_id": prov["resource_id"], "subtotal": doc.subtotal,
+			"total": doc.total, "currency": doc.currency}
 
 
 # --- INR rails (e-mandate + UPI Autopay mandate) -----------------------------

--- a/central/billing/tests/e2e.py
+++ b/central/billing/tests/e2e.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Test-only seed/teardown endpoints for the Playwright e2e suite (no mocks).
+
+Each spec calls `seed(scenario=...)` to get a *fully isolated* team + user (with a
+known password) so it can drive the real dashboard against the real backend and
+the real gateway test sandboxes — Stripe/Razorpay test keys already live in
+`common_site_config.json`, so a top-up creates a genuine test-mode PaymentIntent /
+Razorpay order, nothing stubbed.
+
+Safety: these are whitelisted but HARD-GATED on `frappe.conf.allow_tests`. On a
+site without that flag (i.e. production) every entry point raises immediately, so
+the seed/teardown surface can never be reached off a test bench.
+"""
+
+import frappe
+from frappe.utils.password import update_password
+
+from central.iam import get_user_team_names
+from central.billing.tests.utils import complete_billing_profile, make_user
+
+# Shared login secret for every seeded user — the spec gets it back from seed() and
+# logs in with it. Not a real credential; only valid on an allow_tests bench.
+E2E_PASSWORD = "e2e-Test-Pass-123"
+
+
+def _enter_test_mode() -> None:
+	"""Gate, then elevate. These endpoints are called by an unauthenticated test
+	harness (allow_guest) and must create/delete teams and users across permission
+	hooks, so they run as Administrator. The ONLY thing that makes that safe is the
+	`allow_tests` gate — it is never set on a production site, so this whole surface
+	is unreachable there. Checked first, before any elevation."""
+	if not frappe.conf.get("allow_tests"):
+		frappe.throw("e2e seed endpoints require `allow_tests` on the site.", frappe.PermissionError)
+	frappe.set_user("Administrator")
+
+
+# --- public entry points -----------------------------------------------------
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def seed(scenario: str = "profile_pending", currency: str = "INR") -> dict:
+	"""Build an isolated team for one Playwright spec and return the handles the
+	test needs: the team slug, and the member's login (email + password).
+
+	Scenarios (each builds on the previous):
+	  - `profile_pending` — team + billing member, NO billing profile. Lands the
+	    user on the onboarding wizard; the spec completes the profile itself.
+	  - `ready`           — `profile_pending` + a *complete* billing profile in
+	    `currency`, so money-moving actions (top-up, add card) are un-gated.
+	  - `with_invoices`   — `ready` + one Paid and one Open invoice, for the
+	    invoices screen.
+
+	Pass `currency="USD"` for the Stripe top-up spec: USD's default gateway is
+	Stripe, so the top-up deterministically routes to the Stripe card Element.
+
+	The seeded user owns exactly one team — the personal team Central bootstraps on
+	user creation (`central.users.bootstrap_user_team`), where they are Owner with
+	full billing capability. We seed onto *that* team so it is the deterministic
+	whoami default; the spec never has to switch teams.
+	"""
+	_enter_test_mode()
+
+	member = make_user(f"e2e-{frappe.generate_hash(8)}@example.com")
+	update_password(member, E2E_PASSWORD)
+	team = get_user_team_names(member)[0]
+
+	if scenario in ("ready", "with_invoices"):
+		complete_billing_profile(team, currency=currency)
+	if scenario == "with_invoices":
+		_seed_invoices(team, currency)
+
+	frappe.db.commit()
+	return {"team": team, "email": member, "password": E2E_PASSWORD, "currency": currency, "scenario": scenario}
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def teardown(team: str | None = None, email: str | None = None) -> dict:
+	"""Delete everything `seed()` created for one spec. Best-effort and idempotent:
+	a spec calls this in its afterEach, so it must never raise on partially-built
+	state. Billing rows go first (they link the team), then the team, then the user
+	(who is the team's owner). `email` is also deleted directly in case the team was
+	never created."""
+	_enter_test_mode()
+
+	if team and frappe.db.exists("Team", team):
+		owner = frappe.db.get_value("Team", team, "owner_user")
+		for dt in (
+			"Invoice", "Payment Attempt", "Payment Method", "Credit Ledger Entry",
+			"Gateway Customer", "Billing Profile", "Trust Tier", "Tax Profile",
+		):
+			frappe.db.delete(dt, {"team": team})
+		frappe.db.delete("Credit Wallet", {"team": team})
+		frappe.delete_doc("Team", team, force=True, ignore_permissions=True)
+		_delete_user(owner)
+
+	_delete_user(email)
+	frappe.db.commit()
+	return {"ok": True}
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def finish_razorpay_topup(team: str, gateway: str, order_id: str, amount: float) -> dict:
+	"""Complete a Razorpay top-up the way the hosted-checkout callback would — but
+	without driving Razorpay's bot-protected sheet (hCaptcha/fraud frames/3DS) which
+	can't be automated reliably.
+
+	The e2e spec drives the real UI up to the point where the genuine Razorpay test
+	sheet opens against a *real* test order (proving the UI → create_topup_order
+	integration). This then finishes the no-mock path the gateway boundary leaves:
+	it computes the **real** checkout signature with the **real** test secret over
+	that **real** order (exactly the HMAC Razorpay's callback returns), mints a
+	payment id, and calls the **real** `confirm_topup` — which verifies the signature
+	with the test key and credits the wallet. The only synthetic value is the
+	`pay_…` id string, because minting a Razorpay-issued one needs its hosted sheet.
+	"""
+	import hashlib
+	import hmac
+
+	_enter_test_mode()
+	from central.billing.api.dashboard.invoices import confirm_topup
+	from central.billing.gateways.registry import get_adapter
+
+	adapter = get_adapter(frappe.get_doc("Payment Gateway", gateway))
+	secret = adapter.get_credential("api_secret")
+	payment_id = f"pay_e2e{frappe.generate_hash(length=14)}"
+	signature = hmac.new(
+		secret.encode(), f"{order_id}|{payment_id}".encode(), hashlib.sha256
+	).hexdigest()
+
+	return confirm_topup(
+		team=team, amount=amount, gateway=gateway,
+		razorpay_order_id=order_id, razorpay_payment_id=payment_id, razorpay_signature=signature,
+	)
+
+
+# --- scenario builders -------------------------------------------------------
+
+
+def _seed_invoices(team: str, currency: str) -> None:
+	"""One settled and one outstanding invoice — enough to exercise the list (a
+	Paid + an Open row) and the detail view (line items + a tax block)."""
+	tax_type = "GST" if currency == "INR" else "VAT"
+	for status, period, paid in (
+		("Paid", ("2026-05-01", "2026-05-31"), True),
+		("Open", ("2026-06-01", "2026-06-30"), False),
+	):
+		frappe.get_doc({
+			"doctype": "Invoice", "team": team, "invoice_type": "Billable", "status": status,
+			"period_start": period[0], "period_end": period[1], "currency": currency,
+			"subtotal": 1000, "output_tax_type": tax_type, "output_tax_amount": 180, "total": 1180,
+			"amount_paid": 1180 if paid else 0,
+			"items": [{"resource_type": "bundle", "rate": 1000, "days": 30, "amount": 1000}],
+		}).insert(ignore_permissions=True)
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+def _delete_user(email: str | None) -> None:
+	if email and frappe.db.exists("User", email):
+		frappe.delete_doc("User", email, force=True, ignore_permissions=True)

--- a/central/billing/tests/test_sync.py
+++ b/central/billing/tests/test_sync.py
@@ -1,32 +1,63 @@
 # Copyright (c) 2026, Frappe and contributors
 # For license information, please see license.txt
+"""Agentless provisioning writes the price-lock (ADR 0006).
 
-from unittest.mock import MagicMock, patch
+There is no Subscription Agent and no plan push; Central provisions a resource and
+records the authoritative runtime (the price-lock) itself, at the catalog rate —
+so the rate shown is the rate locked, with no reconciliation gap.
+"""
 
+import frappe
 from frappe.tests import IntegrationTestCase
 
-from central.billing.platform.sync import push_plans_to_agent
-from central.billing.tests.utils import make_plan
+from central.billing.catalog import subscriptions
+from central.billing.tests.utils import complete_billing_profile, ensure_team, make_plan
+
+TEAM = "team-provision"
+PLAN = "bundle-provision"
+CLUSTER = "ap-south-1"
 
 
-class TestPushPlansToAgent(IntegrationTestCase):
-	def test_posts_identity_includes_and_rates_to_agent_endpoint(self):
-		make_plan("bundle-test-push")
+class TestProvisionWritesLock(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		complete_billing_profile(TEAM, currency="INR")
+		make_plan(PLAN)  # INR catalog rate 3200
+		frappe.db.delete("Price Lock", {"team": TEAM})
+		frappe.db.commit()
 
-		with patch("central.billing.platform.sync.requests.post") as mock_post:
-			mock_post.return_value = MagicMock(status_code=200)
-			mock_post.return_value.json.return_value = {"message": {"received": ["bundle-test-push"]}}
+	def test_provision_writes_open_lock_at_catalog_rate(self):
+		res = subscriptions.provision_subscription(TEAM, CLUSTER, PLAN)
 
-			push_plans_to_agent(agent_url="https://agent.example", plans=["bundle-test-push"])
+		self.assertTrue(res["resource_id"])
+		self.assertEqual(res["currency"], "INR")
+		self.assertEqual(res["shown_rate"], 3200)
 
-		self.assertEqual(mock_post.call_count, 1)
-		_, kwargs = mock_post.call_args
-		# Targets the Agent's receive_plans method endpoint.
-		self.assertIn("press_billing_agent.sync.receive_plans", kwargs["url"])
+		lock = frappe.db.get_value(
+			"Price Lock",
+			{"team": TEAM, "resource_id": res["resource_id"]},
+			["plan", "locked_rate", "central_rate", "discrepancy", "ended_at", "event_type"],
+			as_dict=True,
+		)
+		self.assertIsNotNone(lock)  # provisioning wrote the lock — no agent push needed
+		self.assertEqual(lock.plan, PLAN)
+		self.assertEqual(lock.event_type, "subscribed")
+		self.assertFalse(lock.ended_at)  # an open (live) lock
+		# Rate shown == rate locked == Central's catalog rate: no discrepancy.
+		self.assertEqual(float(lock.locked_rate), 3200)
+		self.assertEqual(float(lock.central_rate), 3200)
+		self.assertFalse(lock.discrepancy)
 
-		pushed = kwargs["json"]["plans"][0]
-		self.assertEqual(pushed["plan"], "bundle-test-push")  # immutable identity
-		self.assertEqual(len(pushed["includes"]), 3)  # composition, no price
-		rates_by_ccy = {r["currency"]: r["rate"] for r in pushed["rates"]}
-		self.assertEqual(rates_by_ccy["USD"], 40)  # full rate set, both currencies
-		self.assertEqual(rates_by_ccy["INR"], 3200)
+	def test_provision_lock_drives_invoice_generation(self):
+		from central.billing.revenue import invoicing
+
+		res = subscriptions.provision_subscription(
+			TEAM, CLUSTER, PLAN, start_date="2026-06-01"
+		)
+		name = invoicing.generate_draft_invoice(res["subscription"], "2026-06-01", "2026-06-30")
+		inv = frappe.get_doc("Invoice", name)
+		# A full June on the locked ₹3200 plan → a non-zero draft generated straight
+		# from Central's own price-lock, with no agent in the loop.
+		self.assertEqual(inv.status, "Draft")
+		self.assertGreater(inv.subtotal, 0)
+		self.assertTrue(inv.items)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -94,6 +94,16 @@ cd ../../..            # the bench root (cenral-bench)
 PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH" bench start
 ```
 
+## CI
+
+`.github/workflows/e2e.yml` runs the suite on push to `develop` and on manual
+dispatch (not on PRs — it needs gateway secrets, which aren't exposed to fork PRs).
+It boots a bench + `test_site`, builds the SPA, seeds the catalog/gateways, serves
+on port 8000, installs Playwright, and runs the suite, uploading the HTML report as
+an artifact. **Required repo secrets** (test-mode keys): `STRIPE_SECRET_KEY`,
+`STRIPE_PUBLISHABLE_KEY`, `RAZORPAY_KEY_ID`, `RAZORPAY_KEY_SECRET` — the job fails
+fast with a clear message if they're absent.
+
 ## Running
 
 ```bash

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -34,6 +34,7 @@ just a new subfolder. Each domain wires its own test-only seed endpoint under
 | `settlement.spec.js` | Credits-only, partial credits + card, and the "Pay" button | **real credits→card waterfall**, real off-session PaymentIntent, real `apply_webhook` |
 | `mandate-upi.spec.js` | UPI Autopay mandate setup (INR) | **real Razorpay recurring order + real signature**, real `confirm_mandate` |
 | `emandate.spec.js` | INR e-mandate pre-debit notice + the ₹15,000 Action Required fork | **fully real** `schedule_predebit` / `collection_mode` |
+| `dunning.spec.js` | Declined card → Overdue + Past Due after the retry window | **real Stripe decline** + real dunning state machine (simulated clock) |
 
 ### INR rails (e-mandate + UPI Autopay)
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -35,6 +35,7 @@ just a new subfolder. Each domain wires its own test-only seed endpoint under
 | `mandate-upi.spec.js` | UPI Autopay mandate setup (INR) | **real Razorpay recurring order + real signature**, real `confirm_mandate` |
 | `emandate.spec.js` | INR e-mandate pre-debit notice + the ₹15,000 Action Required fork | **fully real** `schedule_predebit` / `collection_mode` |
 | `dunning.spec.js` | Declined card → Overdue + Past Due after the retry window | **real Stripe decline** + real dunning state machine (simulated clock) |
+| `refunds.spec.js` | Full dispute → source (invoice stays Paid); partial overcharge → wallet | **real Stripe refund** + real credit ledger |
 
 ### INR rails (e-mandate + UPI Autopay)
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,108 @@
+# End-to-end suite (no mocks)
+
+Playwright specs that drive the **real** Frappe-UI dashboard against a **running
+`central.local` bench** and the **real gateway test sandboxes**. Nothing is
+stubbed: a top-up creates a genuine Stripe test-mode `PaymentIntent`, the wallet is
+credited only after the gateway confirms, and every read renders from real DocTypes.
+
+## Layout
+
+Specs are grouped by domain, each domain owning its fixtures + helpers so the
+seams stay independent:
+
+```
+e2e/
+  billing/            # billing dashboard flows (this suite)
+    fixtures.js       # `billing` fixture: seed/login/teardown + finishRazorpay
+    helpers/stripe.js # fill the Stripe card Element
+    *.spec.js
+  # iam/              # (future) IAM flows — its own fixtures + seed endpoint
+```
+
+Playwright discovers `**/*.spec.js` under `e2e/` recursively, so a new domain is
+just a new subfolder. Each domain wires its own test-only seed endpoint under
+`central/<domain>/tests/e2e.py`; billing's lives at `central/billing/tests/e2e.py`.
+
+## What billing covers
+
+| Spec | Flow | No-mock surface |
+| --- | --- | --- |
+| `onboarding.spec.js` | First-run wizard completes the Billing Profile | real `save_billing_profile` |
+| `topup-stripe.spec.js` | USD wallet top-up via the embedded Stripe card Element | **real Stripe test-mode PaymentIntent** (4242 card) |
+| `topup-razorpay.spec.js` | INR wallet top-up — real Razorpay sheet opens, finished at the gateway boundary | **real Razorpay test order + real signature**, real `confirm_topup` |
+| `invoices.spec.js` | Invoice list + detail (line items, tax block) | real `Invoice` docs |
+
+### Gateway automation note
+
+**Stripe Elements** automates cleanly — we type the 4242 test card straight into
+Stripe's iframe and confirm a genuine PaymentIntent. **Razorpay's hosted Checkout**
+does not: it loads invisible hCaptcha, Sardine fraud signals and a cross-origin 3DS
+simulator that resist (and detect) browser automation. So the Razorpay spec drives
+the real UI until the **genuine Razorpay test sheet opens against a real test
+order**, then completes the no-mock path at the gateway boundary —
+`e2e.py:finish_razorpay_topup` signs that real order with the **real test secret**
+(the exact HMAC Razorpay's callback returns) and calls the **real** `confirm_topup`,
+which verifies the signature and credits the wallet. Only the `pay_…` id string is
+synthetic, because minting a Razorpay-issued one needs its bot-gated sheet.
+
+## Prerequisites
+
+- The bench must already be running and serving the dashboard on
+  `http://central.local:8011` (`central.local` is in `/etc/hosts`).
+- `central.local` must have `allow_tests: true` (it does) — this gates the
+  test-only seed endpoints. They are unreachable on any site without it.
+- Real **test-mode** gateway keys in `sites/common_site_config.json`
+  (`stripe_secret_key`/`stripe_publishable_key` = `sk_test_`/`pk_test_`,
+  `razorpay_key_id`/`razorpay_key_secret` = `rzp_test`). Stripe specs need
+  outbound network to `js.stripe.com` and the Stripe API.
+
+### Starting the bench
+
+```bash
+cd ../../..            # the bench root (cenral-bench)
+# node >= 24 must be on PATH or honcho's `watch` process crashes and tears the
+# whole bench down — prepend the nvm node if your shell defaults to an older one:
+PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH" bench start
+```
+
+## Running
+
+```bash
+cd apps/central
+yarn test:e2e            # headless
+yarn test:e2e:headed     # watch it drive a real browser
+yarn test:e2e:report     # open the last HTML report
+
+# target the host explicitly:
+E2E_BASE_URL=http://central.local:8011 npx playwright test
+```
+
+Specs run **serially** (`workers: 1`) on purpose — the gateway sandboxes are
+shared, rate-limited, mutable state, so two specs must never confirm a payment at
+the same instant.
+
+## How isolation works
+
+Each spec provisions its own sandbox through the test-only backend endpoints in
+`central/billing/tests/e2e.py`:
+
+- `seed(scenario, currency)` creates a fresh user (known password) and seeds data
+  onto the personal team Central bootstraps for them — so they own exactly one
+  team and it is the deterministic `whoami` default. Scenarios:
+  `profile_pending` → `ready` (complete profile) → `with_invoices`.
+- `teardown(team, email)` deletes everything that spec created.
+
+The `billing` fixture in `billing/fixtures.js` calls these for you
+(`billing.signIn(...)`) and tears down in `afterEach`, so a full run leaves **zero**
+residue. Seed/teardown run as guest over HTTP and elevate to Administrator behind
+the `allow_tests` gate.
+
+## Adding a spec
+
+1. Add a scenario branch to `seed()` in `central/billing/tests/e2e.py` if you need
+   new backing data. **Restart the web worker** after editing it (the dev server
+   caches imported modules).
+2. Add the spec under `e2e/billing/`. `import { test, expect } from './fixtures'`,
+   call `await billing.signIn({...})`, `page.goto('/dashboard/...')`, and assert on
+   user-visible state.
+3. For Stripe card entry, use `fillStripeCard()` from `./helpers/stripe.js`.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -36,6 +36,7 @@ just a new subfolder. Each domain wires its own test-only seed endpoint under
 | `emandate.spec.js` | INR e-mandate pre-debit notice + the ₹15,000 Action Required fork | **fully real** `schedule_predebit` / `collection_mode` |
 | `dunning.spec.js` | Declined card → Overdue + Past Due after the retry window | **real Stripe decline** + real dunning state machine (simulated clock) |
 | `refunds.spec.js` | Full dispute → source (invoice stays Paid); partial overcharge → wallet | **real Stripe refund** + real credit ledger |
+| `invoice-generation.spec.js` | Provision a price-lock → generate the invoice from it | **real agentless pipeline** (`provision_subscription` → `generate_draft_invoice`), no fabrication |
 
 ### INR rails (e-mandate + UPI Autopay)
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -32,6 +32,20 @@ just a new subfolder. Each domain wires its own test-only seed endpoint under
 | `topup-razorpay.spec.js` | INR wallet top-up — real Razorpay sheet opens, finished at the gateway boundary | **real Razorpay test order + real signature**, real `confirm_topup` |
 | `invoices.spec.js` | Invoice list + detail (line items, tax block) | real `Invoice` docs |
 | `settlement.spec.js` | Credits-only, partial credits + card, and the "Pay" button | **real credits→card waterfall**, real off-session PaymentIntent, real `apply_webhook` |
+| `mandate-upi.spec.js` | UPI Autopay mandate setup (INR) | **real Razorpay recurring order + real signature**, real `confirm_mandate` |
+| `emandate.spec.js` | INR e-mandate pre-debit notice + the ₹15,000 Action Required fork | **fully real** `schedule_predebit` / `collection_mode` |
+
+### INR rails (e-mandate + UPI Autopay)
+
+`emandate.spec.js` is fully real (no gateway): it drives `schedule_predebit`, asserting
+the **pre-debit notice** for a ≤₹15,000 bill and the **Action Required** banner + the
+prepaid/manual-checkout choice for a bill over the silent-debit ceiling. `mandate-upi.spec.js`
+sets up a UPI Autopay mandate — UPI authorises through Razorpay's hosted recurring sheet
+(same bot protection as the top-up), so it opens the **real recurring order/sheet** from the
+UI and confirms at the gateway boundary (`e2e.py:finish_mandate`: real checkout-callback
+signature; only the recurring **token id** is synthetic, since Razorpay issues one only via
+the bank/UPI auth flow). The successful recurring **debit** of an INR invoice isn't covered
+end-to-end for the same reason — it needs a real authorised token.
 
 ### Settlement & the webhook boundary
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -31,6 +31,19 @@ just a new subfolder. Each domain wires its own test-only seed endpoint under
 | `topup-stripe.spec.js` | USD wallet top-up via the embedded Stripe card Element | **real Stripe test-mode PaymentIntent** (4242 card) |
 | `topup-razorpay.spec.js` | INR wallet top-up — real Razorpay sheet opens, finished at the gateway boundary | **real Razorpay test order + real signature**, real `confirm_topup` |
 | `invoices.spec.js` | Invoice list + detail (line items, tax block) | real `Invoice` docs |
+| `settlement.spec.js` | Credits-only, partial credits + card, and the "Pay" button | **real credits→card waterfall**, real off-session PaymentIntent, real `apply_webhook` |
+
+### Settlement & the webhook boundary
+
+`settlement.spec.js` runs the real credits-then-card waterfall (`open_and_collect`):
+credits apply first; if they cover the bill it is `Paid` with no charge, otherwise
+the remainder is charged to a **real Stripe test card** (attached off-session via
+`tok_visa`) through a genuine PaymentIntent. The `Open → Paid` flip is webhook-only
+in production, and a local bench can't receive live webhooks — so the spec delivers
+it by building a `Webhook Event` from the **real captured transaction id** and
+running the **real** `apply_webhook` (`e2e.py:deliver_webhook`). Only the HTTP
+signature check (a separate gate, unit-tested) is skipped; the charge, the txn id,
+and the settlement logic are all real.
 
 ### Gateway automation note
 

--- a/e2e/billing/dunning.spec.js
+++ b/e2e/billing/dunning.spec.js
@@ -1,0 +1,33 @@
+import { test, expect } from './fixtures'
+
+// Declined-card dunning (issue #14). A real off-session charge against a card
+// Stripe declines (tok_chargeCustomerFail) fails the Payment Attempt and leaves
+// the invoice Open; once the retries are exhausted, dunning takes the invoice
+// Overdue and moves the subscription's account standing to Past Due. We walk the
+// real dunning state machine with a simulated clock (no waiting calendar days);
+// every charge, decline, and transition is real.
+test.describe('Dunning (declined card)', () => {
+  test('a declined charge goes Overdue and Past Due after the retry window', async ({ page, billing }) => {
+    const { team } = await billing.signIn({ scenario: 'ready', currency: 'USD' })
+    await billing.saveCard({ team, token: 'tok_chargeCustomerFail' }) // real card that declines on charge
+    const { invoice } = await billing.makeInvoice({ team, total: 1180, linkCard: 1 })
+
+    // The waterfall charges the card; Stripe declines → Failed attempt, invoice stays Open.
+    const res = await billing.settle({ team, invoice, collect: 1 })
+    expect(res.status).toBe('Open')
+
+    // The customer is told the payment failed.
+    await page.goto('/dashboard/settings/notifications')
+    await expect(page.getByText('Payment Failure').first()).toBeVisible()
+
+    // Day 7: retries exhausted → invoice Overdue, subscription Past Due.
+    const day7 = await billing.dun({ invoice, days: 7 })
+    expect(day7.standing).toBe('Past Due')
+
+    await page.goto('/dashboard/billing/invoices')
+    await expect(page.locator('ul.divide-y > li').filter({ hasText: 'Overdue' })).toHaveCount(1)
+
+    await page.goto('/dashboard/billing/subscriptions')
+    await expect(page.getByText('Past Due')).toBeVisible()
+  })
+})

--- a/e2e/billing/emandate.spec.js
+++ b/e2e/billing/emandate.spec.js
@@ -1,0 +1,44 @@
+import { test, expect } from './fixtures'
+
+// INR e-mandate collection (ADR 0005 / #50). An e-mandate team may auto-debit
+// silently only up to ₹15,000, and only after an RBI pre-debit notice ≥24h before.
+// These tests exercise the real orchestration (emandate.schedule_predebit) and its
+// two outcomes, asserting the customer-visible result on the dashboard. No gateway
+// debit runs here — that's the separate (token-gated) charge step.
+test.describe('INR e-mandate collection', () => {
+  test('sends a pre-debit notice for a bill within the ₹15,000 ceiling', async ({ page, billing }) => {
+    const { team } = await billing.signIn({ scenario: 'ready', currency: 'INR' })
+    await billing.setCollectionMode({ team, mode: 'emandate' })
+
+    const { invoice } = await billing.makeInvoice({ team, total: 5000 })
+    await billing.settle({ team, invoice, collect: 0 }) // open it; e-mandate debits later
+    const res = await billing.predebit({ invoice })
+    expect(res.notified).toBe(true)
+
+    // The customer sees the pre-debit notice in their notification feed.
+    await page.goto('/dashboard/settings/notifications')
+    await expect(page.getByText('Pre-debit Notice').first()).toBeVisible()
+  })
+
+  test('forks a bill over the ceiling to the Action Required choice', async ({ page, billing }) => {
+    const { team } = await billing.signIn({ scenario: 'ready', currency: 'INR' })
+    await billing.setCollectionMode({ team, mode: 'emandate' })
+
+    const { invoice } = await billing.makeInvoice({ team, total: 20000 }) // over ₹15,000
+    await billing.settle({ team, invoice, collect: 0 })
+    const res = await billing.predebit({ invoice })
+    expect(res.action_required).toBe(true) // can't debit silently → ask the customer
+
+    // The Action Required banner appears on the overview; the customer picks how to pay.
+    await page.goto('/dashboard/billing')
+    await expect(page.getByText('Action required — choose how to keep paying')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Choose how to pay' }).click()
+    const dialog = page.getByRole('dialog')
+    await dialog.getByText('Prepaid wallet').click()
+    await dialog.getByRole('button', { name: 'Confirm' }).click()
+
+    // Resolved → the banner clears.
+    await expect(page.getByText('Action required — choose how to keep paying')).toHaveCount(0)
+  })
+})

--- a/e2e/billing/fixtures.js
+++ b/e2e/billing/fixtures.js
@@ -64,6 +64,10 @@ export const test = base.extend({
     const makeInvoice = ({ team, total = 1180, linkCard = 0 }) =>
       backend('make_invoice', { team, total, link_card: linkCard })
     const settle = ({ team, invoice, collect = 1 }) => backend('settle', { team, invoice, collect })
+    // Generate an invoice through the real agentless pipeline (provision → price-lock
+    // → generate_draft_invoice), not by fabricating an Invoice doc.
+    const generateInvoice = ({ team, monthlyRate = 3000 }) =>
+      backend('generate_invoice', { team, monthly_rate: monthlyRate })
     const deliverWebhook = ({ attempt }) => backend('deliver_webhook', { attempt })
     // Run one day of dunning as if `days` had elapsed past the invoice due date.
     const dun = ({ invoice, days = 7 }) => backend('dun', { invoice, days })
@@ -82,7 +86,7 @@ export const test = base.extend({
 
     await use({
       seed, login, signIn, finishRazorpay,
-      addCredits, saveCard, makeInvoice, settle, deliverWebhook, dun, refund,
+      addCredits, saveCard, makeInvoice, settle, deliverWebhook, dun, refund, generateInvoice,
       setTrustTier, setCollectionMode, predebit, finishMandate,
     })
 

--- a/e2e/billing/fixtures.js
+++ b/e2e/billing/fixtures.js
@@ -65,9 +65,19 @@ export const test = base.extend({
     const settle = ({ team, invoice, collect = 1 }) => backend('settle', { team, invoice, collect })
     const deliverWebhook = ({ attempt }) => backend('deliver_webhook', { attempt })
 
+    // INR rails (e-mandate + UPI Autopay mandate): give the team a trust tier (the
+    // UPI ceiling), switch collection mode, run the pre-debit step, and confirm a
+    // mandate at the gateway boundary (its hosted recurring sheet can't be automated).
+    const setTrustTier = ({ team, maxSpend = 50000 }) => backend('set_trust_tier', { team, max_spend: maxSpend })
+    const setCollectionMode = ({ team, mode }) => backend('set_collection_mode', { team, mode })
+    const predebit = ({ invoice }) => backend('predebit', { invoice })
+    const finishMandate = ({ paymentMethod, orderId }) =>
+      backend('finish_mandate', { payment_method: paymentMethod, order_id: orderId })
+
     await use({
       seed, login, signIn, finishRazorpay,
       addCredits, saveCard, makeInvoice, settle, deliverWebhook,
+      setTrustTier, setCollectionMode, predebit, finishMandate,
     })
 
     // Best-effort teardown of everything this test seeded (guest context).

--- a/e2e/billing/fixtures.js
+++ b/e2e/billing/fixtures.js
@@ -59,11 +59,14 @@ export const test = base.extend({
     // attach a real Stripe test card, create a Draft invoice, run the credits→card
     // waterfall, and deliver the success webhook that flips Open → Paid.
     const addCredits = ({ team, amount }) => backend('add_credits', { team, amount })
-    const saveCard = ({ team }) => backend('save_test_card', { team })
+    // token='tok_chargeCustomerFail' attaches a real card that declines on charge.
+    const saveCard = ({ team, token } = {}) => backend('save_test_card', { team, ...(token && { token }) })
     const makeInvoice = ({ team, total = 1180, linkCard = 0 }) =>
       backend('make_invoice', { team, total, link_card: linkCard })
     const settle = ({ team, invoice, collect = 1 }) => backend('settle', { team, invoice, collect })
     const deliverWebhook = ({ attempt }) => backend('deliver_webhook', { attempt })
+    // Run one day of dunning as if `days` had elapsed past the invoice due date.
+    const dun = ({ invoice, days = 7 }) => backend('dun', { invoice, days })
 
     // INR rails (e-mandate + UPI Autopay mandate): give the team a trust tier (the
     // UPI ceiling), switch collection mode, run the pre-debit step, and confirm a
@@ -76,7 +79,7 @@ export const test = base.extend({
 
     await use({
       seed, login, signIn, finishRazorpay,
-      addCredits, saveCard, makeInvoice, settle, deliverWebhook,
+      addCredits, saveCard, makeInvoice, settle, deliverWebhook, dun,
       setTrustTier, setCollectionMode, predebit, finishMandate,
     })
 

--- a/e2e/billing/fixtures.js
+++ b/e2e/billing/fixtures.js
@@ -40,18 +40,35 @@ export const test = base.extend({
       return creds
     }
 
-    // Complete a Razorpay top-up at the gateway boundary: signs the real order with
-    // the real test secret and calls the real confirm_topup (see e2e.py). Used by
-    // the Razorpay spec, whose hosted sheet can't be automated reliably.
-    async function finishRazorpay({ team, gateway, orderId, amount }) {
-      const res = await request.post(method('central.billing.tests.e2e.finish_razorpay_topup'), {
-        form: { team, gateway, order_id: orderId, amount },
-      })
-      expect(res.ok(), `finish_razorpay failed: ${res.status()} ${await res.text()}`).toBeTruthy()
+    // Call any test-only backend helper (guest, allow_tests-gated) and return its
+    // result. Used by the settlement specs to arrange real backend state and to
+    // deliver the gateway webhook the local bench can't receive.
+    async function backend(name, form) {
+      const res = await request.post(method(`central.billing.tests.e2e.${name}`), { form })
+      expect(res.ok(), `${name} failed: ${res.status()} ${await res.text()}`).toBeTruthy()
       return (await res.json()).message
     }
 
-    await use({ seed, login, signIn, finishRazorpay })
+    // Complete a Razorpay top-up at the gateway boundary: signs the real order with
+    // the real test secret and calls the real confirm_topup (see e2e.py). Used by
+    // the Razorpay spec, whose hosted sheet can't be automated reliably.
+    const finishRazorpay = ({ team, gateway, orderId, amount }) =>
+      backend('finish_razorpay_topup', { team, gateway, order_id: orderId, amount })
+
+    // Settlement arrange-helpers (all real backend, no mocks): fund the wallet,
+    // attach a real Stripe test card, create a Draft invoice, run the credits→card
+    // waterfall, and deliver the success webhook that flips Open → Paid.
+    const addCredits = ({ team, amount }) => backend('add_credits', { team, amount })
+    const saveCard = ({ team }) => backend('save_test_card', { team })
+    const makeInvoice = ({ team, total = 1180, linkCard = 0 }) =>
+      backend('make_invoice', { team, total, link_card: linkCard })
+    const settle = ({ team, invoice, collect = 1 }) => backend('settle', { team, invoice, collect })
+    const deliverWebhook = ({ attempt }) => backend('deliver_webhook', { attempt })
+
+    await use({
+      seed, login, signIn, finishRazorpay,
+      addCredits, saveCard, makeInvoice, settle, deliverWebhook,
+    })
 
     // Best-effort teardown of everything this test seeded (guest context).
     for (const c of seeded) {

--- a/e2e/billing/fixtures.js
+++ b/e2e/billing/fixtures.js
@@ -67,6 +67,9 @@ export const test = base.extend({
     const deliverWebhook = ({ attempt }) => backend('deliver_webhook', { attempt })
     // Run one day of dunning as if `days` had elapsed past the invoice due date.
     const dun = ({ invoice, days = 7 }) => backend('dun', { invoice, days })
+    // Refund a captured attempt: destination 'Source' (real Stripe refund) or 'Wallet'.
+    const refund = ({ attempt, amount, destination = 'Source' }) =>
+      backend('refund', { payment_attempt: attempt, destination, ...(amount && { amount }) })
 
     // INR rails (e-mandate + UPI Autopay mandate): give the team a trust tier (the
     // UPI ceiling), switch collection mode, run the pre-debit step, and confirm a
@@ -79,7 +82,7 @@ export const test = base.extend({
 
     await use({
       seed, login, signIn, finishRazorpay,
-      addCredits, saveCard, makeInvoice, settle, deliverWebhook, dun,
+      addCredits, saveCard, makeInvoice, settle, deliverWebhook, dun, refund,
       setTrustTier, setCollectionMode, predebit, finishMandate,
     })
 

--- a/e2e/billing/fixtures.js
+++ b/e2e/billing/fixtures.js
@@ -1,0 +1,65 @@
+import { test as base, expect } from '@playwright/test'
+
+// Shared fixtures for the billing e2e suite.
+//
+// `billing.seed(...)` provisions a fully isolated team + login against the real
+// backend (central.billing.tests.e2e.seed) and registers it for teardown after
+// the test — so every spec runs in its own sandbox with no cross-test coupling.
+// Seeding/teardown go through the test-scoped `request` context, which is a guest
+// (its cookie jar is separate from the browser), so they never need a session or
+// CSRF token. `billing.login(...)` authenticates the *browser* via `page.request`,
+// whose cookies are shared with the page — so after it the dashboard is signed in.
+
+const method = (dotted) => `/api/method/${dotted}`
+
+export const test = base.extend({
+  billing: async ({ page, request }, use) => {
+    const seeded = []
+
+    async function seed({ scenario = 'profile_pending', currency = 'INR' } = {}) {
+      const res = await request.post(method('central.billing.tests.e2e.seed'), {
+        form: { scenario, currency },
+      })
+      expect(res.ok(), `seed failed: ${res.status()} ${await res.text()}`).toBeTruthy()
+      const creds = (await res.json()).message
+      seeded.push(creds)
+      return creds
+    }
+
+    // Sign the browser in as a seeded user. Uses page.request so the session
+    // cookie lands in the page's context; a subsequent goto renders as that user.
+    async function login({ email, password }) {
+      const res = await page.request.post(method('login'), { form: { usr: email, pwd: password } })
+      expect(res.ok(), `login failed: ${res.status()}`).toBeTruthy()
+    }
+
+    // One call for the common path: seed a scenario, then sign in as it.
+    async function signIn(opts) {
+      const creds = await seed(opts)
+      await login(creds)
+      return creds
+    }
+
+    // Complete a Razorpay top-up at the gateway boundary: signs the real order with
+    // the real test secret and calls the real confirm_topup (see e2e.py). Used by
+    // the Razorpay spec, whose hosted sheet can't be automated reliably.
+    async function finishRazorpay({ team, gateway, orderId, amount }) {
+      const res = await request.post(method('central.billing.tests.e2e.finish_razorpay_topup'), {
+        form: { team, gateway, order_id: orderId, amount },
+      })
+      expect(res.ok(), `finish_razorpay failed: ${res.status()} ${await res.text()}`).toBeTruthy()
+      return (await res.json()).message
+    }
+
+    await use({ seed, login, signIn, finishRazorpay })
+
+    // Best-effort teardown of everything this test seeded (guest context).
+    for (const c of seeded) {
+      await request
+        .post(method('central.billing.tests.e2e.teardown'), { form: { team: c.team, email: c.email } })
+        .catch(() => {})
+    }
+  },
+})
+
+export { expect }

--- a/e2e/billing/helpers/stripe.js
+++ b/e2e/billing/helpers/stripe.js
@@ -1,0 +1,23 @@
+import { expect } from '@playwright/test'
+
+// Stripe's PCI-scoped card Element is a cross-origin iframe; we can't read its
+// internals, but we CAN type into its inputs by frame name. These are real
+// keystrokes into the real (test-mode) Stripe Element — the same path a customer
+// takes — so the PaymentIntent that follows is genuine, nothing stubbed.
+
+// 4242… is Stripe's universal test card that always succeeds. The combined Card
+// Element (elements().create('card')) renders one iframe holding the number,
+// expiry and CVC inputs (postal hidden via hidePostalCode).
+export const TEST_CARD = { number: '4242424242424242', expiry: '12 / 34', cvc: '123' }
+
+// Fill the Stripe card Element mounted inside `root` (the dialog/card container).
+// Waits for the iframe to attach, then types each field. Returns once filled so
+// the caller can assert the gateway-confirm step.
+export async function fillStripeCard(root, card = TEST_CARD) {
+  const frame = root.frameLocator('iframe[title*="card"], iframe[name^="__privateStripeFrame"]')
+  const number = frame.locator('[name="cardnumber"], [name="number"]').first()
+  await expect(number).toBeVisible({ timeout: 20_000 })
+  await number.fill(card.number)
+  await frame.locator('[name="exp-date"], [name="expiry"]').first().fill(card.expiry)
+  await frame.locator('[name="cvc"]').first().fill(card.cvc)
+}

--- a/e2e/billing/invoice-generation.spec.js
+++ b/e2e/billing/invoice-generation.spec.js
@@ -1,0 +1,26 @@
+import { test, expect } from './fixtures'
+
+// Invoice GENERATION through the real agentless pipeline (ADR 0006). Unlike the
+// other specs, this fabricates nothing: provisioning writes a price-lock at the
+// catalog rate (Central, no agent), and generate_draft_invoice computes the line
+// items from that lock over the period. We then open the draft and assert the
+// generated figure on the dashboard — proving an invoice can be produced from
+// recorded runtime, not just hand-built.
+test.describe('Invoice generation', () => {
+  test('provisions a price-lock and generates the invoice from it', async ({ page, billing }) => {
+    const { team } = await billing.signIn({ scenario: 'ready', currency: 'INR' })
+
+    // Real pipeline: provision (writes the lock) → generate_draft_invoice.
+    const gen = await billing.generateInvoice({ team, monthlyRate: 3000 })
+    expect(gen.subtotal).toBe(3000) // a full June on the ₹3,000 locked plan, computed from the lock
+    await billing.settle({ team, invoice: gen.invoice, collect: 0 }) // Draft → Open (no charge)
+
+    await page.goto('/dashboard/billing/invoices')
+    const rows = page.locator('ul.divide-y > li')
+    await rows.filter({ hasText: '3,000' }).click()
+
+    // The detail renders the generated line item + total — not a fabricated number.
+    await expect(page.getByText('Line items')).toBeVisible()
+    await expect(page.locator('dl').filter({ hasText: 'Total' }).getByText('3,000').first()).toBeVisible()
+  })
+})

--- a/e2e/billing/invoices.spec.js
+++ b/e2e/billing/invoices.spec.js
@@ -1,0 +1,34 @@
+import { test, expect } from './fixtures'
+
+// Read path: a team with one settled and one outstanding invoice sees both on the
+// Invoices screen, each with the right amount and status badge, and can open one
+// to read its line items + tax block. No mocks — the rows come from real Invoice
+// docs the seed inserted for this team.
+test.describe('Invoices', () => {
+  test('lists the seeded paid and open invoices', async ({ page, billing }) => {
+    await billing.signIn({ scenario: 'with_invoices', currency: 'USD' })
+
+    await page.goto('/dashboard/billing/invoices')
+
+    const rows = page.locator('ul.divide-y > li')
+    await expect(rows).toHaveCount(2)
+    await expect(rows.filter({ hasText: 'Paid' })).toHaveCount(1)
+    await expect(rows.filter({ hasText: 'Open' })).toHaveCount(1)
+    // Both invoices total $1,180.00 (1000 + 180 tax) in the seeded scenario.
+    await expect(rows.filter({ hasText: '1,180' })).toHaveCount(2)
+  })
+
+  test('opens an invoice to show its line items and tax', async ({ page, billing }) => {
+    await billing.signIn({ scenario: 'with_invoices', currency: 'USD' })
+
+    await page.goto('/dashboard/billing/invoices')
+    await page.locator('ul.divide-y > li').filter({ hasText: 'Paid' }).click()
+
+    // Detail pane: line-item table + the totals/tax block from the seeded invoice.
+    await expect(page.getByText('Line items')).toBeVisible()
+    const totals = page.locator('dl').filter({ hasText: 'Total' })
+    await expect(totals.getByText('Subtotal')).toBeVisible()
+    await expect(totals.getByText('VAT')).toBeVisible() // USD output tax in the seed
+    await expect(totals.getByText('1,180').first()).toBeVisible() // total = subtotal + tax
+  })
+})

--- a/e2e/billing/mandate-upi.spec.js
+++ b/e2e/billing/mandate-upi.spec.js
@@ -1,0 +1,48 @@
+import { test, expect } from './fixtures'
+
+// Set up a UPI Autopay mandate for an INR team. UPI Autopay authorises through
+// Razorpay's hosted recurring sheet (the same bot-protected Checkout the top-up
+// uses), so we drive the real UI until the genuine recurring sheet opens against a
+// real order, then confirm the mandate at the gateway boundary (real
+// checkout-callback signature; only the recurring token id is synthetic, since
+// Razorpay issues one only through the bank/UPI auth flow). The mandate's ceiling
+// is the team's trust-tier cap.
+test.describe('UPI Autopay mandate', () => {
+  test('authorises a mandate via the real Razorpay recurring sheet', async ({ page, billing }) => {
+    const { team } = await billing.signIn({ scenario: 'ready', currency: 'INR' })
+    await billing.setTrustTier({ team, maxSpend: 50000 }) // UPI cap, below the ₹1,00,000 limit
+
+    await page.goto('/dashboard/settings/methods')
+    await expect(page.getByText('No payment methods yet.')).toBeVisible()
+
+    // Open the add dialog and choose UPI Autopay; capture the real recurring order.
+    await page.getByRole('button', { name: 'Add method' }).click()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog.getByText('Recurring mandate up to')).toBeVisible()
+    const setupResp = page.waitForResponse((r) => r.url().includes('setup_payment_method_order'))
+    await dialog.getByText('UPI Autopay', { exact: true }).click()
+    const order = (await (await setupResp).json()).data
+    expect(order.recurring).toBe(1) // a genuine Razorpay recurring order
+    expect(order.payment_method).toBeTruthy()
+
+    // The real Razorpay recurring sheet opens against that order.
+    await expect
+      .poll(
+        () => page.frames().some((f) => /api\.razorpay\.com\/v1\/checkout\/public/.test(f.url())),
+        { timeout: 20_000 },
+      )
+      .toBe(true)
+
+    // Confirm the authorisation at the gateway boundary → mandate goes Active.
+    const res = await billing.finishMandate({ paymentMethod: order.payment_method, orderId: order.order_id })
+    expect(res.status).toBe('Active')
+    expect(res.mandate_max_amount).toBe(50000)
+
+    // The active UPI Autopay mandate now shows in the methods list as the default.
+    await page.goto('/dashboard/settings/methods')
+    await expect(page.getByText('No payment methods yet.')).toHaveCount(0)
+    const row = page.locator('ul li').filter({ hasText: 'UPI Autopay' })
+    await expect(row).toHaveCount(1)
+    await expect(row.getByText('Default')).toBeVisible()
+  })
+})

--- a/e2e/billing/onboarding.spec.js
+++ b/e2e/billing/onboarding.spec.js
@@ -1,0 +1,42 @@
+import { test, expect } from './fixtures'
+
+// First-run setup: a brand-new team (no billing profile) lands on the onboarding
+// wizard and completes the required Billing Profile step against the real
+// save_billing_profile endpoint — currency, legal name and a full address. Saving
+// flips the step to complete, which is what un-gates every money-moving action.
+test.describe('Onboarding', () => {
+  test('completes the billing profile step', async ({ page, billing }) => {
+    await billing.signIn({ scenario: 'profile_pending' })
+
+    await page.goto('/dashboard/onboarding')
+    await expect(page.getByRole('heading', { name: 'Set up billing for your team' })).toBeVisible()
+    await expect(page.getByText('0 of 2 done')).toBeVisible()
+
+    // Currency is a frappe-ui (reka-ui) select combobox, not a native <select>:
+    // open it and click the option.
+    await page.getByRole('combobox', { name: 'Currency *' }).click()
+    await page.getByRole('option', { name: 'USD' }).click()
+
+    await page.getByLabel('Legal name *').fill('E2E Test Co')
+    await page.getByLabel('Billing email').fill('billing@e2e.example')
+    await page.getByLabel('Address line 1 *').fill('1 Market Street')
+    await page.getByLabel('City *').fill('San Francisco')
+
+    // Country is a frappe-ui autocomplete (a trigger button + searchable popover):
+    // open it, type to filter, pick the option.
+    await page.getByRole('button', { name: 'Select country' }).click()
+    await page.keyboard.type('United States')
+    await page.getByRole('option', { name: 'United States', exact: true }).click()
+
+    // Non-India → State is a plain text field; PIN is required.
+    await page.getByLabel('State *').fill('California')
+    await page.getByLabel('PIN code *').fill('94105')
+
+    await page.getByRole('button', { name: 'Save & continue' }).click()
+
+    // Step completes → progress advances and the dashboard becomes reachable.
+    await expect(page.getByText('Billing profile saved.', { exact: true })).toBeVisible()
+    await expect(page.getByText('1 of 2 done')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Go to dashboard' })).toBeEnabled()
+  })
+})

--- a/e2e/billing/refunds.spec.js
+++ b/e2e/billing/refunds.spec.js
@@ -1,0 +1,45 @@
+import { test, expect } from './fixtures'
+
+// Refunds (issue #15). Both paths start from a real charge: a card is charged to a
+// genuine PaymentIntent and the invoice settles via the real webhook. A full
+// dispute then issues a real Stripe refund of that PaymentIntent (the attempt goes
+// Refunded; the invoice stays Paid). A partial overcharge instead books the
+// difference as a wallet credit, applied next cycle. Refunds are an operator action
+// (no customer button), so the spec issues them via the backend and asserts the
+// customer-visible result on the dashboard.
+const open = (page) => page.locator('ul.divide-y > li')
+
+async function chargeAndSettle(billing) {
+  const { team } = await billing.signIn({ scenario: 'ready', currency: 'USD' })
+  await billing.saveCard({ team })
+  const { invoice } = await billing.makeInvoice({ team, total: 1180, linkCard: 1 })
+  const res = await billing.settle({ team, invoice, collect: 1 }) // real PaymentIntent
+  await billing.deliverWebhook({ attempt: res.attempt }) // Open → Paid
+  return { team, invoice, attempt: res.attempt }
+}
+
+test.describe('Refunds', () => {
+  test('full dispute refunds to source; the invoice stays Paid', async ({ page, billing }) => {
+    const { invoice, attempt } = await chargeAndSettle(billing)
+
+    const res = await billing.refund({ attempt, destination: 'Source' }) // real Stripe refund
+    expect(res.status).toBe('Completed')
+
+    // The invoice is still Paid, and its activity timeline records the refund.
+    await page.goto('/dashboard/billing/invoices')
+    await open(page).filter({ hasText: 'Paid' }).click()
+    await expect(page.getByText('Payment refunded')).toBeVisible()
+  })
+
+  test('partial overcharge is credited back to the wallet', async ({ page, billing }) => {
+    const { attempt } = await chargeAndSettle(billing)
+
+    const res = await billing.refund({ attempt, amount: 200, destination: 'Wallet' })
+    expect(res.status).toBe('Completed')
+
+    // The $200 overcharge correction shows as a wallet credit, applied next cycle.
+    await page.goto('/dashboard/billing/credits')
+    await expect(page.getByText('$200.00').first()).toBeVisible()
+    await expect(page.getByText(/Overcharge refund/)).toBeVisible()
+  })
+})

--- a/e2e/billing/settlement.spec.js
+++ b/e2e/billing/settlement.spec.js
@@ -1,0 +1,86 @@
+import { test, expect } from './fixtures'
+
+// Invoice settlement through the real credits-then-card waterfall (no mocks). Each
+// test arranges real backend state (wallet credits, a real Stripe test card, a
+// Draft invoice), runs the real `open_and_collect` waterfall, and asserts the
+// outcome on the rendered dashboard. Card charges hit a genuine off-session
+// PaymentIntent; the Open → Paid flip is delivered by the real apply_webhook with
+// the real captured transaction id (the local bench can't receive live webhooks).
+
+const open = (page) => page.locator('ul.divide-y > li')
+
+test.describe('Invoice settlement', () => {
+  test('settles fully from wallet credits — no card charged', async ({ page, billing }) => {
+    const { team } = await billing.signIn({ scenario: 'ready', currency: 'USD' })
+    await billing.addCredits({ team, amount: 2000 })
+    const { invoice } = await billing.makeInvoice({ team, total: 1180 })
+
+    // Credits ($2,000) cover the $1,180 bill in full → Paid with no gateway charge.
+    const res = await billing.settle({ team, invoice, collect: 1 })
+    expect(res.status).toBe('Paid')
+
+    await page.goto('/dashboard/billing/invoices')
+    await expect(open(page).filter({ hasText: 'Paid' })).toHaveCount(1)
+    await open(page).filter({ hasText: 'Paid' }).click()
+    await expect(page.locator('dl').getByText('Credit applied')).toBeVisible()
+
+    // Wallet dropped by the full invoice total ($2,000 − $1,180 = $820).
+    await page.goto('/dashboard/billing/credits')
+    await expect(page.getByText('$820.00').first()).toBeVisible()
+    await expect(page.getByText(new RegExp(`Credit applied to ${invoice}`))).toBeVisible()
+  })
+
+  test('settles partly from credits, charges the remainder to the card', async ({ page, billing }) => {
+    const { team } = await billing.signIn({ scenario: 'ready', currency: 'USD' })
+    await billing.addCredits({ team, amount: 500 })
+    await billing.saveCard({ team })
+    const { invoice } = await billing.makeInvoice({ team, total: 1180 })
+
+    // $500 credit applied, the $680 remainder charged to the real test card.
+    const res = await billing.settle({ team, invoice, collect: 1 })
+    expect(res.credit_applied).toBe(500)
+    expect(res.expected_collection).toBe(680)
+    expect(res.attempt).toBeTruthy() // a captured off-session PaymentIntent
+    await billing.deliverWebhook({ attempt: res.attempt }) // flips Open → Paid
+
+    await page.goto('/dashboard/billing/invoices')
+    await expect(open(page).filter({ hasText: 'Paid' })).toHaveCount(1)
+    await open(page).filter({ hasText: 'Paid' }).click()
+    const totals = page.locator('dl')
+    await expect(totals.getByText('Credit applied')).toBeVisible()
+    await expect(totals.getByText('$500.00')).toBeVisible() // credit leg
+    await expect(totals.getByText('Paid', { exact: true })).toBeVisible()
+
+    // Wallet fully drained by the $500 it contributed.
+    await page.goto('/dashboard/billing/credits')
+    await expect(page.getByText('$0.00').first()).toBeVisible()
+  })
+
+  test('charges a saved card from the invoice "Pay" button', async ({ page, billing }) => {
+    const { team } = await billing.signIn({ scenario: 'ready', currency: 'USD' })
+    await billing.saveCard({ team })
+    // linkCard attaches a subscription pointing at the card, so the Pay button resolves it.
+    const { invoice } = await billing.makeInvoice({ team, total: 1180, linkCard: 1 })
+
+    // Open the invoice without charging (no credits) so the UI button drives the charge.
+    const res = await billing.settle({ team, invoice, collect: 0 })
+    expect(res.status).toBe('Open')
+
+    await page.goto('/dashboard/billing/invoices')
+    await open(page).filter({ hasText: 'Open' }).click()
+
+    // The detail pane offers "Pay $1,180.00"; clicking it runs the real off-session
+    // charge. Capture the attempt from the response to deliver its webhook.
+    const payResp = page.waitForResponse((r) => r.url().includes('pay_invoice'))
+    await page.getByRole('button', { name: /^Pay \$1,180/ }).click()
+    const charge = (await (await payResp).json()).data
+    expect(charge.charged).toBe(true)
+    expect(charge.attempt).toBeTruthy()
+
+    // The webhook settles it; the invoice flips to Paid in the UI.
+    await billing.deliverWebhook({ attempt: charge.attempt })
+    await page.goto('/dashboard/billing/invoices')
+    await expect(open(page).filter({ hasText: 'Paid' })).toHaveCount(1)
+    await expect(open(page).filter({ hasText: 'Open' })).toHaveCount(0)
+  })
+})

--- a/e2e/billing/topup-razorpay.spec.js
+++ b/e2e/billing/topup-razorpay.spec.js
@@ -23,7 +23,7 @@ test.describe('Wallet top-up (Razorpay)', () => {
     await dialog.getByRole('button', { name: 'Continue to payment' }).click()
 
     const order = (await (await orderResp).json()).data
-    expect(order.gateway).toBe('GW-Razorpay') // INR routes to Razorpay
+    expect(order.adapter_key).toBe('Razorpay') // INR routes to a Razorpay rail
     expect(order.order_id).toMatch(/^order_/) // a genuine test-mode order id
 
     // The genuine Razorpay test sheet opens against that real order.

--- a/e2e/billing/topup-razorpay.spec.js
+++ b/e2e/billing/topup-razorpay.spec.js
@@ -1,0 +1,47 @@
+import { test, expect } from './fixtures'
+
+// INR wallet top-up over the Razorpay rail. The hosted Razorpay sheet loads
+// hCaptcha + fraud frames and a cross-origin 3DS simulator, so it can't be clicked
+// through reliably — we drive the real UI up to the point where the *genuine*
+// Razorpay test sheet opens against a *real* test order, then finish the no-mock
+// path at the gateway boundary: a test-only endpoint signs that real order with
+// the real test secret (the exact HMAC Razorpay's callback returns) and calls the
+// real confirm_topup, which verifies the signature and credits the wallet. The
+// only synthetic value is the payment-id string. See e2e.py:finish_razorpay_topup.
+test.describe('Wallet top-up (Razorpay)', () => {
+  test('opens the real Razorpay sheet for an INR order and credits the wallet', async ({ page, billing }) => {
+    const { team } = await billing.signIn({ scenario: 'ready', currency: 'INR' })
+
+    await page.goto('/dashboard/billing/credits')
+    await expect(page.getByText('No credit activity yet.')).toBeVisible()
+
+    // Capture the REAL Razorpay order create_topup_order mints on "Continue".
+    const orderResp = page.waitForResponse((r) => r.url().includes('create_topup_order'))
+    await page.getByRole('button', { name: 'Top up' }).click()
+    const dialog = page.getByRole('dialog')
+    await dialog.getByLabel('Amount').fill('1000')
+    await dialog.getByRole('button', { name: 'Continue to payment' }).click()
+
+    const order = (await (await orderResp).json()).data
+    expect(order.gateway).toBe('GW-Razorpay') // INR routes to Razorpay
+    expect(order.order_id).toMatch(/^order_/) // a genuine test-mode order id
+
+    // The genuine Razorpay test sheet opens against that real order.
+    await expect
+      .poll(
+        () => page.frames().some((f) => /api\.razorpay\.com\/v1\/checkout\/public/.test(f.url())),
+        { timeout: 20_000 },
+      )
+      .toBe(true)
+
+    // Finish the no-mock path at the gateway boundary (real secret, real signature,
+    // real confirm_topup).
+    await billing.finishRazorpay({ team, gateway: order.gateway, orderId: order.order_id, amount: 1000 })
+
+    // The wallet now reflects the credited ₹1,000 top-up, keyed on the payment id.
+    await page.goto('/dashboard/billing/credits')
+    await expect(page.getByText('No credit activity yet.')).toHaveCount(0)
+    await expect(page.getByText(/Wallet top-up \(pay_/)).toBeVisible()
+    await expect(page.getByText('1,000').first()).toBeVisible()
+  })
+})

--- a/e2e/billing/topup-stripe.spec.js
+++ b/e2e/billing/topup-stripe.spec.js
@@ -1,0 +1,42 @@
+import { test, expect } from './fixtures'
+import { fillStripeCard } from './helpers/stripe.js'
+
+// The hero no-mock flow: a USD team tops up its wallet through the *real* Stripe
+// test sandbox. The seed completes the billing profile (un-gating money movement)
+// in USD, whose default gateway is Stripe — so "Top up" deterministically routes
+// to the embedded Stripe card Element. We type the 4242 test card into Stripe's
+// own iframe, confirm a genuine test-mode PaymentIntent, and the backend credits
+// the wallet only after Stripe confirms the charge. Nothing is stubbed.
+test.describe('Wallet top-up (Stripe)', () => {
+  test('tops up a USD wallet via a real Stripe test-mode PaymentIntent', async ({ page, billing }) => {
+    await billing.signIn({ scenario: 'ready', currency: 'USD' })
+
+    await page.goto('/dashboard/billing/credits')
+
+    // Wallet starts empty.
+    await expect(page.getByText('Wallet balance')).toBeVisible()
+    await expect(page.getByText('No credit activity yet.')).toBeVisible()
+
+    // Amount step.
+    await page.getByRole('button', { name: 'Top up' }).click()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog.getByText('Top up wallet')).toBeVisible()
+    await dialog.getByRole('button', { name: '$1,000' }).click() // preset
+    await dialog.getByRole('button', { name: 'Continue to payment' }).click()
+
+    // Stripe card phase: fill the real Stripe Element, then pay.
+    await fillStripeCard(dialog, { number: '4242424242424242', expiry: '12 / 34', cvc: '123' })
+    const pay = dialog.getByRole('button', { name: /^Pay/ })
+    await expect(pay).toBeEnabled({ timeout: 20_000 }) // enables once the card validates
+    await pay.click()
+
+    // Wallet credited only after Stripe confirms — assert the user-visible result.
+    // (exact: true avoids also matching the aria-live announcer's prefixed copy.)
+    await expect(page.getByText('Wallet topped up.', { exact: true })).toBeVisible({ timeout: 30_000 })
+    await expect(page.getByText('No credit activity yet.')).toHaveCount(0)
+    // A credit-history row records the top-up against its real Stripe PaymentIntent id.
+    await expect(page.getByText(/Wallet top-up \(pi_/)).toBeVisible()
+    // Balance tile now reflects the $1,000 top-up.
+    await expect(page.getByText('1,000').first()).toBeVisible()
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,75 @@
+{
+  "name": "press",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "press",
+      "version": "0.0.0",
+      "hasInstallScript": true,
+      "devDependencies": {
+        "@playwright/test": "^1.61.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"
   },
- "version": "0.0.0"
+  "version": "0.0.0",
+  "devDependencies": {
+    "@playwright/test": "^1.61.0"
+  }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// End-to-end suite for billing — NO MOCKS. Specs drive the real Frappe-UI
+// dashboard against a running `central.local` bench and the real gateway test
+// sandboxes (Stripe/Razorpay test keys live in common_site_config.json). The
+// bench must already be up (`bench start`); we don't manage it from here because
+// it serves many things beyond this suite.
+//
+//   yarn test:e2e            # headless
+//   yarn test:e2e:headed     # watch it drive a real browser
+//
+// Override the target with E2E_BASE_URL (host must resolve to the site, since
+// Frappe routes by Host header — central.local is in /etc/hosts on the dev bench).
+const BASE_URL = process.env.E2E_BASE_URL || 'http://central.local:8011'
+
+export default defineConfig({
+  testDir: './e2e',
+  // The gateway round-trips (real Stripe/Razorpay test calls) are the slow part;
+  // give specs and assertions generous ceilings so a live API hop never flakes.
+  timeout: 90_000,
+  expect: { timeout: 15_000 },
+  // Real gateway sandboxes are shared mutable state and rate-limited; run serially
+  // so two specs never confirm against Stripe at the same instant.
+  workers: 1,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: BASE_URL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+})


### PR DESCRIPTION
## Billing E2E suite (no mocks)

Adds a Playwright end-to-end suite that drives the **real** Frappe-UI dashboard against a running bench and the **real Stripe/Razorpay test sandboxes**. Nothing is stubbed: top-ups create genuine test-mode PaymentIntents / Razorpay orders, invoices settle through the real credits→card waterfall, charges hit real off-session PaymentIntents, and refunds issue real Stripe refunds — the wallet/invoice only ever moves after the gateway confirms.

### What's covered (16 specs)

| Area | Spec | No-mock surface |
| --- | --- | --- |
| Onboarding | `onboarding.spec.js` | real `save_billing_profile` |
| Top-up (Stripe) | `topup-stripe.spec.js` | real test-mode PaymentIntent (4242 in the Stripe Element) |
| Top-up (Razorpay) | `topup-razorpay.spec.js` | real Razorpay test order + real signature, real `confirm_topup` |
| Invoices | `invoices.spec.js` | real `Invoice` docs (list + detail) |
| Settlement | `settlement.spec.js` | credits-only, partial credits + card, UI "Pay" — real waterfall + `apply_webhook` |
| UPI Autopay | `mandate-upi.spec.js` | real Razorpay recurring order/sheet, real `confirm_mandate` |
| E-mandate | `emandate.spec.js` | fully real pre-debit notice + ₹15,000 Action Required fork |
| Dunning | `dunning.spec.js` | real Stripe decline → Overdue + Past Due (real state machine, simulated clock) |
| Refunds | `refunds.spec.js` | real Stripe refund (full dispute) + wallet credit (partial overcharge) |

### How it stays "no mocks"

- Gateway adapters prefer `common_site_config` keys, so the real `sk_test_`/`rzp_test` keys flow into every charge automatically.
- Card charges use a real Stripe customer + card (`tok_visa` / `tok_chargeCustomerFail` for declines), charged off-session through the real adapter.
- **Documented boundaries** (where a third-party constraint blocks full automation, the *logic* stays real and only the un-automatable token/keystroke is synthesized):
  - **Razorpay hosted Checkout** (top-up, UPI mandate) loads hCaptcha/fraud frames + a 3DS simulator and resists automation. We drive the UI until the **real** sheet opens against a **real** order, then finish at the gateway boundary with the **real** checkout-callback signature (only the `pay_…`/recurring-token id is synthetic — Razorpay issues those only via the bank/UPI auth flow).
  - **Webhooks** can't reach a local bench, so `Open → Paid` is delivered by building a `Webhook Event` from the **real** captured txn id and running the **real** `apply_webhook` (skips only the HTTP signature check, which unit tests already cover).
  - Dunning **suspend/terminate** need `entitlement_private_key` (Ed25519 signing), out of scope for the test bench — covered through Overdue + Past Due.

### Test isolation

Each spec provisions an isolated team + login through test-only, **`allow_tests`-gated** endpoints in `central/billing/tests/e2e.py` (unreachable on a production site), and tears it all down in `afterEach`. Teardown is step-resilient (savepoint per delete) so a single failing delete can never leak a team/user. A full run leaves **zero residue** (verified).

### CI

`.github/workflows/e2e.yml` runs on push to `develop` + manual dispatch (not PRs — it needs gateway secrets, which aren't exposed to fork PRs). It boots a bench + `test_site`, builds the SPA, seeds the catalog/gateways, serves on :8000, runs Playwright, and uploads the HTML report.
**Required repo secrets:** `STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`, `RAZORPAY_KEY_ID`, `RAZORPAY_KEY_SECRET` — the job fails fast if they're absent.