### PR TITLE
feat(servers): catalog-driven plan selection for the New Server flow

### DIFF
--- a/central/billing/api/dashboard/__init__.py
+++ b/central/billing/api/dashboard/__init__.py
@@ -13,6 +13,9 @@ this package re-exports the public API so every `billing.api.dashboard.*` path
 stays stable.
 """
 
+from central.billing.api.dashboard.catalog import (
+	get_provisionable_plans,
+)
 from central.billing.api.dashboard.account import (
 	get_billing_geo,
 	get_billing_profile,
@@ -63,6 +66,7 @@ __all__ = [
 	"get_collection_status", "set_collection_mode",
 	"list_switchable_teams",
 	"list_notifications", "get_notification_preferences", "save_notification_preferences",
+	"get_provisionable_plans",
 	"get_forecast", "list_subscriptions", "list_invoices", "get_invoice", "list_payment_attempts",
 	"get_credit_balance", "credit_ledger", "purchase_credits", "pay_invoice", "create_topup_order",
 	"confirm_topup", "pay_invoice_checkout", "confirm_invoice_checkout",

--- a/central/billing/api/dashboard/__init__.py
+++ b/central/billing/api/dashboard/__init__.py
@@ -14,7 +14,7 @@ stays stable.
 """
 
 from central.billing.api.dashboard.catalog import (
-	get_provisionable_plans,
+	get_eligible_plans,
 )
 from central.billing.api.dashboard.account import (
 	get_billing_geo,
@@ -66,7 +66,7 @@ __all__ = [
 	"get_collection_status", "set_collection_mode",
 	"list_switchable_teams",
 	"list_notifications", "get_notification_preferences", "save_notification_preferences",
-	"get_provisionable_plans",
+	"get_eligible_plans",
 	"get_forecast", "list_subscriptions", "list_invoices", "get_invoice", "list_payment_attempts",
 	"get_credit_balance", "credit_ledger", "purchase_credits", "pay_invoice", "create_topup_order",
 	"confirm_topup", "pay_invoice_checkout", "confirm_invoice_checkout",

--- a/central/billing/api/dashboard/catalog.py
+++ b/central/billing/api/dashboard/catalog.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Plan catalog for the dashboard's create-server flow.
+
+Lists the active plans a team can actually provision on a given cluster: priced
+for the team's currency on that cluster, admitted by the trust tier's allow-lists,
+and within the trust-tier spend cap. The cluster's provisioning check still has
+the final say at provision time (run-rate vs the live cap, ADR 0006); this read
+only narrows the menu the customer is shown.
+"""
+
+import frappe
+
+from central.billing.api.dashboard._shared import _resolve_team, _team_currency
+from central.billing.catalog.entitlements import get_team_caps
+from central.billing.catalog.pricing import get_catalog_rates, resolve_rate
+
+
+def _allowlist(value) -> set[str] | None:
+	"""A tier allow-list (JSON field) as a set of names, or None for 'no restriction'.
+
+	An empty/unset list is *not* an empty allow-list — it means the tier places no
+	restriction on this axis, so every candidate qualifies."""
+	if not value:
+		return None
+	items = frappe.parse_json(value) if isinstance(value, str) else value
+	names = {str(x).strip() for x in (items or []) if str(x).strip()}
+	return names or None
+
+
+@frappe.whitelist()
+def get_provisionable_plans(cluster: str | None = None, team: str | None = None) -> dict:
+	"""Active plans the team can provision on `cluster`, filtered by its trust tier.
+
+	A plan is offered only when ALL of the following hold:
+	  - it is active;
+	  - the tier's `allowed_plans` admits it (unset = all plans);
+	  - the tier's `allowed_clusters` admits `cluster` (unset = all clusters) —
+	    a forbidden cluster yields an empty list;
+	  - it prices the team's currency on this cluster (the regional Catalog Rate,
+	    else the global blank-cluster rate);
+	  - its rate fits the trust-tier spend cap (`max_spend`). An untiered team has
+	    a 0 cap and so sees only free plans — it has no provisioning headroom yet.
+	"""
+	team = _resolve_team(team)
+	currency = _team_currency(team)
+	caps = get_team_caps(team)
+	spend_cap = frappe.utils.flt(caps.max_spend)
+	cluster = (cluster or "").strip() or None
+
+	allowed_plans = _allowlist(caps.allowed_plans)
+	allowed_clusters = _allowlist(caps.allowed_clusters)
+
+	header = {
+		"team": team, "cluster": cluster, "currency": currency,
+		"tier": caps.tier, "max_spend": spend_cap,
+	}
+
+	# The tier forbids this cluster outright — nothing is provisionable here.
+	if cluster and allowed_clusters is not None and cluster not in allowed_clusters:
+		return {**header, "plans": []}
+
+	plans = []
+	for name in frappe.get_all("Plan", filters={"is_active": 1}, pluck="name", order_by="title asc"):
+		if allowed_plans is not None and name not in allowed_plans:
+			continue
+		rate = resolve_rate(get_catalog_rates("Plan", name), currency, cluster)
+		if rate is None:
+			continue  # not priced for this currency/cluster → not available here
+		if frappe.utils.flt(rate) > spend_cap:
+			continue  # beyond the trust-tier spend ceiling
+		plans.append(_plan_row(name, currency, cluster, rate))
+
+	return {**header, "plans": plans}
+
+
+def _plan_row(name: str, currency: str, cluster: str | None, rate) -> dict:
+	"""A create-server menu entry: identity, composition (specs), and resolved rate."""
+	doc = frappe.get_doc("Plan", name)
+	return {
+		"plan": name,
+		"title": doc.title,
+		"plan_class": doc.plan_class,
+		"billing_cycle": doc.billing_cycle,
+		"currency": currency,
+		"cluster": cluster,
+		"rate": frappe.utils.flt(rate),
+		"includes": [
+			{"resource_type": i.resource_type, "quantity": i.quantity, "unit": i.unit}
+			for i in doc.includes
+		],
+	}

--- a/central/billing/api/dashboard/catalog.py
+++ b/central/billing/api/dashboard/catalog.py
@@ -76,6 +76,8 @@ def get_eligible_plans(cluster: str | None = None, team: str | None = None) -> d
 			continue  # would push the team past its remaining trust-tier headroom
 		plans.append(_plan_row(name, currency, cluster, rate))
 
+	# Cheapest first; the title-ordered iteration above is a stable tiebreaker.
+	plans.sort(key=lambda p: frappe.utils.flt(p["rate"]))
 	return {**header, "plans": plans}
 
 

--- a/central/billing/api/dashboard/catalog.py
+++ b/central/billing/api/dashboard/catalog.py
@@ -29,15 +29,24 @@ def _allowlist(value) -> set[str] | None:
 	return names or None
 
 
+# Canonical class order for the grouped menu (matches the Plan.plan_class Select).
+# An unset class is folded into "General" so unclassified plans get a real label.
+_CLASS_ORDER = ["General", "CPU Optimised", "Memory Optimised", "Storage Optimised", "Custom"]
+
+
 @frappe.whitelist()
 def get_eligible_plans(cluster: str | None = None, team: str | None = None) -> dict:
-	"""Active plans the team can provision on `cluster`, filtered by its trust tier.
+	"""Active plans the team can provision on `cluster`, grouped by plan class.
+
+	`plans` is a `{plan_class: [rows]}` map so the client can render one tab per
+	class without re-grouping: keys are in canonical order (`_CLASS_ORDER`, then any
+	unknown classes alphabetically), rows within each class are cheapest-first, and
+	an unset class is folded into "General". A forbidden cluster yields an empty map.
 
 	A plan is offered only when ALL of the following hold:
 	  - it is active;
 	  - the tier's `allowed_plans` admits it (unset = all plans);
-	  - the tier's `allowed_clusters` admits `cluster` (unset = all clusters) —
-	    a forbidden cluster yields an empty list;
+	  - the tier's `allowed_clusters` admits `cluster` (unset = all clusters);
 	  - it prices the team's currency on this cluster (the regional Catalog Rate,
 	    else the global blank-cluster rate);
 	  - its rate fits the team's *remaining* headroom: the trust-tier spend cap
@@ -63,7 +72,7 @@ def get_eligible_plans(cluster: str | None = None, team: str | None = None) -> d
 
 	# The tier forbids this cluster outright — nothing is provisionable here.
 	if cluster and allowed_clusters is not None and cluster not in allowed_clusters:
-		return {**header, "plans": []}
+		return {**header, "plans": {}}
 
 	plans = []
 	for name in frappe.get_all("Plan", filters={"is_active": 1}, pluck="name", order_by="title asc"):
@@ -78,7 +87,19 @@ def get_eligible_plans(cluster: str | None = None, team: str | None = None) -> d
 
 	# Cheapest first; the title-ordered iteration above is a stable tiebreaker.
 	plans.sort(key=lambda p: frappe.utils.flt(p["rate"]))
-	return {**header, "plans": plans}
+	return {**header, "plans": _group_by_class(plans)}
+
+
+def _group_by_class(rows: list[dict]) -> dict[str, list]:
+	"""Group plan rows by class into a `{plan_class: [rows]}` map. Keys are emitted in
+	canonical order (then any unknown classes, alphabetically); `rows` keeps the
+	caller's order within each class (so cheapest-first survives)."""
+	grouped: dict[str, list] = {}
+	for row in rows:
+		grouped.setdefault(row["plan_class"], []).append(row)
+	known = [c for c in _CLASS_ORDER if c in grouped]
+	extra = sorted(c for c in grouped if c not in _CLASS_ORDER)
+	return {c: grouped[c] for c in [*known, *extra]}
 
 
 def _current_run_rate(team: str) -> float:
@@ -99,7 +120,7 @@ def _plan_row(name: str, currency: str, cluster: str | None, rate) -> dict:
 	return {
 		"plan": name,
 		"title": doc.title,
-		"plan_class": doc.plan_class,
+		"plan_class": doc.plan_class or "General",  # unset class groups under General
 		"billing_cycle": doc.billing_cycle,
 		"currency": currency,
 		"cluster": cluster,

--- a/central/billing/api/dashboard/catalog.py
+++ b/central/billing/api/dashboard/catalog.py
@@ -4,7 +4,8 @@
 
 Lists the active plans a team can actually provision on a given cluster: priced
 for the team's currency on that cluster, admitted by the trust tier's allow-lists,
-and within the trust-tier spend cap. The cluster's provisioning check still has
+and within the team's *remaining* trust-tier headroom — the spend cap minus what
+its already-running resources consume. The cluster's provisioning check still has
 the final say at provision time (run-rate vs the live cap, ADR 0006); this read
 only narrows the menu the customer is shown.
 """
@@ -39,21 +40,25 @@ def get_provisionable_plans(cluster: str | None = None, team: str | None = None)
 	    a forbidden cluster yields an empty list;
 	  - it prices the team's currency on this cluster (the regional Catalog Rate,
 	    else the global blank-cluster rate);
-	  - its rate fits the trust-tier spend cap (`max_spend`). An untiered team has
-	    a 0 cap and so sees only free plans — it has no provisioning headroom yet.
+	  - its rate fits the team's *remaining* headroom: the trust-tier spend cap
+	    (`max_spend`) minus the run-rate of its already-running resources. A team
+	    on a 4000 cap already running 1000 only sees plans priced 3000 or less.
+	    An untiered team has a 0 cap and so no headroom.
 	"""
 	team = _resolve_team(team)
 	currency = _team_currency(team)
 	caps = get_team_caps(team)
 	spend_cap = frappe.utils.flt(caps.max_spend)
+	current_spend = _current_run_rate(team)
+	available = max(0.0, frappe.utils.flt(spend_cap - current_spend))
 	cluster = (cluster or "").strip() or None
 
 	allowed_plans = _allowlist(caps.allowed_plans)
 	allowed_clusters = _allowlist(caps.allowed_clusters)
 
 	header = {
-		"team": team, "cluster": cluster, "currency": currency,
-		"tier": caps.tier, "max_spend": spend_cap,
+		"team": team, "cluster": cluster, "currency": currency, "tier": caps.tier,
+		"max_spend": spend_cap, "current_spend": current_spend, "available": available,
 	}
 
 	# The tier forbids this cluster outright — nothing is provisionable here.
@@ -67,11 +72,23 @@ def get_provisionable_plans(cluster: str | None = None, team: str | None = None)
 		rate = resolve_rate(get_catalog_rates("Plan", name), currency, cluster)
 		if rate is None:
 			continue  # not priced for this currency/cluster → not available here
-		if frappe.utils.flt(rate) > spend_cap:
-			continue  # beyond the trust-tier spend ceiling
+		if frappe.utils.flt(rate) > available:
+			continue  # would push the team past its remaining trust-tier headroom
 		plans.append(_plan_row(name, currency, cluster, rate))
 
 	return {**header, "plans": plans}
+
+
+def _current_run_rate(team: str) -> float:
+	"""The team's committed monthly run-rate: the summed `locked_rate` of its active
+	price-locks. A team bills in one currency, so the locks are already in it — no
+	normalisation needed (unlike the cross-team, INR-normalised admin view)."""
+	rates = frappe.get_all(
+		"Price Lock",
+		filters={"team": team, "ended_at": ["is", "not set"]},
+		pluck="locked_rate",
+	)
+	return frappe.utils.flt(sum(frappe.utils.flt(r) for r in rates))
 
 
 def _plan_row(name: str, currency: str, cluster: str | None, rate) -> dict:

--- a/central/billing/api/dashboard/catalog.py
+++ b/central/billing/api/dashboard/catalog.py
@@ -116,6 +116,7 @@ def _rates_by_plan(names: list[str]) -> dict[str, list]:
 		"Catalog Rate",
 		filters={"priced_doctype": "Plan", "priced_for": ["in", names]},
 		fields=["priced_for", "cluster", "currency", "rate"],
+		limit=0,  # all rates for the candidate set (get_all is unbounded, but be explicit)
 	):
 		grouped.setdefault(r.priced_for, []).append(r)
 	return grouped
@@ -131,6 +132,7 @@ def _includes_by_plan(names: list[str]) -> dict[str, list]:
 		filters={"parenttype": "Plan", "parent": ["in", names]},
 		fields=["parent", "resource_type", "quantity", "unit"],
 		order_by="idx asc",
+		limit=0,  # every composition row for the candidate set, not a 20-row page
 	):
 		grouped.setdefault(r.parent, []).append(r)
 	return grouped
