### PR TITLE
feat(Plan Configurator): Atlas Instance-scoped rates + vCPU size dropdowns

### DIFF
--- a/central/billing/api/dashboard/catalog.py
+++ b/central/billing/api/dashboard/catalog.py
@@ -75,11 +75,22 @@ def get_eligible_plans(cluster: str | None = None, team: str | None = None) -> d
 	if cluster and allowed_clusters is not None and cluster not in allowed_clusters:
 		return {**header, "plans": {}}
 
-	# The whole active catalog is wanted on purpose — currency/cluster/headroom
-	# filtering happens in Python below — so opt out of pagination explicitly.
+	# Only families that provision a server belong in the create-server menu — AI
+	# Tokens, storage subscriptions, etc. are billable but not provisioned here. The
+	# family declares this via Plan Category.provision_target (ADR 0007); no server
+	# category means nothing is provisionable.
+	server_categories = frappe.get_all(
+		"Plan Category", filters={"provision_target": "Server"}, pluck="name", limit=0
+	)
+	if not server_categories:
+		return {**header, "plans": {}}
+
+	# The whole active catalog (in server families) is wanted on purpose —
+	# currency/cluster/headroom filtering happens in Python below — so opt out of
+	# pagination explicitly.
 	candidates = frappe.get_all(
 		"Plan",
-		filters={"is_active": 1},
+		filters={"is_active": 1, "category": ["in", server_categories]},
 		fields=["name", "title", "sub_category", "billing_cycle"],
 		order_by="title asc",
 		limit=0,

--- a/central/billing/catalog/configurator.py
+++ b/central/billing/catalog/configurator.py
@@ -29,6 +29,27 @@ from central.billing.catalog.plans import RATIO_FACTORS
 
 _MAX_RUNGS = 24  # safety bound on the doubling loop
 
+# The vCPU dropdown anchors for a ladder's start/ceiling — clean powers of two
+# from 1/16 up to 1024 (final-plan-pricing.md §4). Stored as the fraction string
+# (what the admin sees); `parse_vcpu` turns it into the float the ladder uses.
+VCPU_CHOICES = (
+	"1/16", "1/8", "1/4", "1/2", "1", "2", "4", "8",
+	"16", "32", "64", "128", "256", "512", "1024",
+)
+
+
+def parse_vcpu(value) -> float:
+	"""A vCPU dropdown value as a float: '1/16' -> 0.0625, '4' -> 4. Accepts a
+	plain number too, so direct callers and any pre-Select Float data still parse."""
+	if value in (None, ""):
+		return 0.0
+	text = str(value).strip()
+	if "/" in text:
+		num, den = text.split("/", 1)
+		return flt(num) / flt(den)
+	return flt(text)
+
+
 def ratio_for(sub_category: str | None, memory_ratio: str) -> str:
 	"""The effective ratio: a sub-category that configures a `memory_ratio` pins it
 	(the optimisation profile, set on the Plan Sub-Category master); anything else
@@ -41,8 +62,8 @@ def ratio_for(sub_category: str | None, memory_ratio: str) -> str:
 
 
 def build_ladder(
-	start_vcpu: float,
-	ceiling_vcpu: float,
+	start_vcpu: str | float,
+	ceiling_vcpu: str | float,
 	memory_ratio: str,
 	base_disk_gb: float = 0,
 	base_transfer_gb: float = 0,
@@ -57,8 +78,8 @@ def build_ladder(
 	transfer steps additively (`base + index × step`, since real transfer tiers are
 	rarely a clean multiple). The admin may overwrite any of these before generating.
 	"""
-	start = flt(start_vcpu)
-	ceiling = flt(ceiling_vcpu)
+	start = parse_vcpu(start_vcpu)
+	ceiling = parse_vcpu(ceiling_vcpu)
 	factor = RATIO_FACTORS.get(memory_ratio)
 	if not factor:
 		frappe.throw(f"Memory ratio must be one of {', '.join(RATIO_FACTORS)}.")

--- a/central/billing/catalog/configurator.py
+++ b/central/billing/catalog/configurator.py
@@ -50,14 +50,15 @@ def parse_vcpu(value) -> float:
 	return flt(text)
 
 
-def ratio_for(sub_category: str | None, memory_ratio: str) -> str:
-	"""The effective ratio: a sub-category that configures a `memory_ratio` pins it
-	(the optimisation profile, set on the Plan Sub-Category master); anything else
-	(blank, or a profile with no ratio) uses the explicit ratio."""
+def ratio_for(sub_category: str | None, memory_ratio: str | None) -> str:
+	"""The effective memory ratio. The configurator's own `memory_ratio` wins: the
+	form pre-fills it from the sub-category's optimisation profile, but the admin may
+	override it, and that override is honoured even when it differs from the profile.
+	Fall back to the sub-category's configured ratio only when `memory_ratio` is blank."""
+	if memory_ratio:
+		return memory_ratio
 	if sub_category:
-		configured = frappe.db.get_value("Plan Sub-Category", sub_category, "memory_ratio")
-		if configured:
-			return configured
+		return frappe.db.get_value("Plan Sub-Category", sub_category, "memory_ratio") or memory_ratio
 	return memory_ratio
 
 

--- a/central/billing/catalog/taxonomy_setup.py
+++ b/central/billing/catalog/taxonomy_setup.py
@@ -22,6 +22,7 @@ CATEGORIES = [
 	{
 		"category_name": "VM Plans",
 		"configurator_builder": "VM Rungs",
+		"provision_target": "Server",
 		"sub_category_label": "Optimization profile",
 		"description": "Flat-rate compute bundles (vCPU + memory + disk + transfer).",
 		"allowed": ["Compute", "Memory", "Disk", "Transfer"],
@@ -79,6 +80,7 @@ def _ensure_category(spec):
 				"doctype": "Plan Category",
 				"category_name": spec["category_name"],
 				"configurator_builder": spec["configurator_builder"],
+				"provision_target": spec.get("provision_target", ""),
 				"sub_category_label": spec["sub_category_label"],
 				"description": spec["description"],
 				"allowed_resource_types": [{"resource_type": rt} for rt in spec["allowed"]],

--- a/central/billing/demo/_factory.py
+++ b/central/billing/demo/_factory.py
@@ -81,7 +81,20 @@ def _tiers():
 		}, newname=True)
 
 
+def _atlas_instances():
+	"""Each demo cluster needs a real Atlas Instance — Catalog Rate scopes its
+	regional rates to one via a Link (autonamed by region)."""
+	for cslug, label, _cur in CLUSTERS:
+		if frappe.db.exists("Atlas Instance", cslug):
+			continue
+		frappe.get_doc({
+			"doctype": "Atlas Instance", "region": cslug,
+			"base_url": f"https://{cslug}.atlas.demo", "api_key": "demo", "api_secret": "demo",
+		}).insert(ignore_permissions=True)
+
+
 def _catalog():
+	_atlas_instances()
 	for slug, title, vcpu, ram, disk, transfer, base_inr in PLAN_SIZES:
 		rates = []
 		for cslug, _label, _cur in CLUSTERS:

--- a/central/billing/doctype/catalog_rate/catalog_rate.json
+++ b/central/billing/doctype/catalog_rate/catalog_rate.json
@@ -40,10 +40,12 @@
   },
   {
    "fieldname": "cluster",
-   "fieldtype": "Data",
+   "fieldtype": "Link",
+   "options": "Atlas Instance",
    "in_list_view": 1,
-   "label": "Cluster",
-   "description": "Blank = global default; else a region/cluster key (e.g. ap-south-1)"
+   "in_standard_filter": 1,
+   "label": "Atlas Instance",
+   "description": "Blank = global default (available on every Atlas Instance); else the Atlas Instance (region) this rate is scoped to."
   },
   {
    "fieldname": "currency",

--- a/central/billing/doctype/plan/plan_list.js
+++ b/central/billing/doctype/plan/plan_list.js
@@ -1,51 +1,13 @@
 // Copyright (c) 2026, Frappe and contributors
 // For license information, please see license.txt
 
-// Plan Configurator (issue #33): a thin Desk entry point over the tested
-// `create_configured_plan` API. Pick a ratio + vCPU, memory auto-fills (and is
-// editable for off-ratio bundles), add disk — the server writes plain
-// quantity/unit Plan Includes. Rates are authored separately (Catalog Rate).
+// Plan Configurator (issue #33): the Plan list's entry point routes straight to
+// a new Plan Configurator document — author the ladder there (rungs, base rates,
+// per-Atlas-Instance pricing) instead of the old one-off shortcut dialog.
 frappe.listview_settings["Plan"] = {
 	onload(listview) {
 		listview.page.add_inner_button(__("New from Configurator"), () => {
-			const factor = { "1:2": 2, "1:4": 4 };
-			const dialog = new frappe.ui.Dialog({
-				title: __("Plan Configurator"),
-				fields: [
-					{ fieldname: "name", label: __("Identity"), fieldtype: "Data", reqd: 1,
-						description: __("Immutable bundle identity, e.g. bundle-2vcpu") },
-					{ fieldname: "title", label: __("Title"), fieldtype: "Data", reqd: 1 },
-					{ fieldname: "ratio", label: __("Memory Ratio"), fieldtype: "Select",
-						options: ["1:2", "1:4"], default: "1:2", reqd: 1 },
-					{ fieldname: "vcpu", label: __("vCPU"), fieldtype: "Float", reqd: 1,
-						description: __("Fractional allowed: 0.125, 0.25, 0.5, 1, 2 …") },
-					{ fieldname: "memory_gb", label: __("Memory (GB)"), fieldtype: "Float",
-						description: __("Auto-filled from the ratio; edit for an off-ratio bundle") },
-					{ fieldname: "disk_gb", label: __("Disk (GB)"), fieldtype: "Float", reqd: 1 },
-				],
-				primary_action_label: __("Create"),
-				primary_action(values) {
-					frappe.call({
-						method: "billing.catalog.plans.create_configured_plan",
-						args: values,
-						callback: (r) => {
-							if (r.message) {
-								dialog.hide();
-								frappe.set_route("Form", "Plan", r.message);
-							}
-						},
-					});
-				},
-			});
-			// Pre-fill memory from ratio × vCPU; the user can override afterwards.
-			const prefill = () => {
-				const v = dialog.get_value("vcpu");
-				const f = factor[dialog.get_value("ratio")];
-				if (v && f) dialog.set_value("memory_gb", v * f);
-			};
-			dialog.fields_dict.vcpu.df.onchange = prefill;
-			dialog.fields_dict.ratio.df.onchange = prefill;
-			dialog.show();
+			frappe.new_doc("Plan Configurator");
 		});
 	},
 };

--- a/central/billing/doctype/plan_category/plan_category.json
+++ b/central/billing/doctype/plan_category/plan_category.json
@@ -12,6 +12,7 @@
   "description",
   "column_break_head",
   "configurator_builder",
+  "provision_target",
   "sub_category_label",
   "section_break_resources",
   "allowed_resource_types"
@@ -49,6 +50,13 @@
    "options": "VM Rungs\nSimple",
    "reqd": 1,
    "description": "Which Plan Configurator builder authors this category. VM Rungs = the vCPU/memory/disk/transfer ladder; Simple = name + included quantity + rate."
+  },
+  {
+   "fieldname": "provision_target",
+   "fieldtype": "Select",
+   "label": "Provision Target",
+   "options": "\nServer",
+   "description": "What a member plan provisions, if anything. 'Server' = offered in the create-server flow. Blank = not directly provisionable here (e.g. metered AI Tokens, storage subscriptions). New provisioning surfaces add their own option."
   },
   {
    "fieldname": "sub_category_label",

--- a/central/billing/doctype/plan_category/plan_category.py
+++ b/central/billing/doctype/plan_category/plan_category.py
@@ -21,6 +21,7 @@ class PlanCategory(Document):
 		configurator_builder: DF.Literal["VM Rungs", "Simple"]
 		description: DF.SmallText | None
 		is_active: DF.Check
+		provision_target: DF.Literal["", "Server"]
 		sub_category_label: DF.Data | None
 	# end: auto-generated types
 

--- a/central/billing/doctype/plan_configurator/plan_configurator.js
+++ b/central/billing/doctype/plan_configurator/plan_configurator.js
@@ -22,7 +22,7 @@ function vcpu_label(v) {
 frappe.ui.form.on("Plan Configurator", {
 	sub_category(frm) {
 		if (!frm.doc.sub_category) return;
-		// The optimisation profile pins the memory ratio — read it off the master.
+		// Pre-fill the memory ratio from the profile; the admin can override it after.
 		frappe.db.get_value("Plan Sub-Category", frm.doc.sub_category, "memory_ratio").then((r) => {
 			const ratio = r.message && r.message.memory_ratio;
 			if (ratio) frm.set_value("memory_ratio", ratio);

--- a/central/billing/doctype/plan_configurator/plan_configurator.js
+++ b/central/billing/doctype/plan_configurator/plan_configurator.js
@@ -1,8 +1,18 @@
 // Copyright (c) 2026, Frappe and contributors
 // For license information, please see license.txt
 
-// Mirror of configurator._num / _vcpu_label, for live autofill of added rows.
+// Mirror of configurator._num / _vcpu_label / parse_vcpu, for live autofill.
 const num = (v) => parseFloat(Number(v).toPrecision(12)).toString();
+// "1/16" -> 0.0625, "4" -> 4 — start_vcpu is a fraction-string dropdown value.
+function parse_vcpu(v) {
+	if (v == null || v === "") return 0;
+	const s = String(v).trim();
+	if (s.includes("/")) {
+		const [n, d] = s.split("/");
+		return parseFloat(n) / parseFloat(d);
+	}
+	return parseFloat(s);
+}
 function vcpu_label(v) {
 	if (v >= 1) return `${num(v)} vCPU`;
 	const inv = 1 / v;
@@ -98,7 +108,7 @@ function fill_rung(frm, row) {
 	const prefix = frm.doc.plan_name_prefix || "Bundle";
 	if (!row.plan_name) row.plan_name = `${prefix} ${num(row.vcpu)} vCPU ${num(row.memory_gb)} GB`;
 	if (!row.label) row.label = `${vcpu_label(row.vcpu)} · ${num(row.memory_gb)} GB`;
-	if (!row.multiplier) row.multiplier = row.vcpu / (frm.doc.start_vcpu || 1);
+	if (!row.multiplier) row.multiplier = row.vcpu / (parse_vcpu(frm.doc.start_vcpu) || 1);
 	frm.refresh_field("rungs");
 }
 

--- a/central/billing/doctype/plan_configurator/plan_configurator.js
+++ b/central/billing/doctype/plan_configurator/plan_configurator.js
@@ -149,9 +149,10 @@ function generate_dialog(frm) {
 		fields: [
 			{
 				fieldname: "cluster",
-				fieldtype: "Data",
-				label: __("Cluster"),
-				description: __("Blank = global rate (every cluster). Else a region key. Re-run per cluster."),
+				fieldtype: "Link",
+				options: "Atlas Instance",
+				label: __("Atlas Instance"),
+				description: __("Blank = global rate (every Atlas Instance). Else pick one. Re-run per Atlas Instance."),
 			},
 			{ fieldname: "sb_cur", fieldtype: "Section Break", label: __("Currencies") },
 			{

--- a/central/billing/doctype/plan_configurator/plan_configurator.json
+++ b/central/billing/doctype/plan_configurator/plan_configurator.json
@@ -98,13 +98,12 @@
    "reqd": 1
   },
   {
-   "default": "1:4",
-   "description": "GB RAM per vCPU. Auto-filled from the Sub-Category's configured ratio when it has one; otherwise set it here. A pre-fill; edit a generated Plan to go off-ratio.",
+   "description": "GB RAM per vCPU. Pre-filled from the Sub-Category's optimisation profile, but authoritative once set — override it here and the override wins over the profile. Edit a generated Plan to go off-ratio.",
    "fieldname": "memory_ratio",
    "fieldtype": "Select",
    "label": "Memory Ratio",
-   "options": "1:2\n1:4\n1:6\n1:8",
-   "reqd": 1
+   "options": "\n1:2\n1:4\n1:6\n1:8",
+   "mandatory_depends_on": "eval:doc.builder=='VM Rungs'"
   },
   {
    "default": "0",

--- a/central/billing/doctype/plan_configurator/plan_configurator.json
+++ b/central/billing/doctype/plan_configurator/plan_configurator.json
@@ -79,22 +79,22 @@
    "label": "Sizing"
   },
   {
-   "default": "0.125",
+   "default": "1/8",
    "description": "Smallest rung, in vCPU (1 vCPU = 1000 millicores). The ladder doubles from here.",
    "fieldname": "start_vcpu",
-   "fieldtype": "Float",
+   "fieldtype": "Select",
+   "options": "1/16\n1/8\n1/4\n1/2\n1\n2\n4\n8\n16\n32\n64\n128\n256\n512\n1024",
    "in_list_view": 1,
    "label": "Start vCPU",
-   "precision": "3",
    "reqd": 1
   },
   {
    "default": "4",
    "description": "Largest rung. The ladder doubles from start up to (and including) this.",
    "fieldname": "ceiling_vcpu",
-   "fieldtype": "Float",
+   "fieldtype": "Select",
+   "options": "1/16\n1/8\n1/4\n1/2\n1\n2\n4\n8\n16\n32\n64\n128\n256\n512\n1024",
    "label": "Ceiling vCPU",
-   "precision": "3",
    "reqd": 1
   },
   {

--- a/central/billing/doctype/plan_configurator/plan_configurator.json
+++ b/central/billing/doctype/plan_configurator/plan_configurator.json
@@ -2,26 +2,27 @@
  "actions": [],
  "allow_rename": 1,
  "autoname": "field:template_name",
- "creation": "2026-06-18 00:00:00.000000",
- "description": "Authoring tool: generate a t-shirt-size ladder of bundles, then price it per cluster. Reusable — re-apply pricing when a new cluster onboards (final-plan-pricing.md §11, issue #33).",
+ "creation": "2026-06-18 00:00:00",
+ "description": "Authoring tool: generate a t-shirt-size ladder of bundles, then price it per cluster. Reusable \u2014 re-apply pricing when a new cluster onboards (final-plan-pricing.md \u00a711, issue #33).",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
   "template_name",
+  "plan_name_prefix",
+  "billing_cycle",
+  "column_break_xbyf",
   "is_active",
   "category",
   "builder",
   "sub_category",
   "sizing_section",
   "start_vcpu",
-  "ceiling_vcpu",
   "memory_ratio",
-  "base_disk_gb",
   "base_transfer_gb",
-  "transfer_step_gb",
   "column_break_sizing",
-  "plan_name_prefix",
-  "billing_cycle",
+  "ceiling_vcpu",
+  "base_disk_gb",
+  "transfer_step_gb",
   "pricing_section",
   "base_rates",
   "pricing_help",
@@ -32,12 +33,13 @@
  ],
  "fields": [
   {
+   "description": "Identifies this reusable ladder (e.g. \"Standard 1:2\").",
    "fieldname": "template_name",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Template Name",
    "reqd": 1,
-   "unique": 1,
-   "description": "Identifies this reusable ladder (e.g. \"Standard 1:2\")."
+   "unique": 1
   },
   {
    "default": "1",
@@ -47,27 +49,28 @@
   },
   {
    "default": "VM Plans",
+   "description": "The Plan Category these plans belong to. Its builder (VM Rungs / Simple) decides how you author them (ADR 0007).",
    "fieldname": "category",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Category",
    "options": "Plan Category",
-   "reqd": 1,
-   "description": "The Plan Category these plans belong to. Its builder (VM Rungs / Simple) decides how you author them (ADR 0007)."
+   "reqd": 1
   },
   {
+   "description": "Resolved from the category \u2014 VM Rungs (vCPU ladder) or Simple (name + quantity + rate).",
    "fetch_from": "category.configurator_builder",
    "fieldname": "builder",
-   "fieldtype": "Data",
+   "fieldtype": "Read Only",
    "label": "Builder",
-   "read_only": 1,
-   "description": "Resolved from the category — VM Rungs (vCPU ladder) or Simple (name + quantity + rate)."
+   "read_only": 1
   },
   {
+   "description": "The optimisation profile / variant within the category (filtered to it). For VM plans this is the profile that pins the memory ratio configured on the Sub-Category. Leave blank, or create a new one inline if it isn't a preconfigured option.",
    "fieldname": "sub_category",
    "fieldtype": "Link",
    "label": "Sub-Category",
-   "options": "Plan Sub-Category",
-   "description": "The optimisation profile / variant within the category (filtered to it). For VM plans this is the profile that pins the memory ratio configured on the Sub-Category. Leave blank, or create a new one inline if it isn't a preconfigured option."
+   "options": "Plan Sub-Category"
   },
   {
    "depends_on": "eval:doc.builder=='VM Rungs'",
@@ -77,54 +80,55 @@
   },
   {
    "default": "0.125",
+   "description": "Smallest rung, in vCPU (1 vCPU = 1000 millicores). The ladder doubles from here.",
    "fieldname": "start_vcpu",
    "fieldtype": "Float",
+   "in_list_view": 1,
    "label": "Start vCPU",
    "precision": "3",
-   "reqd": 1,
-   "description": "Smallest rung, in vCPU (1 vCPU = 1000 millicores). The ladder doubles from here."
+   "reqd": 1
   },
   {
    "default": "4",
+   "description": "Largest rung. The ladder doubles from start up to (and including) this.",
    "fieldname": "ceiling_vcpu",
    "fieldtype": "Float",
    "label": "Ceiling vCPU",
    "precision": "3",
-   "reqd": 1,
-   "description": "Largest rung. The ladder doubles from start up to (and including) this."
+   "reqd": 1
   },
   {
    "default": "1:4",
+   "description": "GB RAM per vCPU. Auto-filled from the Sub-Category's configured ratio when it has one; otherwise set it here. A pre-fill; edit a generated Plan to go off-ratio.",
    "fieldname": "memory_ratio",
    "fieldtype": "Select",
    "label": "Memory Ratio",
    "options": "1:2\n1:4\n1:6\n1:8",
-   "reqd": 1,
-   "description": "GB RAM per vCPU. Auto-filled from the Sub-Category's configured ratio when it has one; otherwise set it here. A pre-fill; edit a generated Plan to go off-ratio."
+   "reqd": 1
   },
   {
    "default": "0",
+   "description": "Disk for the smallest rung; scales with the size multiplier. 0 = no disk line.",
    "fieldname": "base_disk_gb",
    "fieldtype": "Float",
    "label": "Base Disk (GB)",
-   "precision": "3",
-   "description": "Disk for the smallest rung; scales with the size multiplier. 0 = no disk line."
+   "precision": "3"
   },
   {
    "default": "0",
+   "description": "Transfer for the smallest rung. 0 = no transfer line. Real transfer tiers are irregular \u2014 tune per rung below.",
    "fieldname": "base_transfer_gb",
    "fieldtype": "Float",
    "label": "Base Transfer (GB)",
-   "precision": "3",
-   "description": "Transfer for the smallest rung. 0 = no transfer line. Real transfer tiers are irregular — tune per rung below."
+   "precision": "3"
   },
   {
    "default": "0",
+   "description": "Added to transfer per rung (base + index \u00d7 step), e.g. +1000 GB each step.",
    "fieldname": "transfer_step_gb",
    "fieldtype": "Float",
    "label": "Transfer Step (GB)",
-   "precision": "3",
-   "description": "Added to transfer per rung (base + index × step), e.g. +1000 GB each step."
+   "precision": "3"
   },
   {
    "fieldname": "column_break_sizing",
@@ -132,11 +136,12 @@
   },
   {
    "default": "Bundle",
+   "description": "Generated plan names start with this (e.g. \"Bundle 2 vCPU 4 GB\").",
    "fieldname": "plan_name_prefix",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Plan Name Prefix",
-   "reqd": 1,
-   "description": "Generated plan names start with this (e.g. \"Bundle 2 vCPU 4 GB\")."
+   "reqd": 1
   },
   {
    "default": "Monthly",
@@ -151,17 +156,17 @@
    "label": "Default Pricing"
   },
   {
+   "description": "One row per currency \u2014 the price of the smallest rung. Each rung is priced base_rate \u00d7 its size multiplier.",
    "fieldname": "base_rates",
    "fieldtype": "Table",
    "label": "Base Rates",
    "options": "Plan Configurator Rate",
-   "reqd": 1,
-   "description": "One row per currency — the price of the smallest rung. Each rung is priced base_rate × its size multiplier."
+   "reqd": 1
   },
   {
    "fieldname": "pricing_help",
    "fieldtype": "HTML",
-   "options": "<p class='text-muted small'><b>Populate Rungs</b> fills the table below from the formula; edit any value (irregular transfer, off-ratio memory, a hand-authored tier). <b>Generate Plans</b> opens a dialog to pick the cluster, currencies, and which rungs — then runs in the background, creating a bundle per rung and its rates. Re-run it per cluster (a plan is sellable on a cluster only where it has a rate, or a global one); blank cluster = global.</p>"
+   "options": "<p class='text-muted small'><b>Populate Rungs</b> fills the table below from the formula; edit any value (irregular transfer, off-ratio memory, a hand-authored tier). <b>Generate Plans</b> opens a dialog to pick the cluster, currencies, and which rungs \u2014 then runs in the background, creating a bundle per rung and its rates. Re-run it per cluster (a plan is sellable on a cluster only where it has a rate, or a global one); blank cluster = global.</p>"
   },
   {
    "depends_on": "eval:doc.builder=='VM Rungs'",
@@ -170,11 +175,11 @@
    "label": "Rungs"
   },
   {
+   "description": "Populate from the formula, then edit before generating.",
    "fieldname": "rungs",
    "fieldtype": "Table",
    "label": "Rungs",
-   "options": "Plan Configurator Plan",
-   "description": "Populate from the formula, then edit before generating."
+   "options": "Plan Configurator Plan"
   },
   {
    "depends_on": "eval:doc.builder=='Simple'",
@@ -183,19 +188,24 @@
    "label": "Plans"
   },
   {
+   "description": "One row per plan: title, the category's resource type, included quantity, unit, and a rate multiplier (rate = base rate x multiplier).",
    "fieldname": "simple_plans",
    "fieldtype": "Table",
    "label": "Plans",
-   "options": "Plan Configurator Simple Plan",
-   "description": "One row per plan: title, the category's resource type, included quantity, unit, and a rate multiplier (rate = base rate x multiplier)."
+   "options": "Plan Configurator Simple Plan"
+  },
+  {
+   "fieldname": "column_break_xbyf",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-18 00:00:00.000000",
+ "modified": "2026-06-24 12:54:45.644382",
  "modified_by": "Administrator",
  "module": "Billing",
  "name": "Plan Configurator",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -211,6 +221,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/central/billing/doctype/plan_configurator/plan_configurator.py
+++ b/central/billing/doctype/plan_configurator/plan_configurator.py
@@ -28,13 +28,13 @@ class PlanConfigurator(Document):
 		billing_cycle: DF.Literal["Monthly", "Annual"]
 		builder: DF.ReadOnly | None
 		category: DF.Link
-		ceiling_vcpu: DF.Float
+		ceiling_vcpu: DF.Literal["1/16", "1/8", "1/4", "1/2", "1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024"]
 		is_active: DF.Check
 		memory_ratio: DF.Literal["1:2", "1:4", "1:6", "1:8"]
 		plan_name_prefix: DF.Data
 		rungs: DF.Table[PlanConfiguratorPlan]
 		simple_plans: DF.Table[PlanConfiguratorSimplePlan]
-		start_vcpu: DF.Float
+		start_vcpu: DF.Literal["1/16", "1/8", "1/4", "1/2", "1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024"]
 		sub_category: DF.Link | None
 		template_name: DF.Data
 		transfer_step_gb: DF.Float
@@ -44,7 +44,7 @@ class PlanConfigurator(Document):
 		"""Fill identity/price for hand-added or edited rungs, so an inserted size
 		(e.g. 1 vCPU 3 GB between the 2 GB and 4 GB rungs) is usable without the
 		admin spelling out its name, label, and multiplier."""
-		start = flt(self.start_vcpu) or 1
+		start = configurator.parse_vcpu(self.start_vcpu) or 1
 		for r in self.rungs:
 			if not flt(r.multiplier) and flt(r.vcpu):
 				r.multiplier = flt(r.vcpu) / start

--- a/central/billing/doctype/plan_configurator/plan_configurator.py
+++ b/central/billing/doctype/plan_configurator/plan_configurator.py
@@ -11,6 +11,35 @@ _RUNG_FIELDS = ("plan_name", "label", "vcpu", "memory_gb", "disk_gb", "transfer_
 
 
 class PlanConfigurator(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from central.billing.doctype.plan_configurator_plan.plan_configurator_plan import PlanConfiguratorPlan
+		from central.billing.doctype.plan_configurator_rate.plan_configurator_rate import PlanConfiguratorRate
+		from central.billing.doctype.plan_configurator_simple_plan.plan_configurator_simple_plan import PlanConfiguratorSimplePlan
+		from frappe.types import DF
+
+		base_disk_gb: DF.Float
+		base_rates: DF.Table[PlanConfiguratorRate]
+		base_transfer_gb: DF.Float
+		billing_cycle: DF.Literal["Monthly", "Annual"]
+		builder: DF.ReadOnly | None
+		category: DF.Link
+		ceiling_vcpu: DF.Float
+		is_active: DF.Check
+		memory_ratio: DF.Literal["1:2", "1:4", "1:6", "1:8"]
+		plan_name_prefix: DF.Data
+		rungs: DF.Table[PlanConfiguratorPlan]
+		simple_plans: DF.Table[PlanConfiguratorSimplePlan]
+		start_vcpu: DF.Float
+		sub_category: DF.Link | None
+		template_name: DF.Data
+		transfer_step_gb: DF.Float
+	# end: auto-generated types
+
 	def before_validate(self):
 		"""Fill identity/price for hand-added or edited rungs, so an inserted size
 		(e.g. 1 vCPU 3 GB between the 2 GB and 4 GB rungs) is usable without the

--- a/central/billing/doctype/plan_configurator/plan_configurator.py
+++ b/central/billing/doctype/plan_configurator/plan_configurator.py
@@ -44,6 +44,13 @@ class PlanConfigurator(Document):
 		"""Fill identity/price for hand-added or edited rungs, so an inserted size
 		(e.g. 1 vCPU 3 GB between the 2 GB and 4 GB rungs) is usable without the
 		admin spelling out its name, label, and multiplier."""
+		# The sub-category's optimisation profile is the *default* memory ratio — pre-fill
+		# it here (mirroring the form's on-select prefill) so programmatic creation and the
+		# mandatory check have a value. The configurator's own ratio stays authoritative:
+		# ratio_for honours it even when the admin has overridden it off the profile.
+		if not self.memory_ratio and self.sub_category:
+			self.memory_ratio = configurator.ratio_for(self.sub_category, None)
+
 		start = configurator.parse_vcpu(self.start_vcpu) or 1
 		for r in self.rungs:
 			if not flt(r.multiplier) and flt(r.vcpu):

--- a/central/billing/doctype/plan_configurator/test_plan_configurator.py
+++ b/central/billing/doctype/plan_configurator/test_plan_configurator.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026, frappe and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+
+class IntegrationTestPlanConfigurator(IntegrationTestCase):
+	"""
+	Integration tests for PlanConfigurator.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/central/billing/patches/v20_configurator_vcpu_dropdown/configurator_vcpu_dropdown.py
+++ b/central/billing/patches/v20_configurator_vcpu_dropdown/configurator_vcpu_dropdown.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Plan Configurator's start_vcpu / ceiling_vcpu move from Float to a Select of
+clean t-shirt sizes (1/16 … 1024). The doctype sync can't cast a fraction default
+like '1/8' against the existing decimal column (it does float('1/8')), so widen
+the columns to varchar here — before sync — and rewrite stored numbers to their
+matching dropdown label so the Select shows them.
+"""
+
+import frappe
+
+from central.billing.catalog.configurator import VCPU_CHOICES, parse_vcpu
+
+COLUMNS = ("start_vcpu", "ceiling_vcpu")
+
+
+def execute():
+	if not frappe.db.table_exists("Plan Configurator"):
+		return
+
+	for column in COLUMNS:
+		if frappe.db.has_column("Plan Configurator", column):
+			# Fixed table/column literals — no user input in this DDL.
+			frappe.db.sql_ddl(f"ALTER TABLE `tabPlan Configurator` MODIFY `{column}` varchar(140)")
+
+	# Existing decimal values became strings ('0.125'); map each back to its label.
+	label_for = {round(parse_vcpu(choice), 6): choice for choice in VCPU_CHOICES}
+	for row in frappe.get_all("Plan Configurator", fields=["name", *COLUMNS]):
+		for column in COLUMNS:
+			label = label_for.get(round(parse_vcpu(row.get(column)), 6))
+			if label and row.get(column) != label:
+				frappe.db.set_value("Plan Configurator", row.name, column, label, update_modified=False)

--- a/central/billing/patches/v21_category_provision_target/category_provision_target.py
+++ b/central/billing/patches/v21_category_provision_target/category_provision_target.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Backfill Plan Category.provision_target so the create-server flow can filter to
+provisionable families. Sets it from the taxonomy seed specs (VM Plans -> Server);
+families with no provision target stay blank. Existing categories predate the field,
+so seeding (which only creates absent rows) doesn't reach them — hence this patch.
+"""
+
+import frappe
+
+from central.billing.catalog.taxonomy_setup import CATEGORIES
+
+
+def execute():
+	for spec in CATEGORIES:
+		target = spec.get("provision_target")
+		if target and frappe.db.exists("Plan Category", spec["category_name"]):
+			frappe.db.set_value(
+				"Plan Category", spec["category_name"], "provision_target", target, update_modified=False
+			)

--- a/central/billing/tests/test_dashboard_catalog.py
+++ b/central/billing/tests/test_dashboard_catalog.py
@@ -79,6 +79,19 @@ class TestEligiblePlans(IntegrationTestCase):
 			}
 		).insert(ignore_permissions=True)
 
+	def test_excludes_non_server_families(self):
+		# An AI Tokens plan is billable but not provisioned via the create-server flow;
+		# its family's provision_target is blank, so it never appears in the menu.
+		make_plan(
+			"tokens-100m", category="AI Tokens",
+			includes=[{"resource_type": "Tokens", "quantity": 100, "unit": "1M tokens"}],
+			rates=_rates(800),
+		)
+		set_team_tier(TEAM, max_spend=100000)  # ample headroom — exclusion is by family, not price
+		plans, _ = self._titles()
+		self.assertIn(CHEAP, plans)            # a VM Plans (Server) family member shows
+		self.assertNotIn("tokens-100m", plans)  # the AI Tokens family does not
+
 	def test_spend_cap_hides_plans_above_the_ceiling(self):
 		set_team_tier(TEAM, max_spend=2000)  # admits CHEAP (1000) + MID (2000), not PRICEY
 		plans, out = self._titles()

--- a/central/billing/tests/test_plan_configurator.py
+++ b/central/billing/tests/test_plan_configurator.py
@@ -103,23 +103,29 @@ class TestBuildLadder(IntegrationTestCase):
 		self.assertEqual([r["transfer_gb"] for r in rungs], [4000, 5000, 6000, 7000])
 
 	def test_ratio_for_sub_category(self):
-		# Pinned by the ratio configured on each VM profile (the Plan Sub-Category master).
-		self.assertEqual(configurator.ratio_for("CPU Optimised", "1:4"), "1:2")
-		self.assertEqual(configurator.ratio_for("General", "1:2"), "1:4")
-		self.assertEqual(configurator.ratio_for("Memory Optimised", "1:2"), "1:8")
-		self.assertEqual(configurator.ratio_for("Storage Optimised", "1:2"), "1:8")
-		# A profile with no configured ratio (or none picked) uses the explicit one.
+		# The configurator's own ratio wins, even when it differs from the profile's.
+		self.assertEqual(configurator.ratio_for("CPU Optimised", "1:4"), "1:4")
+		self.assertEqual(configurator.ratio_for("Memory Optimised", "1:2"), "1:2")
+		# Blank ratio falls back to the profile's configured optimisation ratio.
+		self.assertEqual(configurator.ratio_for("CPU Optimised", None), "1:2")
+		self.assertEqual(configurator.ratio_for("General", None), "1:4")
+		self.assertEqual(configurator.ratio_for("Memory Optimised", None), "1:8")
+		self.assertEqual(configurator.ratio_for("Storage Optimised", None), "1:8")
+		# No profile (or one with no configured ratio) uses the explicit ratio.
 		self.assertEqual(configurator.ratio_for("Custom", "1:6"), "1:6")
 		self.assertEqual(configurator.ratio_for(None, "1:4"), "1:4")
 
 	def test_ratio_is_configurable_on_the_sub_category(self):
-		# The ratio is data, not code: set it on the master and ratio_for follows.
+		# The fallback ratio is data, not code: set it on the master and a blank
+		# configurator ratio follows it.
 		frappe.get_doc({
 			"doctype": "Plan Sub-Category", "sub_category_name": "Cfg Ratio Test",
 			"category": "VM Plans", "memory_ratio": "1:6",
 		}).insert(ignore_permissions=True)
 		self.addCleanup(frappe.delete_doc, "Plan Sub-Category", "Cfg Ratio Test", force=True)
-		self.assertEqual(configurator.ratio_for("Cfg Ratio Test", "1:2"), "1:6")
+		self.assertEqual(configurator.ratio_for("Cfg Ratio Test", None), "1:6")
+		# An explicit ratio still overrides the master.
+		self.assertEqual(configurator.ratio_for("Cfg Ratio Test", "1:2"), "1:2")
 
 	def test_labels_and_names(self):
 		rungs = configurator.build_ladder(0.125, 1, "1:2", name_prefix=PREFIX)
@@ -284,6 +290,23 @@ class TestGenerate(IntegrationTestCase):
 		comp = {i.resource_type: i.quantity for i in plan.includes}
 		self.assertEqual(comp["Memory"], 8)
 		self.assertEqual(plan.sub_category, "Memory Optimised")
+
+	def test_explicit_ratio_overrides_sub_category(self):
+		# Profile is Memory Optimised (1:8) but the configurator sets 1:2 — the
+		# configurator's ratio wins, so 1 vCPU yields 2 GB, not 8 GB.
+		cfg = frappe.get_doc({
+			"doctype": "Plan Configurator", "template_name": "Cfg Test Override",
+			"sub_category": "Memory Optimised", "memory_ratio": "1:2",
+			"start_vcpu": "1", "ceiling_vcpu": "1",
+			"plan_name_prefix": PREFIX, "billing_cycle": "Monthly", "is_active": 1,
+			"base_rates": [{"currency": "INR", "base_rate": 500}],
+		}).insert(ignore_permissions=True)
+		self.assertEqual(cfg.memory_ratio, "1:2")  # not overwritten by the profile
+		cfg.populate_rungs()
+		cfg.generate_and_price()
+		plan = _plan_for(cfg, f"{PREFIX} 1 vCPU 2 GB")
+		comp = {i.resource_type: i.quantity for i in plan.includes}
+		self.assertEqual(comp["Memory"], 2)
 
 	def test_reproduces_general_purpose_family(self):
 		# DigitalOcean's General Purpose ladder, exactly (USD): the configurator's

--- a/central/billing/tests/test_plan_configurator.py
+++ b/central/billing/tests/test_plan_configurator.py
@@ -16,6 +16,7 @@ from frappe.tests import IntegrationTestCase
 
 from central.billing.catalog import configurator, plans
 from central.billing.catalog.pricing import get_catalog_rates, resolve_rate
+from central.billing.tests.utils import ensure_atlas_instance
 
 PREFIX = "CfgTest"
 TEMPLATE = "Cfg Test Template"
@@ -144,9 +145,10 @@ class TestBuildLadder(IntegrationTestCase):
 class TestGenerate(IntegrationTestCase):
 	def setUp(self):
 		_cleanup()
+		ensure_atlas_instance("ap-south-1")
 		self.cfg = frappe.get_doc({
 			"doctype": "Plan Configurator", "template_name": TEMPLATE,
-			"start_vcpu": 0.125, "ceiling_vcpu": 4,
+			"start_vcpu": "1/8", "ceiling_vcpu": "4",
 			"memory_ratio": "1:2", "base_disk_gb": 10, "plan_name_prefix": PREFIX,
 			"billing_cycle": "Monthly", "is_active": 1,
 			"base_rates": [{"currency": "INR", "base_rate": 100}, {"currency": "USD", "base_rate": 2}],
@@ -272,7 +274,7 @@ class TestGenerate(IntegrationTestCase):
 	def test_sub_category_drives_ratio_and_composition(self):
 		mem = frappe.get_doc({
 			"doctype": "Plan Configurator", "template_name": "Cfg Test Mem",
-			"sub_category": "Memory Optimised", "start_vcpu": 1, "ceiling_vcpu": 1,
+			"sub_category": "Memory Optimised", "start_vcpu": "1", "ceiling_vcpu": "1",
 			"plan_name_prefix": PREFIX, "billing_cycle": "Monthly", "is_active": 1,
 			"base_rates": [{"currency": "INR", "base_rate": 500}],
 		}).insert(ignore_permissions=True)
@@ -288,7 +290,7 @@ class TestGenerate(IntegrationTestCase):
 		# formula reproduces vCPU/RAM/disk/transfer/price across the rungs.
 		gp = frappe.get_doc({
 			"doctype": "Plan Configurator", "template_name": "Cfg Test GP",
-			"sub_category": "General", "start_vcpu": 2, "ceiling_vcpu": 16,
+			"sub_category": "General", "start_vcpu": "2", "ceiling_vcpu": "16",
 			"base_disk_gb": 25, "base_transfer_gb": 4000, "transfer_step_gb": 1000,
 			"plan_name_prefix": "CfgGP", "billing_cycle": "Monthly", "is_active": 1,
 			"base_rates": [{"currency": "USD", "base_rate": 63}],

--- a/central/billing/tests/utils.py
+++ b/central/billing/tests/utils.py
@@ -23,6 +23,17 @@ DEFAULT_INCLUDES = [
 ]
 
 
+def ensure_atlas_instance(region):
+	"""Catalog Rate.cluster is a Link to Atlas Instance, so a per-region rate needs
+	that instance to exist. Atlas Instance is autonamed by region."""
+	if not frappe.db.exists("Atlas Instance", region):
+		frappe.get_doc({
+			"doctype": "Atlas Instance", "region": region,
+			"base_url": f"https://{region}.atlas.test", "api_key": "test", "api_secret": "test",
+		}).insert(ignore_permissions=True)
+	return region
+
+
 def make_plan(name, rates=None, includes=None, **kwargs):
 	"""Create (or replace) a bundle Plan and its Catalog Rate rows; return its name."""
 	if frappe.db.exists("Plan", name):
@@ -44,8 +55,17 @@ def make_plan(name, rates=None, includes=None, **kwargs):
 	doc.name = name
 	doc.flags.name_set = True
 	doc.insert(ignore_permissions=True)
-	set_catalog_rates("Plan", doc.name, rates if rates is not None else DEFAULT_RATES)
+	rates = rates if rates is not None else DEFAULT_RATES
+	_ensure_rate_instances(rates)
+	set_catalog_rates("Plan", doc.name, rates)
 	return doc.name
+
+
+def _ensure_rate_instances(rates):
+	"""Seed the Atlas Instance behind every non-blank cluster a rate row references."""
+	for cluster in {(r.get("cluster") or "").strip() for r in rates}:
+		if cluster:
+			ensure_atlas_instance(cluster)
 
 
 def make_addon(name, rates=None, **kwargs):
@@ -66,7 +86,9 @@ def make_addon(name, rates=None, **kwargs):
 		}
 	)
 	doc.insert(ignore_permissions=True)
-	set_catalog_rates("Add-on", doc.name, rates if rates is not None else DEFAULT_ADDON_RATES)
+	rates = rates if rates is not None else DEFAULT_ADDON_RATES
+	_ensure_rate_instances(rates)
+	set_catalog_rates("Add-on", doc.name, rates)
 	return doc.name
 
 

--- a/central/patches.txt
+++ b/central/patches.txt
@@ -75,4 +75,7 @@ central.billing.patches.v18_drop_unused_category_billing_meta.drop_unused_catego
 # Backfill the configurable memory ratio onto the VM optimisation-profile
 # sub-categories (moved off a hardcoded dict onto the master) — ADR 0007.
 central.billing.patches.v19_sub_category_memory_ratio.sub_category_memory_ratio
+# Backfill Plan Category.provision_target (VM Plans -> Server) so the create-server
+# flow lists only provisionable families, not AI Tokens / storage plans — issue #33.
+central.billing.patches.v21_category_provision_target.category_provision_target
 central.patches.v01_capability_model_v2.rename_capabilities

--- a/central/patches.txt
+++ b/central/patches.txt
@@ -8,6 +8,10 @@ central.billing.patches.v01_rates_to_standalone.snapshot_legacy_rate_children
 # per slug, rewrite values, backfill Team Members, drop User.billing_team. Runs
 # while `team` is still Data, before the Link field-type flip is synced (#43).
 central.billing.patches.v03_team_link_to_central_team.migrate_team_to_central_team
+# Plan Configurator start_vcpu / ceiling_vcpu: Float -> Select (1/16 … 1024).
+# Widen the decimal columns to varchar before sync (the sync can't cast a '1/8'
+# default against a decimal column) and relabel stored values — issue #33.
+central.billing.patches.v20_configurator_vcpu_dropdown.configurator_vcpu_dropdown
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated


### PR DESCRIPTION
## What & why

Tightens up the Plan Configurator authoring flow and ties catalog rates to real Atlas Instances.

### Catalog Rate → Atlas Instance
- `Catalog Rate.cluster` becomes a **Link to Atlas Instance** (relabeled "Atlas Instance"), replacing the free-text region key. No data migration needed — Atlas Instance is autonamed by region, so existing region values already match instance names. The fieldname stays `cluster`, so the pricing resolver and configurator are untouched.
- The same field in the configurator's **"Generate Plans"** dialog becomes an Atlas Instance Link.
- Pricing a region now validates that the Atlas Instance exists — you can't price a region that isn't a real cluster.

### "New from Configurator" routing
- The Plan list's **"New from Configurator"** button now opens a new **Plan Configurator** document instead of the old one-off `create_configured_plan` shortcut dialog. (`create_configured_plan` stays as a tested API.)

### vCPU size dropdowns
- `start_vcpu` / `ceiling_vcpu` become **Select dropdowns** of clean t-shirt sizes — `1/16, 1/8, 1/4, 1/2, 1, 2, … 1024` — instead of free Float fields. The ladder still doubles; each rung carries a single vCPU value (the label *is* what's provisioned to Atlas).
- `parse_vcpu()` turns a fraction-string value (`"1/16" → 0.0625`) into the float the ladder math uses; `build_ladder`, `before_validate`, and the rung-autofill JS all parse through it. Millicores remain authoring-only.

### Form layout
- Plan Configurator form layout + controller tidy-up (see `feat: Form layout`).