### PR TITLE
feat(atlas): asset mirror — inbound event webhook + reconcile

### DIFF
--- a/central/api.py
+++ b/central/api.py
@@ -36,3 +36,63 @@ def check_capability(user: str, team: str, capability: str) -> dict:
 		"capability": capability,
 		"allowed": can(user, team, capability),
 	}
+
+
+# --- Atlas-facing inbound contract (spec/16-central.md "The wire contract") --
+# Atlas is the client: it pings, registers, fetches catalogs, and reports events.
+# Authenticated by the calling Atlas's Frappe token; `register` assigns the
+# `atlas_id` that `event` then routes on.
+
+
+@frappe.whitelist(methods=["GET"])
+def ping() -> dict:
+	"""Reachability + auth check for a registering Atlas."""
+	return {"label": frappe.local.site}
+
+
+@frappe.whitelist(methods=["POST"])
+def register(**kwargs) -> dict:
+	"""Register a regional Atlas: match its (operator-created) Atlas Instance by
+	region and assign a stable `atlas_id`, which Atlas stamps on every event so we
+	can route them to this cluster."""
+	region = frappe._dict(kwargs).region
+	if not region:
+		frappe.throw(_("region is required to register."), frappe.ValidationError)
+	name = frappe.db.get_value("Atlas Instance", {"region": region})
+	if not name:
+		frappe.throw(_("No Atlas Instance configured for region {0}.").format(region), frappe.DoesNotExistError)
+	instance = frappe.get_doc("Atlas Instance", name)
+	if not instance.atlas_id:
+		instance.atlas_id = frappe.generate_hash(length=12)
+		# System write: Atlas Instance is operator-managed (not writable by the
+		# authenticated service caller), and stamping the id is part of registration.
+		instance.save(ignore_permissions=True)
+	return {"atlas_id": instance.atlas_id, "label": frappe.local.site}
+
+
+@frappe.whitelist(methods=["GET"])
+def sizes() -> dict:
+	"""VM size catalog Central declares for Atlas. Empty until catalog management
+	lands — wired so Atlas's Fetch Sizes is a clean no-op, not an error."""
+	return {"sizes": []}
+
+
+@frappe.whitelist(methods=["GET"])
+def images() -> dict:
+	"""Expected bench images Central declares for Atlas. Empty for now (see sizes)."""
+	return {"images": []}
+
+
+@frappe.whitelist(methods=["POST"])
+def event(**kwargs) -> dict:
+	"""Webhook sink for Atlas lifecycle events (spec/16-central.md § Event reporting).
+
+	Atlas authenticates with its Frappe token; `ingest_event` then verifies the
+	`atlas_id` is one we know before touching the mirror. Body: `atlas_id`, `type`,
+	`payload`, `occurred_at`.
+	"""
+	from central.atlas import ingest_event
+
+	data = frappe._dict(kwargs)
+	payload = frappe.parse_json(data.payload) if isinstance(data.payload, str) else (data.payload or {})
+	return ingest_event(data.atlas_id, data.type, payload, data.occurred_at)

--- a/central/atlas.py
+++ b/central/atlas.py
@@ -2,51 +2,16 @@ from __future__ import annotations
 
 import frappe
 
-from central.atlas_client import AtlasClient, stub_vm_inventory
-from central.iam import can, get_user_team_names, user_has_operator_bypass
+from central.atlas_client import AtlasClient
+from central.iam import can, get_user_team_names
 