@@ -156,6 +158,7 @@ def _current_run_rate(team: str) -> float:
 		"Price Lock",
 		filters={"team": team, "ended_at": ["is", "not set"]},
 		pluck="locked_rate",
+		limit=0,  # sum every active lock; a 20-row page would understate the run-rate
 	)
 	return frappe.utils.flt(sum(frappe.utils.flt(r) for r in rates))
 

--- a/central/billing/api/dashboard/catalog.py
+++ b/central/billing/api/dashboard/catalog.py
@@ -74,11 +74,14 @@ def get_eligible_plans(cluster: str | None = None, team: str | None = None) -> d
 	if cluster and allowed_clusters is not None and cluster not in allowed_clusters:
 		return {**header, "plans": {}}
 
+	# The whole active catalog is wanted on purpose — currency/cluster/headroom
+	# filtering happens in Python below — so opt out of pagination explicitly.
 	candidates = frappe.get_all(
 		"Plan",
 		filters={"is_active": 1},
 		fields=["name", "title", "plan_class", "billing_cycle"],
 		order_by="title asc",
+		limit=0,
 	)
 	if allowed_plans is not None:
 		candidates = [p for p in candidates if p.name in allowed_plans]

--- a/central/billing/api/dashboard/catalog.py
+++ b/central/billing/api/dashboard/catalog.py
@@ -30,7 +30,7 @@ def _allowlist(value) -> set[str] | None:
 
 
 @frappe.whitelist()
-def get_provisionable_plans(cluster: str | None = None, team: str | None = None) -> dict:
+def get_eligible_plans(cluster: str | None = None, team: str | None = None) -> dict:
 	"""Active plans the team can provision on `cluster`, filtered by its trust tier.
 
 	A plan is offered only when ALL of the following hold:

--- a/central/billing/api/dashboard/catalog.py
+++ b/central/billing/api/dashboard/catalog.py
@@ -14,7 +14,7 @@ import frappe
 
 from central.billing.api.dashboard._shared import _resolve_team, _team_currency
 from central.billing.catalog.entitlements import get_team_caps
-from central.billing.catalog.pricing import get_catalog_rates, resolve_rate
+from central.billing.catalog.pricing import resolve_rate
 
 
 def _allowlist(value) -> set[str] | None:
@@ -74,20 +74,63 @@ def get_eligible_plans(cluster: str | None = None, team: str | None = None) -> d
 	if cluster and allowed_clusters is not None and cluster not in allowed_clusters:
 		return {**header, "plans": {}}
 
+	candidates = frappe.get_all(
+		"Plan",
+		filters={"is_active": 1},
+		fields=["name", "title", "plan_class", "billing_cycle"],
+		order_by="title asc",
+	)
+	if allowed_plans is not None:
+		candidates = [p for p in candidates if p.name in allowed_plans]
+
+	# Bulk-load rates + composition for the whole candidate set up front, so the loop
+	# below is in-memory work — no per-plan query (was an N+1: a rates query and a
+	# get_doc per plan).
+	names = [p.name for p in candidates]
+	rates_by_plan = _rates_by_plan(names)
+	includes_by_plan = _includes_by_plan(names)
+
 	plans = []
-	for name in frappe.get_all("Plan", filters={"is_active": 1}, pluck="name", order_by="title asc"):
-		if allowed_plans is not None and name not in allowed_plans:
-			continue
-		rate = resolve_rate(get_catalog_rates("Plan", name), currency, cluster)
+	for p in candidates:
+		rate = resolve_rate(rates_by_plan.get(p.name, []), currency, cluster)
 		if rate is None:
 			continue  # not priced for this currency/cluster → not available here
 		if frappe.utils.flt(rate) > available:
 			continue  # would push the team past its remaining trust-tier headroom
-		plans.append(_plan_row(name, currency, cluster, rate))
+		plans.append(_plan_row(p, currency, cluster, rate, includes_by_plan.get(p.name, [])))
 
 	# Cheapest first; the title-ordered iteration above is a stable tiebreaker.
 	plans.sort(key=lambda p: frappe.utils.flt(p["rate"]))
 	return {**header, "plans": _group_by_class(plans)}
+
+
+def _rates_by_plan(names: list[str]) -> dict[str, list]:
+	"""Every Plan's `Catalog Rate` rows in one query, grouped by plan name."""
+	if not names:
+		return {}
+	grouped: dict[str, list] = {}
+	for r in frappe.get_all(
+		"Catalog Rate",
+		filters={"priced_doctype": "Plan", "priced_for": ["in", names]},
+		fields=["priced_for", "cluster", "currency", "rate"],
+	):
+		grouped.setdefault(r.priced_for, []).append(r)
+	return grouped
+
+
+def _includes_by_plan(names: list[str]) -> dict[str, list]:
+	"""Every Plan's `Plan Includes` rows in one query, grouped by parent (in `idx` order)."""
+	if not names:
+		return {}
+	grouped: dict[str, list] = {}
+	for r in frappe.get_all(
+		"Plan Includes",
+		filters={"parenttype": "Plan", "parent": ["in", names]},
+		fields=["parent", "resource_type", "quantity", "unit"],
+		order_by="idx asc",
+	):
+		grouped.setdefault(r.parent, []).append(r)
+	return grouped
 
 
 def _group_by_class(rows: list[dict]) -> dict[str, list]:
@@ -114,19 +157,19 @@ def _current_run_rate(team: str) -> float:
 	return frappe.utils.flt(sum(frappe.utils.flt(r) for r in rates))
 
 
-def _plan_row(name: str, currency: str, cluster: str | None, rate) -> dict:
-	"""A create-server menu entry: identity, composition (specs), and resolved rate."""
-	doc = frappe.get_doc("Plan", name)
+def _plan_row(plan, currency: str, cluster: str | None, rate, includes) -> dict:
+	"""A create-server menu entry: identity, composition (specs), and resolved rate.
+	`plan` is a bulk-fetched Plan row; `includes` its pre-loaded Plan Includes rows."""
 	return {
-		"plan": name,
-		"title": doc.title,
-		"plan_class": doc.plan_class or "General",  # unset class groups under General
-		"billing_cycle": doc.billing_cycle,
+		"plan": plan.name,
+		"title": plan.title,
+		"plan_class": plan.plan_class or "General",  # unset class groups under General
+		"billing_cycle": plan.billing_cycle,
 		"currency": currency,
 		"cluster": cluster,
 		"rate": frappe.utils.flt(rate),
 		"includes": [
 			{"resource_type": i.resource_type, "quantity": i.quantity, "unit": i.unit}
-			for i in doc.includes
+			for i in includes
 		],
 	}

--- a/central/billing/tests/test_dashboard_catalog.py
+++ b/central/billing/tests/test_dashboard_catalog.py
@@ -106,6 +106,12 @@ class TestEligiblePlans(IntegrationTestCase):
 		plans, _ = self._titles()
 		self.assertTrue({CHEAP, MID, PRICEY, REGIONAL}.issubset(plans))
 
+	def test_plans_are_ordered_cheapest_first(self):
+		set_team_tier(TEAM, max_spend=6000)
+		out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
+		rates = [p["rate"] for p in out["plans"]]
+		self.assertEqual(rates, sorted(rates))
+
 	def test_regional_plan_only_on_its_cluster(self):
 		set_team_tier(TEAM, max_spend=6000)
 		on_cluster, _ = self._titles(cluster=CLUSTER)