-# Edge B → registry mirror. Central holds a read model of each team's VMs as Asset
-# rows. `registry` is a pure read of that mirror; `refresh_assets` (a POST) syncs it
-# from every Active Atlas. Source of truth stays in Atlas.
-
-
-def _inventory(instance, team: str) -> list[dict]:
-	"""Team's VMs in one cluster. Real Atlas call, or the dev stub when the
-	`atlas_use_stub_inventory` flag is set — never fabricated data in prod."""
-	if frappe.conf.get("atlas_use_stub_inventory"):
-		return stub_vm_inventory(team)
-	return AtlasClient(instance).list_vms(team)
-
-
-def _upsert_asset(team: str, cluster: str, vm: dict, now) -> None:
-	rid = vm["resource_id"]
-	doc = frappe.get_doc("Asset", rid) if frappe.db.exists("Asset", rid) else frappe.new_doc("Asset")
-	doc.resource_id = rid
-	doc.team = team
-	doc.cluster = cluster
-	doc.status = vm.get("status") or "Provisioning"
-	doc.gateway_url = vm.get("gateway_url") or None
-	doc.last_synced_at = now
-	doc.save(ignore_permissions=True)
-
-
-def sync_team_assets(team: str) -> dict:
-	"""Mirror a team's VMs from every Active Atlas into Asset rows. Fail-soft: a
-	cluster that errors is reported in `stale`, leaving its last-known mirror intact."""
-	now = frappe.utils.now_datetime()
-	synced, stale = [], []
-	for region in frappe.get_all("Atlas Instance", filters={"status": "Active"}, pluck="name"):
-		instance = frappe.get_doc("Atlas Instance", region)
-		try:
-			vms = _inventory(instance, team)
-		except Exception:
-			frappe.log_error(title=f"Atlas inventory sync failed: {region}")
-			stale.append(region)
-			continue
-		for vm in vms:
-			_upsert_asset(team, region, vm, now)
-		synced.append(region)
-	return {"synced": synced, "stale": stale}
+# Edge B → the Asset mirror. Central holds a read model of each team's VMs as
+# Asset rows, kept fresh two ways: Atlas pushes lifecycle events to the
+# `central.api.event` webhook (low latency), and a periodic reconcile pulls the
+# authoritative list to correct any drift the push missed. Source of truth stays
+# in Atlas; both paths share one idempotent, last-writer-wins upsert. The Asset
+# mirrors the VM verbatim (its `status` is the Atlas status as-is). The command
+# path (Central → Atlas) lives at the bottom of this module.
 
 
 def _resolve_team(user: str, team: str | None) -> str:
@@ -58,11 +23,132 @@ def _resolve_team(user: str, team: str | None) -> str:
 	return teams[0]
 
 