--- a/central/billing/tests/test_dashboard_catalog.py
+++ b/central/billing/tests/test_dashboard_catalog.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Create-server plan menu: cluster availability + trust-tier spend filter."""
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from central.billing.api.dashboard.catalog import get_provisionable_plans
+from central.billing.tests.utils import (
+	clear_team_tier,
+	complete_billing_profile,
+	ensure_team,
+	make_plan,
+	set_team_tier,
+)
+
+TEAM = "team-srv-catalog"
+CLUSTER = "ap-south-1"
+OTHER_CLUSTER = "eu-central-1"
+
+CHEAP = "bundle-cheap"      # 1000 INR
+MID = "bundle-mid"          # 2000 INR
+PRICEY = "bundle-pricey"    # 5000 INR
+REGIONAL = "bundle-regional"  # priced only on CLUSTER
+
+
+def _ensure_tier_level(name):
+	"""A linkable Trust Tier Level so set_team_tier's pin resolves and the level's
+	allow-lists are read. Money caps come from set_team_tier's override, so the
+	threshold here is just a placeholder INR row."""
+	if frappe.db.exists("Trust Tier Level", name):
+		frappe.delete_doc("Trust Tier Level", name, force=True)
+	frappe.get_doc(
+		{
+			"doctype": "Trust Tier Level", "__newname": name, "tier": name,
+			"sequence": 1, "is_default": 0, "max_resource_count": 50, "min_paid_invoices": 0,
+			"thresholds": [{"currency": "INR", "max_spend": 100000, "min_cumulative_paid": 0}],
+		}
+	).insert(ignore_permissions=True)
+
+
+def _rates(global_inr, cluster=None, cluster_inr=None):
+	rows = [{"cluster": "", "currency": "INR", "rate": global_inr}]
+	if cluster:
+		rows.append({"cluster": cluster, "currency": "INR", "rate": cluster_inr})
+	return rows
+
+
+class TestProvisionablePlans(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		complete_billing_profile(TEAM, currency="INR")
+		clear_team_tier(TEAM)  # each test pins (or leaves untiered) its own cap
+		_ensure_tier_level("t1")
+		make_plan(CHEAP, rates=_rates(1000))
+		make_plan(MID, rates=_rates(2000))
+		make_plan(PRICEY, rates=_rates(5000))
+		# Priced only on CLUSTER (no global INR row) → invisible elsewhere.
+		make_plan(REGIONAL, rates=[{"cluster": CLUSTER, "currency": "INR", "rate": 1500}])
+		frappe.set_user("Administrator")
+
+	def _titles(self, cluster=CLUSTER):
+		out = get_provisionable_plans(cluster=cluster, team=TEAM)
+		return {p["plan"] for p in out["plans"]}, out
+
+	def test_spend_cap_hides_plans_above_the_ceiling(self):
+		set_team_tier(TEAM, max_spend=2000)  # admits CHEAP (1000) + MID (2000), not PRICEY
+		plans, out = self._titles()
+		self.assertEqual(out["max_spend"], 2000)
+		self.assertIn(CHEAP, plans)
+		self.assertIn(MID, plans)
+		self.assertNotIn(PRICEY, plans)
+
+	def test_higher_cap_reveals_more_plans(self):
+		set_team_tier(TEAM, max_spend=6000)
+		plans, _ = self._titles()
+		self.assertTrue({CHEAP, MID, PRICEY, REGIONAL}.issubset(plans))
+
+	def test_regional_plan_only_on_its_cluster(self):
+		set_team_tier(TEAM, max_spend=6000)
+		on_cluster, _ = self._titles(cluster=CLUSTER)
+		off_cluster, _ = self._titles(cluster=OTHER_CLUSTER)
+		self.assertIn(REGIONAL, on_cluster)
+		self.assertNotIn(REGIONAL, off_cluster)
+
+	def test_resolved_rate_is_the_cluster_rate(self):
+		set_team_tier(TEAM, max_spend=6000)
+		# Re-price CHEAP cheaper on CLUSTER; the menu must show the regional rate.
+		make_plan(CHEAP, rates=_rates(1000, cluster=CLUSTER, cluster_inr=800))
+		out = get_provisionable_plans(cluster=CLUSTER, team=TEAM)
+		row = next(p for p in out["plans"] if p["plan"] == CHEAP)
+		self.assertEqual(row["rate"], 800)
+
+	def test_allowed_plans_allowlist_restricts_menu(self):
+		set_team_tier(TEAM, max_spend=6000)
+		frappe.db.set_value("Trust Tier Level", "t1", "allowed_plans", frappe.as_json([CHEAP, MID]))
+		self.addCleanup(frappe.db.set_value, "Trust Tier Level", "t1", "allowed_plans", None)
+		plans, _ = self._titles()
+		self.assertEqual(plans, {CHEAP, MID})
+
+	def test_allowed_clusters_forbidden_cluster_yields_empty(self):
+		set_team_tier(TEAM, max_spend=6000)
+		frappe.db.set_value("Trust Tier Level", "t1", "allowed_clusters", frappe.as_json([OTHER_CLUSTER]))
+		self.addCleanup(frappe.db.set_value, "Trust Tier Level", "t1", "allowed_clusters", None)
+		plans, out = self._titles(cluster=CLUSTER)
+		self.assertEqual(plans, set())
+
+	def test_untiered_team_has_no_headroom(self):
+		# No tier pinned → 0 cap → no paid plan fits (only free plans, if any).
+		out = get_provisionable_plans(cluster=CLUSTER, team=TEAM)
+		self.assertEqual(out["max_spend"], 0)
+		self.assertTrue(all(p["rate"] == 0 for p in out["plans"]))
+		self.assertEqual({CHEAP, MID, PRICEY} & {p["plan"] for p in out["plans"]}, set())
+
+	def test_inactive_plan_is_excluded(self):
+		set_team_tier(TEAM, max_spend=6000)
+		make_plan(MID, rates=_rates(2000), is_active=0)
+		plans, _ = self._titles()
+		self.assertNotIn(MID, plans)

--- a/central/billing/tests/test_dashboard_catalog.py
+++ b/central/billing/tests/test_dashboard_catalog.py
@@ -46,6 +46,11 @@ def _rates(global_inr, cluster=None, cluster_inr=None):
 	return rows
 
 
+def _flat(out):
+	"""All plan rows across the grouped `{plan_class: [rows]}` menu."""
+	return [p for rows in out["plans"].values() for p in rows]
+
+
 class TestEligiblePlans(IntegrationTestCase):
 	def setUp(self):
 		ensure_team(TEAM)
@@ -62,7 +67,7 @@ class TestEligiblePlans(IntegrationTestCase):
 
 	def _titles(self, cluster=CLUSTER):
 		out = get_eligible_plans(cluster=cluster, team=TEAM)
-		return {p["plan"] for p in out["plans"]}, out
+		return {p["plan"] for p in _flat(out)}, out
 
 	def _provision(self, plan, rate, cluster=CLUSTER):
 		"""A running resource that consumes `rate` of the team's cap (active lock)."""
@@ -109,8 +114,21 @@ class TestEligiblePlans(IntegrationTestCase):
 	def test_plans_are_ordered_cheapest_first(self):
 		set_team_tier(TEAM, max_spend=6000)
 		out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
-		rates = [p["rate"] for p in out["plans"]]
-		self.assertEqual(rates, sorted(rates))
+		for rows in out["plans"].values():
+			rates = [p["rate"] for p in rows]
+			self.assertEqual(rates, sorted(rates))
+
+	def test_plans_are_grouped_by_class(self):
+		set_team_tier(TEAM, max_spend=6000)
+		# Re-class two plans; the rest stay unset → folded into "General".
+		frappe.db.set_value("Plan", MID, "plan_class", "CPU Optimised")
+		frappe.db.set_value("Plan", PRICEY, "plan_class", "Memory Optimised")
+		out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
+		# Canonical key order: General before CPU Optimised before Memory Optimised.
+		self.assertEqual(list(out["plans"]), ["General", "CPU Optimised", "Memory Optimised"])
+		self.assertIn(CHEAP, {p["plan"] for p in out["plans"]["General"]})
+		self.assertEqual({p["plan"] for p in out["plans"]["CPU Optimised"]}, {MID})
+		self.assertEqual({p["plan"] for p in out["plans"]["Memory Optimised"]}, {PRICEY})
 
 	def test_regional_plan_only_on_its_cluster(self):
 		set_team_tier(TEAM, max_spend=6000)
@@ -124,7 +142,7 @@ class TestEligiblePlans(IntegrationTestCase):
 		# Re-price CHEAP cheaper on CLUSTER; the menu must show the regional rate.
 		make_plan(CHEAP, rates=_rates(1000, cluster=CLUSTER, cluster_inr=800))
 		out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
-		row = next(p for p in out["plans"] if p["plan"] == CHEAP)
+		row = next(p for p in _flat(out) if p["plan"] == CHEAP)
 		self.assertEqual(row["rate"], 800)
 
 	def test_allowed_plans_allowlist_restricts_menu(self):
@@ -145,8 +163,9 @@ class TestEligiblePlans(IntegrationTestCase):
 		# No tier pinned → 0 cap → no paid plan fits (only free plans, if any).
 		out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
 		self.assertEqual(out["max_spend"], 0)
-		self.assertTrue(all(p["rate"] == 0 for p in out["plans"]))
-		self.assertEqual({CHEAP, MID, PRICEY} & {p["plan"] for p in out["plans"]}, set())
+		plans = _flat(out)
+		self.assertTrue(all(p["rate"] == 0 for p in plans))
+		self.assertEqual({CHEAP, MID, PRICEY} & {p["plan"] for p in plans}, set())
 
 	def test_inactive_plan_is_excluded(self):
 		set_team_tier(TEAM, max_spend=6000)

--- a/central/billing/tests/test_dashboard_catalog.py
+++ b/central/billing/tests/test_dashboard_catalog.py
@@ -51,6 +51,7 @@ class TestProvisionablePlans(IntegrationTestCase):
 		ensure_team(TEAM)
 		complete_billing_profile(TEAM, currency="INR")
 		clear_team_tier(TEAM)  # each test pins (or leaves untiered) its own cap