+# --- the shared upsert ------------------------------------------------------
+
+
+def _is_stale(resource_id: str, occurred_at) -> bool:
+	"""Last-writer-wins: True if we've already applied a newer event for this VM."""
+	last = frappe.db.get_value("Asset", resource_id, "last_event_at")
+	return bool(last and occurred_at and frappe.utils.get_datetime(last) > frappe.utils.get_datetime(occurred_at))
+
+
+def _mirror_vm(cluster: str, vm: dict, *, occurred_at=None, synced_at=None) -> None:
+	"""Upsert one VM into the Asset mirror — shared by the event push (pass
+	`occurred_at`, which drives LWW) and the reconcile pull (pass `synced_at`). A
+	VM with no team (`central_reference`) belongs to no team's mirror and is
+	skipped."""
+	resource_id, team = vm.get("name"), vm.get("central_reference")
+	if not resource_id or not team or not frappe.db.exists("Team", team):
+		return
+	exists = frappe.db.exists("Asset", resource_id)
+	if exists and occurred_at and _is_stale(resource_id, occurred_at):
+		return
+	doc = frappe.get_doc("Asset", resource_id) if exists else frappe.new_doc("Asset")
+	doc.resource_id = resource_id
+	doc.team = team
+	doc.cluster = cluster
+	doc.status = vm.get("status") or "Pending"
+	doc.title = vm.get("title")
+	doc.vcpus = vm.get("vcpus")
+	doc.memory_megabytes = vm.get("memory_megabytes")
+	doc.disk_gigabytes = vm.get("disk_gigabytes")
+	doc.ipv6_address = vm.get("ipv6_address")
+	doc.public_ipv4 = vm.get("public_ipv4")
+	doc.gateway_url = vm.get("gateway_url") or None
+	if occurred_at:
+		doc.last_event_at = occurred_at
+	if synced_at:
+		doc.last_synced_at = synced_at
+	# System write: Asset is a read-only mirror (users can't write it); the sync
+	# is the sole writer, authorized by the verified Atlas event, not desk RBAC.
+	doc.save(ignore_permissions=True)
+
+
+# --- push: inbound events (central.api.event delegates here) ----------------
+
+
+def _atlas_cluster(atlas_id: str) -> str:
+	"""The cluster (Atlas Instance) an event came from — and the 'known sender'
+	check: events from an unregistered or disabled Atlas are refused."""
+	cluster = frappe.db.get_value("Atlas Instance", {"atlas_id": atlas_id, "status": ["!=", "Disabled"]})
+	if not cluster:
+		frappe.throw(f"Unknown or disabled Atlas '{atlas_id}'.", frappe.PermissionError)
+	return cluster
+
+
+def _on_ping(cluster: str, payload: dict, occurred_at) -> None:
+	print("ping", cluster, payload, occurred_at)
+
+
+def _on_vm(cluster: str, payload: dict, occurred_at) -> None:
+	_mirror_vm(cluster, payload, occurred_at=occurred_at)
+
+
+def _on_vm_deleted(cluster: str, payload: dict, occurred_at) -> None:
+	resource_id = payload.get("name")
+	if resource_id and frappe.db.exists("Asset", resource_id) and not _is_stale(resource_id, occurred_at):
+		frappe.db.set_value("Asset", resource_id, {"status": "Terminated", "last_event_at": occurred_at})
+
+
+_EVENT_HANDLERS = {
+	"ping": _on_ping,
+	"vm.created": _on_vm,
+	"vm.status_changed": _on_vm,
+	"vm.deleted": _on_vm_deleted,
+}
+
+
+def ingest_event(atlas_id: str, event_type: str, payload: dict, occurred_at) -> dict:
+	"""Apply one verified Atlas event to the mirror, dispatched by type. Unknown
+	types are acknowledged and ignored (forward-compatible)."""
+	cluster = _atlas_cluster(atlas_id)
+	handler = _EVENT_HANDLERS.get(event_type)
+	if handler:
+		handler(cluster, payload or {}, occurred_at)
+	return {"ok": True, "handled": bool(handler)}
+
+
+# --- pull: reconcile (periodic + manual backstop) ---------------------------
+
+
+def reconcile_atlas(instance, team: str | None = None) -> int:
+	"""Pull the authoritative VM list from one Atlas and sync the mirror: upsert
+	each, then mark vanished ones Terminated. Optionally scope to one team."""
+	now = frappe.utils.now_datetime()
+	vms = AtlasClient(instance).central_vms(team)
+	seen = {vm.get("name") for vm in vms}
+	for vm in vms:
+		_mirror_vm(instance.name, vm, synced_at=now)
+	gone = {"cluster": instance.name, "status": ["!=", "Terminated"]}
+	if team:
+		gone["team"] = team
+	for resource_id in frappe.get_all("Asset", filters=gone, pluck="name"):
+		if resource_id not in seen:
+			frappe.db.set_value("Asset", resource_id, {"status": "Terminated", "last_synced_at": now})
+	return len(vms)
+
+
+def reconcile(team: str | None = None) -> dict:
+	"""Reconcile the Asset mirror against every Active Atlas — the periodic backstop
+	to the event push (and the scheduler entry point). Fail-soft: an unreachable
+	Atlas is reported in `stale`, its last-known mirror left intact."""
+	synced, stale = [], []
+	for name in frappe.get_all("Atlas Instance", {"status": "Active"}, pluck="name"):
+		try:
+			reconcile_atlas(frappe.get_doc("Atlas Instance", name), team)
+			synced.append(name)
+		except Exception:
+			frappe.log_error(title=f"Atlas reconcile failed: {name}")
+			stale.append(name)
+	return {"synced": synced, "stale": stale}
+
+
+# --- read + manual refresh (dashboard) --------------------------------------
+
+
 @frappe.whitelist(methods=["GET"])
 def registry(team: str | None = None) -> dict:
-	"""List a team's VMs from the Asset mirror — a pure read. Gated on `cluster:view`.
-	The cluster is denormalized on each Asset, so no join is needed. Populate or
-	refresh the mirror with `refresh_assets`."""
+	"""List a team's VMs from the Asset mirror — a pure read. Gated on `cluster:view`."""
 	user = frappe.session.user
 	team = _resolve_team(user, team)
 	if not can(user, team, "cluster:view"):
@@ -70,7 +156,19 @@ def registry(team: str | None = None) -> dict:
 	assets = frappe.get_all(
 		"Asset",
 		filters={"team": team},
-		fields=["resource_id", "cluster", "status", "gateway_url", "last_synced_at"],
+		fields=[
+			"resource_id",
+			"title",
+			"cluster",
+			"status",
+			"vcpus",
+			"memory_megabytes",
+			"disk_gigabytes",
+			"ipv6_address",
+			"public_ipv4",
+			"gateway_url",
+			"last_synced_at",
+		],
 		order_by="cluster asc, resource_id asc",
 	)
 	return {"team": team, "assets": assets}
@@ -78,19 +176,19 @@ def registry(team: str | None = None) -> dict:
 
 @frappe.whitelist(methods=["POST"])
 def refresh_assets(team: str | None = None) -> dict:
-	"""Refresh the team's Asset mirror from every Active Atlas (writes; Frappe
-	commits the POST). Gated on `cluster:view`. Returns which clusters synced vs.
-	were left stale (Atlas unreachable)."""
+	"""Manually reconcile this team's mirror from every Active Atlas — the on-demand
+	twin of the scheduled reconcile. Gated on `cluster:view`."""
 	user = frappe.session.user
 	team = _resolve_team(user, team)
 	if not can(user, team, "cluster:view"):
 		frappe.throw("You can't refresh this team's clusters.", frappe.PermissionError)
-	return sync_team_assets(team)
+	return reconcile(team)
 
 
-# Command path → Central drives Atlas. Capability-gated here (Atlas stays
-# policy-unaware); Central calls Atlas as the operator. create stamps the team's
-# Tenant; lifecycle methods act on an existing asset by id.
+# --- command path: Central drives Atlas -------------------------------------
+# Capability-gated here (Atlas stays policy-unaware); Central calls Atlas as the
+# operator. Lifecycle methods act on an existing asset by id.
+
 
 def _run_command(action: str, capability: str, atlas_method: str, team: str | None, resource_id: str | None) -> dict:
 	"""Shared lifecycle path (start/stop/terminate): gate on `capability`,confirm

--- a/central/atlas_client.py
+++ b/central/atlas_client.py
@@ -3,21 +3,12 @@ from __future__ import annotations
 import frappe
 from frappe.frappeclient import FrappeClient
 
-# Frozen inventory contract Atlas fulfils and Central mirrors into Asset rows.
-INVENTORY_VM_FIELDS = ("resource_id", "status", "gateway_url")
+# Edge B: Central → regional Atlas, over Frappe's standard FrappeClient. Token
+# auth uses the per-instance API key/secret on the `Atlas Instance` record.
 
 
 class AtlasError(frappe.ValidationError):
 	pass
-
-
-def stub_vm_inventory(team: str) -> list[dict]:
-	"""Canned inventory in INVENTORY_VM_FIELDS shape — used by the dev sync until
-	Atlas ships the real endpoint. Keeps Central buildable against a fake."""
-	return [
-		{"resource_id": "vm-blr-1", "status": "Running", "gateway_url": "http://localhost:3030"},
-		{"resource_id": "vm-blr-2", "status": "Stopped", "gateway_url": ""},
-	]
 
 
 def get_atlas_instance(region: str):
@@ -58,6 +49,8 @@ class AtlasClient:
 			"run_doc_method", params={"dt": "Virtual Machine", "dn": name, "method": method}
 		)
 
-	def list_vms(self, team: str) -> list[dict]:
-		"""Inventory of a team's VMs in this cluster — the registry mirror source."""
-		return self.client().get_api("atlas.api.list_team_vms", {"team": team})
+	def central_vms(self, central_reference: str | None = None) -> list[dict]:
+		"""Tenant-tagged VMs on this Atlas for the mirror reconcile (optionally one
+		team). One dict per VM: name, central_reference, status, gateway_url."""
+		params = {"central_reference": central_reference} if central_reference else None
+		return self.client().get_api("atlas.atlas.api.inventory.tenant_vms", params)