+		frappe.db.delete("Price Lock", {"team": TEAM})  # start with no committed usage
 		_ensure_tier_level("t1")
 		make_plan(CHEAP, rates=_rates(1000))
 		make_plan(MID, rates=_rates(2000))
@@ -63,6 +64,16 @@ class TestProvisionablePlans(IntegrationTestCase):
 		out = get_provisionable_plans(cluster=cluster, team=TEAM)
 		return {p["plan"] for p in out["plans"]}, out
 
+	def _provision(self, plan, rate, cluster=CLUSTER):
+		"""A running resource that consumes `rate` of the team's cap (active lock)."""
+		frappe.get_doc(
+			{
+				"doctype": "Price Lock", "team": TEAM, "plan": plan, "cluster": cluster,
+				"resource_id": f"srv-{frappe.generate_hash(6)}", "currency": "INR",
+				"locked_rate": rate, "started_at": frappe.utils.now_datetime(),
+			}
+		).insert(ignore_permissions=True)
+
 	def test_spend_cap_hides_plans_above_the_ceiling(self):
 		set_team_tier(TEAM, max_spend=2000)  # admits CHEAP (1000) + MID (2000), not PRICEY
 		plans, out = self._titles()
@@ -70,6 +81,25 @@ class TestProvisionablePlans(IntegrationTestCase):
 		self.assertIn(CHEAP, plans)
 		self.assertIn(MID, plans)
 		self.assertNotIn(PRICEY, plans)
+
+	def test_existing_usage_reduces_headroom(self):
+		# 4000 cap, already running a 1000 server → 3000 headroom. MID (2000) fits,
+		# PRICEY (5000) and any 3001+ plan do not.
+		set_team_tier(TEAM, max_spend=4000)
+		self._provision(CHEAP, 1000)
+		plans, out = self._titles()
+		self.assertEqual(out["max_spend"], 4000)
+		self.assertEqual(out["current_spend"], 1000)
+		self.assertEqual(out["available"], 3000)
+		self.assertIn(MID, plans)
+		self.assertNotIn(PRICEY, plans)
+
+	def test_usage_at_cap_leaves_no_paid_headroom(self):
+		set_team_tier(TEAM, max_spend=2000)
+		self._provision(MID, 2000)  # consumes the whole cap
+		plans, out = self._titles()
+		self.assertEqual(out["available"], 0)
+		self.assertEqual({CHEAP, MID, PRICEY} & plans, set())
 
 	def test_higher_cap_reveals_more_plans(self):
 		set_team_tier(TEAM, max_spend=6000)