--- a/central/central/doctype/asset/asset.json
+++ b/central/central/doctype/asset/asset.json
@@ -7,11 +7,18 @@
  "engine": "InnoDB",
  "field_order": [
   "resource_id",
+  "title",
   "team",
   "cluster",
   "status",
+  "vcpus",
+  "memory_megabytes",
+  "disk_gigabytes",
+  "ipv6_address",
+  "public_ipv4",
   "gateway_url",
-  "last_synced_at"
+  "last_synced_at",
+  "last_event_at"
  ],
  "fields": [
   {
@@ -22,6 +29,14 @@
    "label": "Resource ID",
    "reqd": 1,
    "unique": 1
+  },
+  {
+   "description": "Human label, mirrored from the Atlas VM (resource_id is a UUID).",
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title",
+   "read_only": 1
   },
   {
    "description": "Owning Central team (mirrored from Atlas).",
@@ -44,25 +59,64 @@
    "reqd": 1
   },
   {
-   "default": "Provisioning",
+   "default": "Pending",
+   "description": "Mirrors the Atlas Virtual Machine status verbatim.",
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Provisioning\nRunning\nStopped\nTerminated"
+   "options": "Pending\nRunning\nPaused\nStopped\nFailed\nTerminated"
   },
   {
-   "description": "The bench gateway Central deep-links into (VM leaf). Empty unless Running.",
+   "fieldname": "vcpus",
+   "fieldtype": "Int",
+   "label": "vCPUs",
+   "read_only": 1
+  },
+  {
+   "fieldname": "memory_megabytes",
+   "fieldtype": "Int",
+   "label": "Memory (MB)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "disk_gigabytes",
+   "fieldtype": "Int",
+   "label": "Disk (GB)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "ipv6_address",
+   "fieldtype": "Data",
+   "label": "IPv6 Address",
+   "read_only": 1
+  },
+  {
+   "fieldname": "public_ipv4",
+   "fieldtype": "Data",
+   "label": "Public IPv4",
+   "read_only": 1
+  },
+  {
+   "description": "The bench gateway Central deep-links into (VM leaf). Reserved — empty until the bench-gateway layer reports it.",
    "fieldname": "gateway_url",
    "fieldtype": "Data",
    "label": "Gateway URL",
    "options": "URL"
   },
   {
+   "description": "When the last reconcile (pull) refreshed this row.",
    "fieldname": "last_synced_at",
    "fieldtype": "Datetime",
    "label": "Last Synced At",
+   "read_only": 1
+  },
+  {
+   "description": "occurred_at of the last applied Atlas event. Used for last-writer-wins so a stale or duplicate push can't overwrite newer state.",
+   "fieldname": "last_event_at",
+   "fieldtype": "Datetime",
+   "label": "Last Event At",
    "read_only": 1
   }
  ],

--- a/central/central/doctype/asset/asset.py
+++ b/central/central/doctype/asset/asset.py
@@ -13,11 +13,18 @@ class Asset(Document):
 		from frappe.types import DF
 
 		cluster: DF.Link
+		disk_gigabytes: DF.Int
 		gateway_url: DF.Data | None
+		ipv6_address: DF.Data | None
+		last_event_at: DF.Datetime | None
 		last_synced_at: DF.Datetime | None
+		memory_megabytes: DF.Int
+		public_ipv4: DF.Data | None
 		resource_id: DF.Data
-		status: DF.Literal["Provisioning", "Running", "Stopped", "Terminated"]
+		status: DF.Literal["Pending", "Running", "Paused", "Stopped", "Failed", "Terminated"]
 		team: DF.Link
+		title: DF.Data | None
+		vcpus: DF.Int
 	# end: auto-generated types
 
 	pass

--- a/central/central/doctype/atlas_instance/atlas_instance.json
+++ b/central/central/doctype/atlas_instance/atlas_instance.json
@@ -9,6 +9,7 @@
   "region",
   "base_url",
   "status",
+  "atlas_id",
   "column_break_auth",
   "api_key",
   "api_secret",
@@ -44,6 +45,13 @@
    "label": "Status",
    "options": "Active\nDraining\nDisabled",
    "reqd": 1
+  },
+  {
+   "description": "The id this Atlas reports as in inbound events (its Central Settings.atlas_id). Routes events to this cluster. Set when the Atlas registers.",
+   "fieldname": "atlas_id",
+   "fieldtype": "Data",
+   "label": "Atlas ID",
+   "unique": 1
   },
   {
    "fieldname": "column_break_auth",

--- a/central/hooks.py
+++ b/central/hooks.py
@@ -159,6 +159,11 @@ doc_events = {
 # ---------------
 
 scheduler_events = {
+	"cron": {
+		# Asset mirror: reconcile against every Active Atlas every 10 minutes — the
+		# backstop that corrects any drift the event push (central.api.event) missed.
+		"*/10 * * * *": ["central.atlas.reconcile"],
+	},
 	"daily": [
 		"central.central.doctype.team_invitation.team_invitation.expire_pending_invitations",
 		# Billing (module): retry/dunning + staged suspension for unpaid invoices,

--- a/central/tests/test_asset.py
+++ b/central/tests/test_asset.py
@@ -1,9 +1,6 @@
-from unittest.mock import patch
-
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from central.atlas_client import INVENTORY_VM_FIELDS, AtlasClient, stub_vm_inventory
 from central.tests.test_iam import ensure_user
 
 
@@ -46,19 +43,3 @@ class TestAsset(IntegrationTestCase):
 		self.assertEqual(asset.name, "vm-xyz")
 		self.assertEqual(asset.team, self.team.name)
 		self.assertEqual(asset.cluster, self.cluster)
-
-	def test_inventory_stub_matches_contract_shape(self):
-		vms = stub_vm_inventory(self.team.name)
-		self.assertTrue(vms)
-		for vm in vms:
-			self.assertEqual(set(vm.keys()), set(INVENTORY_VM_FIELDS))
-
-	def test_list_vms_calls_team_scoped_endpoint(self):
-		inst = frappe.get_doc("Atlas Instance", self.cluster)
-		with patch("central.atlas_client.requests.request") as req:
-			req.return_value.json.return_value = []
-			req.return_value.raise_for_status.return_value = None
-			AtlasClient(inst).list_vms(self.team.name)
-			_, kwargs = req.call_args
-			self.assertEqual(kwargs["params"], {"team": self.team.name})
-			self.assertTrue(req.call_args[0][1].endswith("/api/method/atlas.api.list_team_vms"))

--- a/central/tests/test_atlas_instance.py
+++ b/central/tests/test_atlas_instance.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import frappe
 from frappe.tests import IntegrationTestCase
 
@@ -37,17 +35,14 @@ class TestAtlasInstance(IntegrationTestCase):
 		with self.assertRaises(AtlasError):
 			get_atlas_instance("no-such-region")
 
-	def test_request_sends_token_auth_and_disabled_is_blocked(self):
+	def test_client_carries_token_auth_and_disabled_is_blocked(self):
 		inst = self.make_instance("blr-auth")
-		with patch("central.atlas_client.requests.request") as req:
-			req.return_value.json.return_value = {"message": "pong"}
-			req.return_value.raise_for_status.return_value = None
-			AtlasClient(inst).ping()
-			_, kwargs = req.call_args
-			self.assertEqual(kwargs["headers"]["Authorization"], "token key123:secret456")
-			self.assertEqual(req.call_args[0][1], "https://atlas.example.test/api/method/ping")
+		client = AtlasClient(inst).client()
+		self.assertEqual(client.url, "https://atlas.example.test")
+		self.assertEqual(client.api_key, "key123")
+		self.assertEqual(client.api_secret, "secret456")
 
 		inst.status = "Disabled"
 		inst.save()
 		with self.assertRaises(AtlasError):
-			AtlasClient(inst).ping()
+			AtlasClient(inst).client()

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -3,15 +3,13 @@ from unittest.mock import patch
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from central.atlas import refresh_assets, registry, sync_team_assets
+from central.atlas import ingest_event, reconcile, reconcile_atlas, refresh_assets, registry
 from central.tests.test_iam import ensure_user
 
 
-class TestAtlasSync(IntegrationTestCase):
+class TestAtlasMirror(IntegrationTestCase):
 	def setUp(self):
 		frappe.set_user("Administrator")
-		self._orig_stub = frappe.conf.get("atlas_use_stub_inventory")
-		frappe.conf.atlas_use_stub_inventory = 1
 		self.owner = ensure_user("sync.owner@example.test")
 		self.outsider = ensure_user("sync.outsider@example.test")
 		self.team = frappe.get_doc(
@@ -23,6 +21,7 @@ class TestAtlasSync(IntegrationTestCase):
 			}
 		).insert()
 		self.region = "blr-sync"
+		self.atlas_id = "atlas-blr-sync"
 		if not frappe.db.exists("Atlas Instance", self.region):
 			frappe.get_doc(
 				{
@@ -30,44 +29,100 @@ class TestAtlasSync(IntegrationTestCase):
 					"region": self.region,
 					"base_url": "https://atlas.example.test",
 					"status": "Active",
+					"atlas_id": self.atlas_id,
 					"api_key": "k",
 					"api_secret": "s",
 				}
 			).insert()
+		else:
+			frappe.db.set_value("Atlas Instance", self.region, "atlas_id", self.atlas_id)
 
 	def tearDown(self):
-		frappe.conf.atlas_use_stub_inventory = self._orig_stub
 		frappe.set_user("Administrator")
 
-	def test_sync_mirrors_inventory_into_assets(self):
-		freshness = sync_team_assets(self.team.name)
-		self.assertIn(self.region, freshness["synced"])
-		self.assertEqual(freshness["stale"], [])
+	def _push(self, event_type, vm, occurred_at):
+		return ingest_event(self.atlas_id, event_type, vm, occurred_at)
 
-		vm = frappe.get_doc("Asset", "vm-blr-1")
-		self.assertEqual(vm.team, self.team.name)
-		self.assertEqual(vm.cluster, self.region)
-		self.assertEqual(vm.status, "Running")
-		self.assertTrue(vm.last_synced_at)
+	# --- push -----------------------------------------------------------------
 
-	def test_registry_lists_mirrored_assets(self):
-		sync_team_assets(self.team.name)
-		result = registry(team=self.team.name)
-		ids = {a["resource_id"] for a in result["assets"]}
-		self.assertIn("vm-blr-1", ids)
+	def test_push_creates_then_updates_with_lww(self):
+		self._push(
+			"vm.created",
+			{"name": "vm-1", "central_reference": self.team.name, "status": "Running"},
+			"2026-06-18 10:00:00",
+		)
+		asset = frappe.get_doc("Asset", "vm-1")
+		self.assertEqual(asset.team, self.team.name)
+		self.assertEqual(asset.cluster, self.region)
+		self.assertEqual(asset.status, "Running")
 
-	def test_refresh_assets_syncs_then_registry_lists(self):
-		freshness = refresh_assets(team=self.team.name)
-		self.assertIn(self.region, freshness["synced"])
+		# a newer event applies
+		self._push(
+			"vm.status_changed",
+			{"name": "vm-1", "central_reference": self.team.name, "status": "Stopped"},
+			"2026-06-18 10:05:00",
+		)
+		self.assertEqual(frappe.db.get_value("Asset", "vm-1", "status"), "Stopped")
+
+		# a stale (older) event is ignored
+		self._push(
+			"vm.status_changed",
+			{"name": "vm-1", "central_reference": self.team.name, "status": "Running"},
+			"2026-06-18 09:00:00",
+		)
+		self.assertEqual(frappe.db.get_value("Asset", "vm-1", "status"), "Stopped")
+
+	def test_push_from_unknown_atlas_is_refused(self):
+		with self.assertRaises(frappe.PermissionError):
+			ingest_event(
+				"who-dis",
+				"vm.created",
+				{"name": "vm-x", "central_reference": self.team.name, "status": "Running"},
+				"2026-06-18 10:00:00",
+			)
+
+	def test_push_skips_untenanted_vm(self):
+		self._push("vm.created", {"name": "vm-op", "central_reference": None, "status": "Running"}, "2026-06-18 10:00:00")
+		self.assertFalse(frappe.db.exists("Asset", "vm-op"))
+
+	def test_vm_deleted_marks_terminated(self):
+		self._push(
+			"vm.created",
+			{"name": "vm-2", "central_reference": self.team.name, "status": "Running"},
+			"2026-06-18 10:00:00",
+		)
+		self._push("vm.deleted", {"name": "vm-2"}, "2026-06-18 11:00:00")
+		self.assertEqual(frappe.db.get_value("Asset", "vm-2", "status"), "Terminated")
+
+	# --- pull / reconcile -----------------------------------------------------
+
+	def test_reconcile_upserts_present_and_terminates_missing(self):
+		self._push(
+			"vm.created",
+			{"name": "gone", "central_reference": self.team.name, "status": "Running"},
+			"2026-06-18 10:00:00",
+		)
+		instance = frappe.get_doc("Atlas Instance", self.region)
+		pulled = [{"name": "vm-3", "central_reference": self.team.name, "status": "Stopped", "gateway_url": None}]
+		with patch("central.atlas.AtlasClient.central_vms", return_value=pulled):
+			reconcile_atlas(instance, self.team.name)
+		self.assertEqual(frappe.db.get_value("Asset", "vm-3", "status"), "Stopped")
+		self.assertEqual(frappe.db.get_value("Asset", "gone", "status"), "Terminated")
+
+	def test_refresh_assets_reconciles_and_registry_lists(self):
+		pulled = [{"name": "vm-4", "central_reference": self.team.name, "status": "Running", "gateway_url": None}]
+		with patch("central.atlas.AtlasClient.central_vms", return_value=pulled):
+			result = refresh_assets(team=self.team.name)
+		self.assertIn(self.region, result["synced"])
 		ids = {a["resource_id"] for a in registry(team=self.team.name)["assets"]}
-		self.assertIn("vm-blr-1", ids)
+		self.assertIn("vm-4", ids)
 
-	def test_sync_is_failsoft_when_atlas_unreachable(self):
-		frappe.conf.atlas_use_stub_inventory = 0
-		with patch("central.atlas.AtlasClient.list_vms", side_effect=Exception("unreachable")):
-			freshness = sync_team_assets(self.team.name)
-		self.assertIn(self.region, freshness["stale"])
-		self.assertEqual(freshness["synced"], [])
+	def test_reconcile_is_failsoft_when_atlas_unreachable(self):
+		with patch("central.atlas.AtlasClient.central_vms", side_effect=Exception("unreachable")):
+			result = reconcile(team=self.team.name)
+		self.assertIn(self.region, result["stale"])
+
+	# --- read gate ------------------------------------------------------------
 
 	def test_registry_blocked_for_non_member(self):
 		frappe.set_user(self.outsider)


### PR DESCRIPTION
Completes Central's **Asset mirror** (Edge B): a read model of each team's Atlas VMs, kept fresh by a **push + reconcile** hybrid, on top of the already-merged command path and capability model.

## How it works
- **Push (primary):** Atlas reports VM lifecycle events to a single webhook, `central.api.event`. We verify the sender (`atlas_id` → a known, non-disabled `Atlas Instance`), dispatch by type (`vm.created`/`vm.status_changed` → upsert, `vm.deleted` → Terminated), and apply **last-writer-wins** by `occurred_at`. Idempotent upsert = dedup.
- **Reconcile (backstop):** a 10-min scheduler (`central.atlas.reconcile`) + manual `refresh_assets` pulls the authoritative VM list per Atlas, upserts, and marks vanished VMs Terminated — correcting any drift the fire-and-forget push missed.
- Both paths share one upsert (`_mirror_vm`). The Asset mirrors the Atlas VM **status verbatim** and carries `title`/size/network fields for display.

## Inbound contract (`central/api.py`)
The methods Atlas (the client) calls, per `spec/16-central.md`: `ping`, `register` (assigns the `Atlas Instance.atlas_id` events route on), `sizes`/`images` (empty stubs until catalog management lands), and `event` (the webhook sink).

## Notes
- System mirror writes use `ignore_permissions` (the `Asset` is deliberately not user-writable); each is annotated inline. Caller auth is the Frappe token + the `atlas_id` verification.
- **Companion changes live in the Atlas repo** (separate PR): `central_report._vm_payload` now sends `central_reference` (the owning team, from the VM's Tenant); new `atlas.atlas.api.inventory.tenant_vms` for reconcile; `spec/16` updated. The mirror needs these to attribute and reconcile.

## Testing
- `bench --site <site> run-tests --app central --module central.tests.test_atlas_sync` — push LWW, unknown-atlas refusal, untenanted skip, `vm.deleted`, reconcile upsert + mark-missing, fail-soft, registry gate.
- Manual: register an Atlas, create a tenant-tagged VM → Asset appears and tracks start/stop; `refresh_assets` reconciles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)