--- a/central/billing/tests/test_dashboard_catalog.py
+++ b/central/billing/tests/test_dashboard_catalog.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from central.billing.api.dashboard.catalog import get_provisionable_plans
+from central.billing.api.dashboard.catalog import get_eligible_plans
 from central.billing.tests.utils import (
 	clear_team_tier,
 	complete_billing_profile,
@@ -46,7 +46,7 @@ def _rates(global_inr, cluster=None, cluster_inr=None):
 	return rows
 
 
-class TestProvisionablePlans(IntegrationTestCase):
+class TestEligiblePlans(IntegrationTestCase):
 	def setUp(self):
 		ensure_team(TEAM)
 		complete_billing_profile(TEAM, currency="INR")
@@ -61,7 +61,7 @@ class TestProvisionablePlans(IntegrationTestCase):
 		frappe.set_user("Administrator")
 
 	def _titles(self, cluster=CLUSTER):
-		out = get_provisionable_plans(cluster=cluster, team=TEAM)
+		out = get_eligible_plans(cluster=cluster, team=TEAM)
 		return {p["plan"] for p in out["plans"]}, out
 
 	def _provision(self, plan, rate, cluster=CLUSTER):
@@ -117,7 +117,7 @@ class TestProvisionablePlans(IntegrationTestCase):
 		set_team_tier(TEAM, max_spend=6000)
 		# Re-price CHEAP cheaper on CLUSTER; the menu must show the regional rate.
 		make_plan(CHEAP, rates=_rates(1000, cluster=CLUSTER, cluster_inr=800))
-		out = get_provisionable_plans(cluster=CLUSTER, team=TEAM)
+		out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
 		row = next(p for p in out["plans"] if p["plan"] == CHEAP)
 		self.assertEqual(row["rate"], 800)
 
@@ -137,7 +137,7 @@ class TestProvisionablePlans(IntegrationTestCase):
 
 	def test_untiered_team_has_no_headroom(self):
 		# No tier pinned → 0 cap → no paid plan fits (only free plans, if any).
-		out = get_provisionable_plans(cluster=CLUSTER, team=TEAM)
+		out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
 		self.assertEqual(out["max_spend"], 0)
 		self.assertTrue(all(p["rate"] == 0 for p in out["plans"]))
 		self.assertEqual({CHEAP, MID, PRICEY} & {p["plan"] for p in out["plans"]}, set())

--- a/central/billing/tests/test_dashboard_catalog.py
+++ b/central/billing/tests/test_dashboard_catalog.py
@@ -124,11 +124,15 @@ class TestEligiblePlans(IntegrationTestCase):
 		frappe.db.set_value("Plan", MID, "plan_class", "CPU Optimised")
 		frappe.db.set_value("Plan", PRICEY, "plan_class", "Memory Optimised")
 		out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
-		# Canonical key order: General before CPU Optimised before Memory Optimised.
-		self.assertEqual(list(out["plans"]), ["General", "CPU Optimised", "Memory Optimised"])
+		# Keys come in canonical order, whatever subset of classes the catalog has
+		# (other suites seed plans of their own — don't assume a closed world).
+		canonical = ["General", "CPU Optimised", "Memory Optimised", "Storage Optimised", "Custom"]
+		keys = list(out["plans"])
+		self.assertEqual(keys, [c for c in canonical if c in keys])
+		# Each plan lands in its own class; an unset class stays General.
 		self.assertIn(CHEAP, {p["plan"] for p in out["plans"]["General"]})
-		self.assertEqual({p["plan"] for p in out["plans"]["CPU Optimised"]}, {MID})
-		self.assertEqual({p["plan"] for p in out["plans"]["Memory Optimised"]}, {PRICEY})
+		self.assertIn(MID, {p["plan"] for p in out["plans"]["CPU Optimised"]})
+		self.assertIn(PRICEY, {p["plan"] for p in out["plans"]["Memory Optimised"]})
 
 	def test_regional_plan_only_on_its_cluster(self):
 		set_team_tier(TEAM, max_spend=6000)

--- a/central/central/doctype/asset/asset.py
+++ b/central/central/doctype/asset/asset.py
@@ -47,12 +47,36 @@ class Asset(Document):
 		resource_id, team = vm.get("name"), vm.get("central_reference")
 		if not resource_id or not team or not frappe.db.exists("Team", team):
 			return
-		exists = frappe.db.exists("Asset", resource_id)
-		if exists and occurred_at and cls.is_stale(resource_id, occurred_at):
+		if frappe.db.exists("Asset", resource_id):
+			cls._update_mirror(resource_id, cluster, vm, occurred_at, synced_at)
 			return
-		doc = frappe.get_doc("Asset", resource_id) if exists else frappe.new_doc("Asset")
-		doc.resource_id = resource_id
-		doc.team = team
+		try:
+			doc = frappe.new_doc("Asset")
+			cls._stamp(doc, cluster, vm, occurred_at, synced_at)
+			# Users can't write the mirror; this sync is its sole writer, authorized
+			# by the verified Atlas event/pull rather than desk RBAC.
+			doc.save(ignore_permissions=True)
+		except frappe.DuplicateEntryError:
+			# Lost the insert race: under REPEATABLE READ our exists-check ran on a
+			# snapshot that predated a concurrent writer's commit, so we took the
+			# insert path and hit the unique key. Recover as an update.
+			cls._update_mirror(resource_id, cluster, vm, occurred_at, synced_at)
+
+	@classmethod
+	def _update_mirror(cls, resource_id: str, cluster: str, vm: dict, occurred_at, synced_at) -> None:
+		# A locking read refreshes our snapshot so the row a concurrent insert just
+		# committed is visible here, even when we arrive via the lost-race recovery.
+		frappe.db.get_value("Asset", resource_id, "name", for_update=True)
+		if occurred_at and cls.is_stale(resource_id, occurred_at):
+			return
+		doc = frappe.get_doc("Asset", resource_id)
+		cls._stamp(doc, cluster, vm, occurred_at, synced_at)
+		doc.save(ignore_permissions=True)
+
+	@staticmethod
+	def _stamp(doc, cluster: str, vm: dict, occurred_at, synced_at) -> None:
+		doc.resource_id = vm.get("name")
+		doc.team = vm.get("central_reference")
 		doc.cluster = cluster
 		doc.status = vm.get("status") or "Pending"
 		doc.title = vm.get("title")
@@ -66,9 +90,6 @@ class Asset(Document):
 			doc.last_event_at = occurred_at
 		if synced_at:
 			doc.last_synced_at = synced_at
-		# Users can't write the mirror; this sync is its sole writer, authorized by
-		# the verified Atlas event/pull rather than desk RBAC.
-		doc.save(ignore_permissions=True)
 
 	@staticmethod
 	def mark_terminated(resource_id: str, *, last_event_at=None, last_synced_at=None) -> None:

--- a/console/src/api/methods.ts
+++ b/console/src/api/methods.ts
@@ -22,4 +22,7 @@ export const API = {
 
   // ── SSO open-in-bench (central.api.sso) ──
   getBenchLink: 'central.api.sso.get_bench_link',
+
+  // ── Billing catalog (central.billing.api.dashboard.catalog) ──
+  eligiblePlans: 'central.billing.api.dashboard.catalog.get_eligible_plans',
 } as const

--- a/console/src/components/servers/PlanCards.vue
+++ b/console/src/components/servers/PlanCards.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { planSpecs, planPrice } from '@/lib/plans'
+import type { Plan } from '@/types'
+
+// Selectable grid of plan cards for the New Server flow. Used both flat (single
+// plan class) and inside a class tab panel (multiple classes); the parent owns
+// which plan is selected via v-model.
+defineProps<{ plans: Plan[] }>()
+const selected = defineModel<string | null>({ required: true })
+</script>
+
+<template>
+  <div class="grid gap-3 sm:grid-cols-2">
+    <button
+      v-for="plan in plans"
+      :key="plan.plan"
+      type="button"
+      class="flex flex-col gap-1.5 rounded-lg border px-4 py-3 text-left transition-colors"
+      :class="
+        selected === plan.plan
+          ? 'border-outline-gray-4 bg-surface-gray-2'
+          : 'border-outline-gray-2 hover:border-outline-gray-3'
+      "
+      @click="selected = plan.plan"
+    >
+      <div class="flex items-center justify-between gap-2">
+        <span class="font-medium text-ink-gray-9">{{ plan.title }}</span>
+        <span class="shrink-0 text-p-sm font-medium text-ink-gray-8">{{ planPrice(plan) }}</span>
+      </div>
+      <span class="text-p-sm text-ink-gray-5">{{ planSpecs(plan) }}</span>
+    </button>
+  </div>
+</template>

--- a/console/src/composables/usePlans.ts
+++ b/console/src/composables/usePlans.ts
@@ -1,0 +1,40 @@
+import { computed, watch, type Ref } from 'vue'
+import { useCall } from 'frappe-ui'
+import { API, method } from '@/api/methods'
+import { useSession } from '@/composables/useSession'
+import type { Plan, ProvisionablePlans } from '@/types'
+
+// Plans a team can provision in the selected region, from the billing catalog
+// (central.billing.api.dashboard.catalog.get_eligible_plans). The menu is
+// already narrowed server-side: priced for the team's currency on that region,
+// admitted by the trust tier's allow-lists, and within the team's remaining
+// trust-tier headroom (spend cap minus current run-rate). Plans are priced and
+// gated per region, so this refetches whenever the picked region changes — and
+// stays empty until a region is picked (no cluster, nothing to price).
+
+export function usePlans(cluster: Ref<string | null>) {
+  const { activeTeam } = useSession()
+
+  const call = useCall<ProvisionablePlans, { team: string; cluster: string }>({
+    url: method(API.eligiblePlans),
+    params: () => ({ team: activeTeam.value!, cluster: cluster.value! }),
+    immediate: false,
+  })
+
+  watch(
+    [activeTeam, cluster],
+    ([team, region]) => {
+      if (team && region) call.reload()
+    },
+    { immediate: true },
+  )
+
+  return {
+    plans: computed<Plan[]>(() => call.data?.plans ?? []),
+    currency: computed<string | null>(() => call.data?.currency ?? null),
+    tier: computed<string | null>(() => call.data?.tier ?? null),
+    // Remaining trust-tier headroom in the team's currency — explains an empty menu.
+    available: computed<number | null>(() => call.data?.available ?? null),
+    loading: computed(() => call.loading),
+  }
+}

--- a/console/src/composables/usePlans.ts
+++ b/console/src/composables/usePlans.ts
@@ -29,8 +29,14 @@ export function usePlans(cluster: Ref<string | null>) {
     { immediate: true },
   )
 
+  // The menu arrives grouped by plan class (keys ordered, rows cheapest-first);
+  // `classes` is the tab order, `plans` a flat view for selection lookups.
+  const groups = computed<Record<string, Plan[]>>(() => call.data?.plans ?? {})
+
   return {
-    plans: computed<Plan[]>(() => call.data?.plans ?? []),
+    groups,
+    classes: computed<string[]>(() => Object.keys(groups.value)),
+    plans: computed<Plan[]>(() => Object.values(groups.value).flat()),
     currency: computed<string | null>(() => call.data?.currency ?? null),
     tier: computed<string | null>(() => call.data?.tier ?? null),
     // Remaining trust-tier headroom in the team's currency — explains an empty menu.

--- a/console/src/lib/plans.ts
+++ b/console/src/lib/plans.ts
@@ -1,28 +1,60 @@
-// Size presets for the New Server flow. Plans/sizes aren't modeled on Central
-// yet (Atlas pulls a size catalog from Central, but that catalog doesn't exist
-// here), so these are front-end presets passed straight to create_server as
-// raw resources. When Central grows a real Size/Plan doctype, swap this constant
-// for a fetch — the shape (vcpus/memory/disk) already matches what the API takes.
+// Display + mapping helpers for billing-catalog plans in the New Server flow.
+// Plans come from central.billing.api.dashboard.catalog.get_eligible_plans
+// (see usePlans); these turn one into a spec line, a price label, and the raw
+// size create_server still takes — Atlas provisions resources, not plan names.
 
-export interface SizePreset {
-  slug: string
-  label: string
-  vcpus: number
-  /** Fractional CPU bandwidth share for sub-1-vCPU sizes; omit to default to vcpus. */
-  cpuMaxCores?: number
-  memoryMegabytes: number
-  diskGigabytes: number
+import type { Plan } from '@/types'
+
+/** Compact spec line from a plan's bundled resources, e.g. "2 vCPU · 4 GB RAM · 40 GB disk". */
+export function planSpecs(plan: Plan): string {
+  const parts = plan.includes
+    .filter((inc) => inc.quantity)
+    .map((inc) => `${formatQty(inc.quantity)} ${inc.unit} ${nounFor(inc.resource_type)}`.trim())
+  return parts.join(' · ') || '—'
 }
 
-export const SIZE_PRESETS: SizePreset[] = [
-  { slug: 'hobby', label: 'Hobby', vcpus: 1, cpuMaxCores: 0.5, memoryMegabytes: 512, diskGigabytes: 10 },
-  { slug: 'starter', label: 'Starter', vcpus: 1, memoryMegabytes: 1024, diskGigabytes: 20 },
-  { slug: 'standard', label: 'Standard', vcpus: 2, memoryMegabytes: 2048, diskGigabytes: 40 },
-  { slug: 'business', label: 'Business', vcpus: 4, memoryMegabytes: 8192, diskGigabytes: 80 },
-]
+/** Price label for a plan card, e.g. "₹4,000 / mo" or "$49 / yr". */
+export function planPrice(plan: Plan): string {
+  const cycle = plan.billing_cycle === 'Annual' ? 'yr' : 'mo'
+  return `${formatMoney(plan.rate, plan.currency)} / ${cycle}`
+}
 
-/** Compact spec line for a preset card, e.g. "2 vCPU · 2 GB RAM · 40 GB". */
-export function presetSpecs(p: SizePreset): string {
-  const gb = p.memoryMegabytes >= 1024 ? `${p.memoryMegabytes / 1024} GB` : `${p.memoryMegabytes} MB`
-  return `${p.vcpus} vCPU · ${gb} RAM · ${p.diskGigabytes} GB`
+/** A plan's bundled resources as the raw size create_server takes (Atlas owns the
+ *  catalog of names; we pass concrete vcpus/memory/disk). Memory is stored in
+ *  megabytes; sub-1-vCPU bundles also carry a fractional CPU bandwidth cap. */
+export function planResources(plan: Plan): {
+  vcpus: number
+  memory_megabytes: number
+  disk_gigabytes: number
+  cpu_max_cores?: number
+} {
+  const qty = (type: string) =>
+    plan.includes.find((inc) => inc.resource_type === type)?.quantity ?? 0
+  const vcpu = qty('Compute')
+  return {
+    vcpus: Math.max(1, Math.ceil(vcpu)),
+    memory_megabytes: Math.round(qty('Memory') * 1024),
+    disk_gigabytes: Math.round(qty('Disk')),
+    cpu_max_cores: vcpu > 0 && vcpu < 1 ? vcpu : undefined,
+  }
+}
+
+// The resource types that map to a server's core spec line get a friendly noun;
+// the rest (Transfer/IP/Snapshot) just show their own unit.
+const NOUNS: Record<string, string> = { Compute: '', Memory: 'RAM', Disk: 'disk' }
+
+function nounFor(resourceType: string): string {
+  return NOUNS[resourceType] ?? ''
+}
+
+function formatQty(quantity: number): string {
+  return Number.isInteger(quantity) ? `${quantity}` : quantity.toFixed(1)
+}
+
+function formatMoney(amount: number, currency: string): string {
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: Number.isInteger(amount) ? 0 : 2,
+  }).format(amount)
 }

--- a/console/src/pages/servers/NewServerPage.vue
+++ b/console/src/pages/servers/NewServerPage.vue
@@ -1,17 +1,21 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { Badge, Button, FormControl } from 'frappe-ui'
 import { useRouter } from 'vue-router'
 import PageHeader from '@/components/common/PageHeader.vue'
 import { useRegions } from '@/composables/useRegions'
 import { useServers } from '@/composables/useServers'
 import { useCapabilities } from '@/composables/useCapabilities'
-import { SIZE_PRESETS, presetSpecs, type SizePreset } from '@/lib/plans'
+import { usePlans } from '@/composables/usePlans'
+import { planSpecs, planPrice, planResources } from '@/lib/plans'
+import type { Plan } from '@/types'
 
-// New server. Region is the set of available Atlas Instances; size is a preset
-// (no Plan doctype on Central yet). Create routes through central.api.servers
-// .create_server → the region's Atlas → a real VM (dev fake provider), which is
-// mirrored back so it shows on the Servers list.
+// New server. Region is the set of available Atlas Instances; the plan comes from
+// the billing catalog, priced for the team's currency on that region and within
+// its trust-tier headroom (usePlans). Create routes through central.api.servers
+// .create_server — Atlas provisions raw resources, not plan names, so we pass the
+// plan's bundled vcpus/memory/disk → the region's Atlas → a real VM (dev fake
+// provider), mirrored back so it shows on the Servers list.
 const router = useRouter()
 const { regions, loading } = useRegions()
 const { create, creating } = useServers()
@@ -19,27 +23,37 @@ const { canCreateServer } = useCapabilities()
 
 const selectedRegion = ref<string | null>(null)
 const name = ref('')
-const selectedSlug = ref<string>(SIZE_PRESETS[0].slug)
+const selectedPlan = ref<string | null>(null)
 
-const selectedSize = computed<SizePreset>(
-  () => SIZE_PRESETS.find((p) => p.slug === selectedSlug.value) ?? SIZE_PRESETS[0],
+const { plans, loading: plansLoading } = usePlans(selectedRegion)
+
+const selectedPlanObj = computed<Plan | null>(
+  () => plans.value.find((p) => p.plan === selectedPlan.value) ?? null,
 )
 
+// Switching region re-prices the menu, so a plan picked for the old region may no
+// longer be offered — drop the selection unless it survives.
+watch(plans, (rows) => {
+  if (selectedPlan.value && !rows.some((p) => p.plan === selectedPlan.value)) {
+    selectedPlan.value = null
+  }
+})
+
 const canSubmit = computed(
-  () => canCreateServer.value && !!selectedRegion.value && name.value.trim().length > 0,
+  () =>
+    canCreateServer.value &&
+    !!selectedRegion.value &&
+    !!selectedPlanObj.value &&
+    name.value.trim().length > 0,
 )
 
 async function submit() {
-  if (!canSubmit.value || !selectedRegion.value) return
-  const size = selectedSize.value
+  if (!canSubmit.value || !selectedRegion.value || !selectedPlanObj.value) return
   try {
     await create({
       region: selectedRegion.value,
       title: name.value.trim(),
-      vcpus: size.vcpus,
-      memory_megabytes: size.memoryMegabytes,
-      disk_gigabytes: size.diskGigabytes,
-      cpu_max_cores: size.cpuMaxCores,
+      ...planResources(selectedPlanObj.value),
     })
     router.push('/servers')
   } catch {
@@ -109,27 +123,39 @@ async function submit() {
         </div>
       </section>
 
-      <!-- Size -->
+      <!-- Plan -->
       <section class="space-y-3">
         <div class="flex items-center gap-2">
-          <span class="lucide-cpu size-4 text-ink-gray-6" aria-hidden="true" />
-          <h2 class="text-base font-medium text-ink-gray-8">Size</h2>
+          <span class="lucide-box size-4 text-ink-gray-6" aria-hidden="true" />
+          <h2 class="text-base font-medium text-ink-gray-8">Plan</h2>
         </div>
-        <div class="grid gap-3 sm:grid-cols-2">
+
+        <p v-if="!selectedRegion" class="text-p-sm text-ink-gray-5">
+          Pick a region to see the plans available there.
+        </p>
+        <p v-else-if="plansLoading" class="text-p-sm text-ink-gray-5">Loading plans…</p>
+        <p v-else-if="!plans.length" class="text-p-sm text-ink-gray-5">
+          No plans are available for this region within your current spending limit.
+        </p>
+
+        <div v-else class="grid gap-3 sm:grid-cols-2">
           <button
-            v-for="preset in SIZE_PRESETS"
-            :key="preset.slug"
+            v-for="plan in plans"
+            :key="plan.plan"
             type="button"
-            class="flex flex-col gap-1 rounded-lg border px-4 py-3 text-left transition-colors"
+            class="flex flex-col gap-1.5 rounded-lg border px-4 py-3 text-left transition-colors"
             :class="
-              selectedSlug === preset.slug
+              selectedPlan === plan.plan
                 ? 'border-outline-gray-4 bg-surface-gray-2'
                 : 'border-outline-gray-2 hover:border-outline-gray-3'
             "
-            @click="selectedSlug = preset.slug"
+            @click="selectedPlan = plan.plan"
           >
-            <span class="font-medium text-ink-gray-9">{{ preset.label }}</span>
-            <span class="text-p-sm text-ink-gray-5">{{ presetSpecs(preset) }}</span>
+            <div class="flex items-center justify-between gap-2">
+              <span class="font-medium text-ink-gray-9">{{ plan.title }}</span>
+              <span class="shrink-0 text-p-sm font-medium text-ink-gray-8">{{ planPrice(plan) }}</span>
+            </div>
+            <span class="text-p-sm text-ink-gray-5">{{ planSpecs(plan) }}</span>
           </button>
         </div>
       </section>

--- a/console/src/pages/servers/NewServerPage.vue
+++ b/console/src/pages/servers/NewServerPage.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import { Badge, Button, FormControl } from 'frappe-ui'
+import { Badge, Button, FormControl, Tabs } from 'frappe-ui'
 import { useRouter } from 'vue-router'
 import PageHeader from '@/components/common/PageHeader.vue'
+import PlanCards from '@/components/servers/PlanCards.vue'
 import { useRegions } from '@/composables/useRegions'
 import { useServers } from '@/composables/useServers'
 import { useCapabilities } from '@/composables/useCapabilities'
 import { usePlans } from '@/composables/usePlans'
-import { planSpecs, planPrice, planResources } from '@/lib/plans'
+import { planResources } from '@/lib/plans'
 import type { Plan } from '@/types'
 
 // New server. Region is the set of available Atlas Instances; the plan comes from
@@ -25,18 +26,34 @@ const selectedRegion = ref<string | null>(null)
 const name = ref('')
 const selectedPlan = ref<string | null>(null)
 
-const { plans, loading: plansLoading } = usePlans(selectedRegion)
+// The menu arrives grouped by plan class (server-side: keys ordered, rows
+// cheapest-first); `plans` is the flat view, `groups`/`classes` drive the tabs.
+const { plans, groups, classes, loading: plansLoading } = usePlans(selectedRegion)
 
 const selectedPlanObj = computed<Plan | null>(
   () => plans.value.find((p) => p.plan === selectedPlan.value) ?? null,
 )
 
-// Switching region re-prices the menu, so a plan picked for the old region may no
-// longer be offered — drop the selection unless it survives.
+// Bifurcate the menu by plan class, but only when the region actually offers more
+// than one — a single-class region (e.g. just General) lists its plans flat.
+const hasClassTabs = computed(() => classes.value.length > 1)
+const classTabs = computed(() => classes.value.map((label) => ({ label })))
+// Tabs select by index; reset to the first whenever the class list changes.
+const activeTab = ref(0)
+
+function plansInClass(planClass: string): Plan[] {
+  return groups.value[planClass] ?? []
+}
+
+// Switching region re-prices the menu: drop a selection no longer offered, and
+// point the class tabs back at the first class the new region has.
 watch(plans, (rows) => {
   if (selectedPlan.value && !rows.some((p) => p.plan === selectedPlan.value)) {
     selectedPlan.value = null
   }
+})
+watch(classes, () => {
+  activeTab.value = 0
 })
 
 const canSubmit = computed(
@@ -138,26 +155,15 @@ async function submit() {
           No plans are available for this region within your current spending limit.
         </p>
 
-        <div v-else class="grid gap-3 sm:grid-cols-2">
-          <button
-            v-for="plan in plans"
-            :key="plan.plan"
-            type="button"
-            class="flex flex-col gap-1.5 rounded-lg border px-4 py-3 text-left transition-colors"
-            :class="
-              selectedPlan === plan.plan
-                ? 'border-outline-gray-4 bg-surface-gray-2'
-                : 'border-outline-gray-2 hover:border-outline-gray-3'
-            "
-            @click="selectedPlan = plan.plan"
-          >
-            <div class="flex items-center justify-between gap-2">
-              <span class="font-medium text-ink-gray-9">{{ plan.title }}</span>
-              <span class="shrink-0 text-p-sm font-medium text-ink-gray-8">{{ planPrice(plan) }}</span>
-            </div>
-            <span class="text-p-sm text-ink-gray-5">{{ planSpecs(plan) }}</span>
-          </button>
-        </div>
+        <!-- Multiple classes on this region: split them across tabs. -->
+        <Tabs v-else-if="hasClassTabs" v-model="activeTab" :tabs="classTabs">
+          <template #tab-panel="{ tab }">
+            <PlanCards :plans="plansInClass(tab.label)" v-model="selectedPlan" class="pt-4" />
+          </template>
+        </Tabs>
+
+        <!-- Single class: list the plans flat, unclassified. -->
+        <PlanCards v-else :plans="plans" v-model="selectedPlan" />
       </section>
 
       <!-- Submit -->

--- a/console/src/types/index.ts
+++ b/console/src/types/index.ts
@@ -69,3 +69,38 @@ export interface Team {
 export interface BenchLinkResponse {
   url: string
 }
+
+/** One bundled resource in a plan (central Plan Includes). */
+export interface PlanInclude {
+  resource_type: 'Compute' | 'Memory' | 'Disk' | 'Transfer' | 'IP' | 'Snapshot'
+  quantity: number
+  unit: string
+}
+
+/** An eligible plan from the billing catalog, priced for the team's currency
+ *  on the chosen region.
+ *  (central.billing.api.dashboard.catalog.get_eligible_plans) */
+export interface Plan {
+  plan: string
+  title: string
+  plan_class: string
+  billing_cycle: 'Monthly' | 'Annual'
+  currency: string
+  cluster: string | null
+  rate: number
+  includes: PlanInclude[]
+}
+
+/** get_eligible_plans response: the offered menu plus the trust-tier headroom
+ *  (spend cap minus current run-rate) that shaped it. */
+export interface ProvisionablePlans {
+  team: string
+  cluster: string | null
+  currency: string
+  tier: string | null
+  max_spend: number
+  current_spend: number
+  /** Remaining headroom in the team's currency: a plan is offered only if it fits. */
+  available: number
+  plans: Plan[]
+}

--- a/console/src/types/index.ts
+++ b/console/src/types/index.ts
@@ -92,7 +92,9 @@ export interface Plan {
 }
 
 /** get_eligible_plans response: the offered menu plus the trust-tier headroom
- *  (spend cap minus current run-rate) that shaped it. */
+ *  (spend cap minus current run-rate) that shaped it. `plans` is grouped by plan
+ *  class — keys in canonical order, rows cheapest-first, unset class folded into
+ *  "General"; a forbidden cluster yields an empty map. */
 export interface ProvisionablePlans {
   team: string
   cluster: string | null
@@ -102,5 +104,5 @@ export interface ProvisionablePlans {
   current_spend: number
   /** Remaining headroom in the team's currency: a plan is offered only if it fits. */
   available: number
-  plans: Plan[]
+  plans: Record<string, Plan[]>
 }


### PR DESCRIPTION
## Summary

Replaces the hard-coded size presets on the New Server page with real plans
from the billing catalog. A team now picks a region, then chooses from the
plans actually available to it there — priced for its currency, admitted by
its trust tier, and within its remaining spend headroom — grouped by plan
class the way cloud providers present "Droplet" families.

## Backend

New read endpoint `central.billing.api.dashboard.catalog.get_eligible_plans`
(team- and capability-scoped, `billing:view`). A plan is offered only when it:

- is active;
- is admitted by the tier's `allowed_plans` / `allowed_clusters` (unset = all);
- prices the team's currency on the chosen cluster (regional Catalog Rate,
  else the global blank-cluster rate);
- fits the team's **remaining** headroom — the trust-tier spend cap minus the
  run-rate of its already-running price-locks (an untiered team has 0 cap, so
  no paid plan fits).

The response returns `plans` **grouped by class** — `{plan_class: [rows]}`,
keys in canonical order, rows cheapest-first within each, an unset class folded
into `General`, and a forbidden cluster an empty map — so the client renders it
without re-grouping. The header also carries `tier` / `max_spend` /
`current_spend` / `available` for context.

## Frontend (console)

- `NewServerPage`: region picker drives the plan menu; **class tabs** appear
  only when a region offers more than one class, otherwise the plans list flat.
  The chosen plan's bundled resources are mapped to the raw vcpus/memory/disk
  `create_server` takes (Atlas provisions resources, not plan names).
- New `usePlans` composable (region-scoped, refetches on region change),
  `PlanCards` component, and `Plan` / `ProvisionablePlans` types.
- Supporting server-console groundwork: `server:create` capability gating and
  list-view / row-action refactors.

<img width="1157" height="678" alt="Screenshot 2026-06-23 at 6 39 36 PM" src="https://github.com/user-attachments/assets/e2b6d5ae-f569-4930-802b-e900bd19893f" />
