### PR TITLE
fix: complete the Asset-model billing migration so the suite is green

### DIFF
--- a/central/billing/api/admin/_shared.py
+++ b/central/billing/api/admin/_shared.py
@@ -49,6 +49,19 @@ def _plan_monthly_inr(plan: str, cluster: str | None) -> float:
 	return frappe.utils.flt(resolve_rate(get_catalog_rates("Plan", plan), "INR", cluster))
 
 
+def _asset_cluster_map(asset_ids) -> dict:
+	"""Map asset_id -> cluster in one query. Cluster lives on the Asset now (the
+	runtime record), not the Subscription (cdea38e); admin aggregates resolve a
+	subscription's region through its asset_id."""
+	ids = [a for a in set(asset_ids) if a]
+	if not ids:
+		return {}
+	return {
+		r.name: r.cluster
+		for r in frappe.get_all("Asset", filters={"name": ["in", ids]}, fields=["name", "cluster"])
+	}
+
+
 def _active_locks(filters=None):
 	f = {"ended_at": ["is", "not set"]}
 	if filters:

--- a/central/billing/api/admin/teams.py
+++ b/central/billing/api/admin/teams.py
@@ -11,10 +11,20 @@ from central.billing.authz import require_operator
 from central.billing.api.admin._shared import (
 	_STANDING_RANK,
 	_active_locks,
+	_asset_cluster_map,
 	_plan_monthly_inr,
 	_team_currency,
 	_to_inr,
 )
+
+
+def _with_cluster(subs: list[dict]) -> list[dict]:
+	"""Stamp each subscription row with its region, resolved through its asset_id
+	(cluster lives on the Asset now, not the Subscription)."""
+	clusters = _asset_cluster_map([s.asset_id for s in subs])
+	for s in subs:
+		s.cluster = clusters.get(s.asset_id)
+	return subs
 
 
 @frappe.whitelist()
@@ -30,9 +40,9 @@ def get_team_billing(team: str) -> dict:
 		"team": team,
 		"currency": currency,
 		"tier": frappe.db.get_value("Billing Profile", team, "trust_tier") or "—",
-		"subscriptions": frappe.get_all(
+		"subscriptions": _with_cluster(frappe.get_all(
 			"Subscription", filters={"team": team},
-			fields=["name", "plan", "cluster", "account_standing"]),
+			fields=["name", "plan", "asset_id", "account_standing"])),
 		"invoices": frappe.get_all(
 			"Invoice", filters={"team": team},
 			fields=["name", "status", "total", "amount_paid", "currency", "period_end"], order_by="period_start desc"),
@@ -73,9 +83,9 @@ def get_retention() -> dict:
 def get_metrics() -> dict:
 	"""Headline reports: team counts, on-time vs delinquent, failures, MRR."""
 	require_operator()
-	subs = frappe.get_all(
-		"Subscription", fields=["team", "plan", "cluster", "account_standing", "billing_cycle"]
-	)
+	subs = _with_cluster(frappe.get_all(
+		"Subscription", fields=["team", "plan", "asset_id", "account_standing", "billing_cycle"]
+	))
 	teams, mrr = {}, 0.0
 	for s in subs:
 		rate = _plan_monthly_inr(s.plan, s.cluster)
@@ -101,7 +111,7 @@ def list_teams() -> list[dict]:
 	"""Per-team rollup: standing, tier, MRR, resources, open invoices, credit."""
 	require_operator()
 	teams = {}
-	for s in frappe.get_all("Subscription", fields=["team", "plan", "cluster", "account_standing", "billing_cycle"]):
+	for s in _with_cluster(frappe.get_all("Subscription", fields=["team", "plan", "asset_id", "account_standing", "billing_cycle"])):
 		t = teams.setdefault(s.team, {"team": s.team, "standing": "Current", "mrr": 0.0, "subscriptions": 0, "resources": 0})
 		rate = _plan_monthly_inr(s.plan, s.cluster)
 		t["mrr"] += rate / 12 if s.billing_cycle == "Annual" else rate

--- a/central/billing/catalog/subscriptions.py
+++ b/central/billing/catalog/subscriptions.py
@@ -64,16 +64,37 @@ def create_subscription(
 	default_payment_method: str | None = None,
 	gateway: str | None = None,
 	changed_by: str | None = None,
+	resource_id: str | None = None,
 ):
-	"""Record a subscription INTENT — what the customer asked for. The actual
-	provisioning (calling the cluster manager and writing the price-lock) is
-	`provision_subscription`; this captures the contract only, so it stays usable
-	for fixtures and intent-only flows."""
+	"""Record a subscription INTENT — what the customer asked for — linked to its
+	runtime Asset. The Asset is the resource Central drives on a cluster (it carries
+	the region); the Subscription is the billing contract that links to it via
+	`asset_id`. Billing resolves the region (and so the rate snapshot) through the
+	Asset (ADR 0006, cdea38e). The actual provisioning (calling the cluster manager
+	and writing the price-lock) is `provision_subscription`; this captures the
+	contract + its asset only, so it stays usable for fixtures and intent-only flows.
+
+	The cluster must be a registered Atlas Instance (Asset.cluster is a reqd Link)."""
+	resource_id = resource_id or f"vm-{frappe.generate_hash(length=10)}"
+	if not frappe.db.exists("Asset", resource_id):
+		# Pending — not Running — so the Asset status-sync does not race us to create
+		# a second Subscription for this asset.
+		frappe.get_doc(
+			{
+				"doctype": "Asset",
+				"resource_id": resource_id,
+				"team": team,
+				"cluster": cluster,
+				"plan": plan,
+				"status": "Pending",
+			}
+		).insert(ignore_permissions=True)
+
 	doc = frappe.get_doc(
 		{
 			"doctype": "Subscription",
 			"team": team,
-			"cluster": cluster,
+			"asset_id": resource_id,
 			"plan": plan,
 			"billing_cycle": billing_cycle,
 			"account_standing": "Current",
@@ -110,14 +131,15 @@ def provision_subscription(
 	"""
 	from central.billing.platform.sync import record_usage_events
 
+	resource_id = resource_id or f"res-{frappe.generate_hash(length=10)}"
 	sub = create_subscription(
 		team, cluster, plan, billing_cycle=billing_cycle, start_date=start_date,
 		default_payment_method=default_payment_method, gateway=gateway, changed_by=changed_by,
+		resource_id=resource_id,
 	)
 
 	currency = frappe.db.get_value("Billing Profile", team, "currency") or "INR"
 	shown_rate = frappe.get_doc("Plan", plan).get_rate(currency, cluster)
-	resource_id = resource_id or f"res-{frappe.generate_hash(length=10)}"
 	effective_from = f"{sub.start_date} 00:00:00"
 
 	record_usage_events([{

--- a/central/billing/doctype/subscription/subscription.py
+++ b/central/billing/doctype/subscription/subscription.py
@@ -54,8 +54,15 @@ class Subscription(Document):
 			)
 
 	def after_insert(self):
-		"""Log a 'Created' Subscription Change, with a rate snapshot, on insert."""
+		"""Log a 'Created' Subscription Change, with a rate snapshot, on insert.
+
+		The segment opens at the subscription's start_date (when billing begins),
+		not the wall-clock insert time, so a backdated subscription bills its real
+		period."""
 		rate, currency = self.resolve_rate_snapshot()
+		effective_at = (
+			frappe.utils.get_datetime(self.start_date) if self.start_date else frappe.utils.now_datetime()
+		)
 		frappe.get_doc(
 			{
 				"doctype": "Subscription Change",
@@ -64,13 +71,15 @@ class Subscription(Document):
 				"new_value": self.plan,
 				"locked_rate": rate,
 				"currency": currency,
-				"effective_at": frappe.utils.now_datetime(),
+				"effective_at": effective_at,
 				"changed_by": frappe.session.user,
 			}
 		).insert(ignore_permissions=True)
 
 	def on_update(self):
-		if self.has_value_changed("plan"):
+		# on_update fires during the initial insert too; after_insert already logs the
+		# 'Created' segment, so only log a plan change on a genuine later edit.
+		if not self.flags.in_insert and self.has_value_changed("plan"):
 			self.log_plan_change()
 
 	def log_plan_change(self):

--- a/central/billing/doctype/subscription/test_subscription.py
+++ b/central/billing/doctype/subscription/test_subscription.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from central.billing.tests.utils import ensure_team, make_plan
+from central.billing.tests.utils import ensure_atlas_instance, ensure_team, make_plan
 
 EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
@@ -20,6 +20,7 @@ class IntegrationTestSubscription(IntegrationTestCase):
 		self.team = ensure_team("team-sub-doctype")
 		self.plan = make_plan("plan-sub-doctype-a")
 		self.plan_b = make_plan("plan-sub-doctype-b")
+		ensure_atlas_instance("ap-south-1")
 		if not frappe.db.exists("Asset", "vm-sub-doctype"):
 			frappe.get_doc(
 				{

--- a/central/billing/doctype/subscription_change/test_subscription_change.py
+++ b/central/billing/doctype/subscription_change/test_subscription_change.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from central.billing.tests.utils import ensure_team, make_plan
+from central.billing.tests.utils import ensure_atlas_instance, ensure_team, make_plan
 
 EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
@@ -20,6 +20,7 @@ class IntegrationTestSubscriptionChange(IntegrationTestCase):
 		self.team = ensure_team("team-sub-change")
 		self.plan = make_plan("plan-sub-change-a")
 		self.plan_b = make_plan("plan-sub-change-b")
+		ensure_atlas_instance("ap-south-1")
 		if not frappe.db.exists("Asset", "vm-sub-change"):
 			frappe.get_doc(
 				{

--- a/central/billing/revenue/invoicing/lines.py
+++ b/central/billing/revenue/invoicing/lines.py
@@ -40,7 +40,10 @@ def compute_line_items(team: str, cluster: str, period_start, period_end) -> lis
 			"Subscription Change",
 			filters={"subscription": sub.name, "change_type": ["in", ["Created", "Plan Changed", "Cancelled"]]},
 			fields=["change_type", "new_value", "locked_rate", "effective_at"],
-			order_by="effective_at asc",
+			# Secondary sort on creation so changes sharing an effective_at (e.g. a
+			# same-instant provision then cancel) order deterministically by when they
+			# were recorded — otherwise a Cancelled could sort ahead of its Created.
+			order_by="effective_at asc, creation asc",
 		)
 		for i, change in enumerate(changes):
 			if change.change_type == "Cancelled" or change.locked_rate is None:

--- a/central/billing/tests/test_billing.py
+++ b/central/billing/tests/test_billing.py
@@ -8,32 +8,15 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from central.billing.revenue import invoicing, credits
-from central.billing.catalog import subscriptions
-from central.billing.platform.sync import receive_usage_events
-from central.billing.tests.utils import ensure_team, make_plan
+from central.billing.tests.utils import (
+	add_segment,
+	make_billing_subscription,
+	make_plan,
+)
 
 TEAM = "team-invoice"
 CLUSTER = "ap-south-1"
 PLAN = "bundle-invoice-test"
-
-
-def push_event(event_id, resource_id, rate, effective_from, event_type="subscribed"):
-	receive_usage_events(
-		[
-			{
-				"event_id": event_id,
-				"team": TEAM,
-				"resource_id": resource_id,
-				"cluster": CLUSTER,
-				"plan": PLAN,
-				"shown_rate": rate,
-				"currency": "INR",
-				"event_type": event_type,
-				"effective_from": effective_from,
-				"effective_to": None,
-			}
-		]
-	)
 
 
 def run_workers(n, fn):
@@ -63,12 +46,12 @@ def run_workers(n, fn):
 
 class BillingTestBase(IntegrationTestCase):
 	def setUp(self):
-		ensure_team(TEAM)
 		make_plan(PLAN)
 		self._purge()
-		self.sub = subscriptions.create_subscription(
-			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="Monthly"
-		).name
+		# Asset-model subscription; the auto 'Created' segment is cleared so each test
+		# authors its own run-segment timeline with add_segment.
+		self.sub = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
+		frappe.db.commit()
 
 	def tearDown(self):
 		self._purge()
@@ -85,10 +68,10 @@ class BillingTestBase(IntegrationTestCase):
 
 class TestDraftGeneration(BillingTestBase):
 	def test_day_weighted_line_items_new_plan_wins_the_day(self):
-		# One resource, two plan changes within June (rates 1000 / 2000 / 1000).
-		push_event("e1", "R1", 1000, "2026-06-01 00:00:00", "subscribed")
-		push_event("e2", "R1", 2000, "2026-06-10 00:00:00", "changed")
-		push_event("e3", "R1", 1000, "2026-06-22 00:00:00", "changed")
+		# One subscription, two plan changes within June (rates 1000 / 2000 / 1000).
+		add_segment(self.sub, "Created", 1000, "2026-06-01 00:00:00")
+		add_segment(self.sub, "Plan Changed", 2000, "2026-06-10 00:00:00")
+		add_segment(self.sub, "Plan Changed", 1000, "2026-06-22 00:00:00")
 
 		name = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
 		inv = frappe.get_doc("Invoice", name)
@@ -105,8 +88,8 @@ class TestDraftGeneration(BillingTestBase):
 
 	def test_same_day_provision_destroy_floors_to_one_day(self):
 		# Provisioned and cancelled on the same day → 1 day, not 0.
-		push_event("e1", "R2", 1000, "2026-06-05 00:00:00", "subscribed")
-		push_event("e2", "R2", 1000, "2026-06-05 00:00:00", "Cancelled")
+		add_segment(self.sub, "Created", 1000, "2026-06-05 00:00:00")
+		add_segment(self.sub, "Cancelled", None, "2026-06-05 00:00:00")
 
 		name = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
 		inv = frappe.get_doc("Invoice", name)
@@ -115,7 +98,7 @@ class TestDraftGeneration(BillingTestBase):
 		self.assertEqual(inv.items[0].amount, round(1000 / 30, 2))
 
 	def test_partial_first_month_billed_for_join_window(self):
-		push_event("e1", "R3", 3000, "2026-06-15 00:00:00", "subscribed")
+		add_segment(self.sub, "Created", 3000, "2026-06-15 00:00:00")
 		name = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
 		inv = frappe.get_doc("Invoice", name)
 		self.assertEqual(inv.items[0].days, 16)  # Jun15-30 inclusive
@@ -126,7 +109,7 @@ class TestDraftGeneration(BillingTestBase):
 		self.assertEqual(frappe.db.count("Invoice", {"team": TEAM}), 0)
 
 	def test_draft_generation_is_idempotent(self):
-		push_event("e1", "R1", 1000, "2026-06-01 00:00:00", "subscribed")
+		add_segment(self.sub, "Created", 1000, "2026-06-01 00:00:00")
 		first = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
 		second = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
 		self.assertEqual(first, second)
@@ -139,7 +122,7 @@ class TestDraftGeneration(BillingTestBase):
 
 class TestOpenAndCollect(BillingTestBase):
 	def _draft(self):
-		push_event("e1", "R1", 1000, "2026-06-01 00:00:00", "subscribed")
+		add_segment(self.sub, "Created", 1000, "2026-06-01 00:00:00")
 		return invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
 
 	def test_open_applies_credits_and_transitions(self):

--- a/central/billing/tests/test_commitments.py
+++ b/central/billing/tests/test_commitments.py
@@ -12,32 +12,22 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from central.billing.revenue import invoicing
-from central.billing.catalog import subscriptions
-from central.billing.platform.sync import receive_usage_events
-from central.billing.tests.utils import ensure_team, make_plan
+from central.billing.tests.utils import add_segment, make_billing_subscription, make_plan
 
 TEAM = "team-commitment"
 CLUSTER = "ap-south-1"
 PLAN = "bundle-commitment-test"
 
+_CHANGE_TYPE = {"subscribed": "Created", "changed": "Plan Changed", "Cancelled": "Cancelled"}
+
 
 def push_event(event_id, resource_id, rate, effective_from, event_type="subscribed", team=TEAM):
-	receive_usage_events(
-		[
-			{
-				"event_id": event_id,
-				"team": team,
-				"resource_id": resource_id,
-				"cluster": CLUSTER,
-				"plan": PLAN,
-				"shown_rate": rate,
-				"currency": "INR",
-				"event_type": event_type,
-				"effective_from": effective_from,
-				"effective_to": None,
-			}
-		]
-	)
+	"""Author a run-segment for the team's subscription (the unit billing
+	day-weights over in the Asset model). Kept under the old event-shaped signature
+	so the test bodies read unchanged."""
+	sub = frappe.db.get_value("Subscription", {"team": team}, "name")
+	change_type = _CHANGE_TYPE[event_type]
+	add_segment(sub, change_type, rate, effective_from, plan=PLAN)
 
 
 def make_commitment(team, floor, discount_pct, started_at="2026-06-01", term_months=12, currency="INR"):
@@ -58,12 +48,9 @@ def make_commitment(team, floor, discount_pct, started_at="2026-06-01", term_mon
 
 class CommitmentTestBase(IntegrationTestCase):
 	def setUp(self):
-		ensure_team(TEAM)
 		make_plan(PLAN)
 		self._purge()
-		self.sub = subscriptions.create_subscription(
-			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="Monthly"
-		).name
+		self.sub = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
 
 	def tearDown(self):
 		self._purge()

--- a/central/billing/tests/test_dashboard.py
+++ b/central/billing/tests/test_dashboard.py
@@ -9,8 +9,11 @@ from central.billing.revenue import credits
 from central.billing.api import dashboard
 from central.billing.platform.sync import receive_usage_events
 from central.billing.tests.utils import (
+	add_segment,
 	complete_billing_profile,
+	ensure_atlas_instance,
 	ensure_team,
+	make_billing_subscription,
 	make_billing_team,
 	make_custom_role_team,
 	make_plan,
@@ -36,6 +39,7 @@ class TestDashboardSmoke(IntegrationTestCase):
 class CustomerDataBase(IntegrationTestCase):
 	def setUp(self):
 		ensure_team(TEAM)
+		ensure_atlas_instance(CLUSTER)
 		make_plan(PLAN)
 		self._purge()
 		self.today = frappe.utils.getdate()
@@ -48,14 +52,22 @@ class CustomerDataBase(IntegrationTestCase):
 		for dt in ("Invoice", "Price Lock", "Credit Ledger Entry", "Gateway Customer"):
 			frappe.db.delete(dt, {"team": TEAM})
 		frappe.db.delete("Credit Wallet", {"team": TEAM})
+		for sub in frappe.get_all("Subscription", {"team": TEAM}, pluck="name"):
+			frappe.db.delete("Subscription Change", {"subscription": sub})
+			frappe.db.delete("Subscription", {"name": sub})
 		frappe.db.commit()
 
 	def _provision(self, rate=3000):
+		# Price Lock feeds _team_clusters; the Subscription + its month-start segment
+		# feed compute_line_items (the Asset-model fixed accrual).
 		receive_usage_events(
 			[{"event_id": "ev-cust", "team": TEAM, "resource_id": "srv-cust", "cluster": CLUSTER,
 			  "plan": PLAN, "shown_rate": rate, "currency": "INR", "event_type": "subscribed",
 			  "effective_from": f"{self.month_start} 00:00:00", "effective_to": None}]
 		)
+		sub = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
+		add_segment(sub, "Created", rate, f"{self.month_start} 00:00:00")
+		return sub
 
 
 class TestForecast(CustomerDataBase):

--- a/central/billing/tests/test_hardening.py
+++ b/central/billing/tests/test_hardening.py
@@ -14,7 +14,6 @@ from frappe.tests import IntegrationTestCase
 
 from central import billing
 from central.billing import authz
-from central.billing.catalog import subscriptions
 from central.billing.tests.utils import make_billing_team, make_custom_role_team, make_user
 from central.billing.tests.test_stripe_adapter import make_stripe_gateway
 from central.billing.payments.webhooks import process_webhook
@@ -193,17 +192,11 @@ class TestLoadTwoPhase(IntegrationTestCase):
 
 	def test_thousand_scale_run_no_double_processing(self):
 		from central.billing.revenue import invoicing
-		from central.billing.platform.sync import receive_usage_events
+		from central.billing.tests.utils import add_segment, make_billing_subscription
 
-		for i, team in enumerate(self._teams):
-			receive_usage_events(
-				[{"event_id": f"ev-load-{i}", "team": team, "resource_id": f"srv-{i}",
-				  "cluster": self.CLUSTER, "plan": self.PLAN, "shown_rate": 1000, "currency": "INR",
-				  "event_type": "subscribed", "effective_from": "2026-06-01 00:00:00", "effective_to": None}]
-			)
-			subscriptions.create_subscription(
-				team=team, cluster=self.CLUSTER, plan=self.PLAN, billing_cycle="Monthly"
-			)
+		for team in self._teams:
+			sub = make_billing_subscription(team, self.CLUSTER, self.PLAN, billing_cycle="Monthly")
+			add_segment(sub, "Created", 1000, "2026-06-01 00:00:00")
 
 		drafts = invoicing.generate_draft_invoices("2026-06-01", "2026-06-30")
 		mine = [d for d in drafts if frappe.db.get_value("Invoice", d, "team") in self._teams]

--- a/central/billing/tests/test_metering.py
+++ b/central/billing/tests/test_metering.py
@@ -6,9 +6,14 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from central.billing.revenue import invoicing, metering
-from central.billing.catalog import subscriptions
 from central.billing.platform.sync import receive_meter_rollups, receive_usage_events
-from central.billing.tests.utils import ensure_team, make_metered_plan, make_plan
+from central.billing.tests.utils import (
+	add_segment,
+	ensure_team,
+	make_billing_subscription,
+	make_metered_plan,
+	make_plan,
+)
 
 TEAM = "team-meter"
 CLUSTER = "ap-south-1"
@@ -120,9 +125,10 @@ class TestMeteredLineItems(MeteringTestBase):
 
 	def test_draft_invoice_includes_fixed_and_metered_lines(self):
 		receive_meter_rollups([meter("a", 150)])
-		sub = subscriptions.create_subscription(
-			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="Monthly"
-		).name
+		sub = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
+		# Full-June fixed segment at ₹1000/mo (authored as the run-segment billing
+		# day-weights over), alongside the metered overage.
+		add_segment(sub, "Created", 1000, "2026-06-01 00:00:00")
 		name = invoicing.generate_draft_invoice(sub, "2026-06-01", "2026-06-30")
 		inv = frappe.get_doc("Invoice", name)
 

--- a/central/billing/tests/test_sync.py
+++ b/central/billing/tests/test_sync.py
@@ -11,7 +11,12 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from central.billing.catalog import subscriptions
-from central.billing.tests.utils import complete_billing_profile, ensure_team, make_plan
+from central.billing.tests.utils import (
+	complete_billing_profile,
+	ensure_atlas_instance,
+	ensure_team,
+	make_plan,
+)
 
 TEAM = "team-provision"
 PLAN = "bundle-provision"
@@ -22,6 +27,7 @@ class TestProvisionWritesLock(IntegrationTestCase):
 	def setUp(self):
 		ensure_team(TEAM)
 		complete_billing_profile(TEAM, currency="INR")
+		ensure_atlas_instance(CLUSTER)
 		make_plan(PLAN)  # INR catalog rate 3200
 		frappe.db.delete("Price Lock", {"team": TEAM})
 		frappe.db.commit()

--- a/central/billing/tests/test_tax.py
+++ b/central/billing/tests/test_tax.py
@@ -6,9 +6,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from central.billing.revenue import invoicing, tax
-from central.billing.catalog import subscriptions
-from central.billing.platform.sync import receive_usage_events
-from central.billing.tests.utils import ensure_team, make_plan
+from central.billing.tests.utils import add_segment, make_billing_subscription, make_plan
 
 TEAM = "team-tax"
 CLUSTER = "ap-south-1"
@@ -21,34 +19,12 @@ def set_tax_profile(**kw):
 	frappe.get_doc({"doctype": "Tax Profile", "team": TEAM, **kw}).insert(ignore_permissions=True)
 
 
-def provision(rate=1000):
-	receive_usage_events(
-		[
-			{
-				"event_id": "ev-tax",
-				"team": TEAM,
-				"resource_id": "srv-tax",
-				"cluster": CLUSTER,
-				"plan": PLAN,
-				"shown_rate": rate,
-				"currency": "INR",
-				"event_type": "subscribed",
-				"effective_from": "2026-06-01 00:00:00",
-				"effective_to": None,
-			}
-		]
-	)
-
-
 class TaxTestBase(IntegrationTestCase):
 	def setUp(self):
-		ensure_team(TEAM)
 		make_plan(PLAN)
 		self._purge()
-		provision()  # full-month fixed line = 1000
-		self.sub = subscriptions.create_subscription(
-			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="Monthly"
-		).name
+		self.sub = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
+		add_segment(self.sub, "Created", 1000, "2026-06-01 00:00:00")  # full-month fixed line = 1000
 
 	def tearDown(self):
 		self._purge()

--- a/central/billing/tests/test_trials.py
+++ b/central/billing/tests/test_trials.py
@@ -6,12 +6,17 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from central.billing.revenue import invoicing, credits
-from central.billing.catalog import subscriptions, trials
+from central.billing.catalog import trials
 from central.billing.catalog.entitlements import recompute_trust_tier
 from central.billing.catalog.signing import generate_keypair
 from central.billing.platform.sync import receive_usage_events
 from central.billing.tests.test_entitlements import make_ladder
-from central.billing.tests.utils import ensure_team, make_plan
+from central.billing.tests.utils import (
+	add_segment,
+	ensure_team,
+	make_billing_subscription,
+	make_plan,
+)
 
 TEAM = "team-trial"
 CLUSTER = "ap-south-1"
@@ -43,10 +48,11 @@ class TrialTestBase(IntegrationTestCase):
 		make_ladder()  # t0 (entry, default) / t1 / t2
 		make_plan(PLAN)
 		self._purge()
+		# Asset-model subscription (seeds the cluster's Atlas Instance + the team's
+		# INR Billing Profile, clears the auto 'Created' segment); the trust tier is
+		# then pinned to the entry tier on that profile.
+		self.sub = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
 		recompute_trust_tier(TEAM, paid_invoice_count=0, cumulative_paid=0)  # entry tier t0
-		self.sub = subscriptions.create_subscription(
-			team=TEAM, cluster=CLUSTER, plan=PLAN, billing_cycle="Monthly"
-		).name
 
 	def tearDown(self):
 		self._purge()
@@ -67,11 +73,13 @@ class TestCostReportGeneration(TrialTestBase):
 	def test_entry_tier_invoice_is_cost_report(self):
 		self.assertTrue(trials.is_trial_team(TEAM))
 		provision()
+		add_segment(self.sub, "Created", 1000, "2026-06-01 00:00:00")
 		name = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
 		self.assertEqual(frappe.db.get_value("Invoice", name, "invoice_type"), "Cost Report")
 
 	def test_cost_report_is_computed_but_not_charged(self):
 		provision()
+		add_segment(self.sub, "Created", 1000, "2026-06-01 00:00:00")
 		credits.purchase(TEAM, 500, "INR")  # even with a wallet, nothing is drawn
 		name = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
 
@@ -89,6 +97,7 @@ class TestCostReportGeneration(TrialTestBase):
 class TestConversion(TrialTestBase):
 	def test_convert_to_paid_flips_type_and_keeps_resources(self):
 		provision()
+		add_segment(self.sub, "Created", 1000, "2026-06-01 00:00:00")  # runs into July too
 		# June: trial → cost_report.
 		june = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
 		self.assertEqual(frappe.db.get_value("Invoice", june, "invoice_type"), "Cost Report")
@@ -111,8 +120,13 @@ class TestConversion(TrialTestBase):
 class TestSubsidyAndExpiry(TrialTestBase):
 	def test_subsidy_total_sums_cost_report_invoices(self):
 		# A far-future period isolates this global aggregate from seeded demo data.
+		# Two run-segments in the team+cluster (1000 + 2000) — the consolidated draft
+		# day-weights both over the full month.
 		provision("srv-a", rate=1000, start="2099-01-01 00:00:00")
 		provision("srv-b", rate=2000, start="2099-01-01 00:00:00")
+		add_segment(self.sub, "Created", 1000, "2099-01-01 00:00:00")
+		sub_b = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
+		add_segment(sub_b, "Created", 2000, "2099-01-01 00:00:00")
 		name = invoicing.generate_draft_invoice(self.sub, "2099-01-01", "2099-01-31")
 		self.assertEqual(frappe.db.get_value("Invoice", name, "invoice_type"), "Cost Report")
 

--- a/central/billing/tests/utils.py
+++ b/central/billing/tests/utils.py
@@ -171,6 +171,42 @@ def complete_billing_profile(team, currency="INR"):
 	return team
 
 
+def make_billing_subscription(team, cluster, plan, start_date=None, clear_changes=True, **kwargs):
+	"""Provision a billable subscription for billing tests under the Asset model:
+	ensure the cluster's Atlas Instance + the team's Billing Profile currency, create
+	the Asset (carrying the region) + linked Subscription, and (by default) clear the
+	auto 'Created' segment so the test can author its own Subscription Change timeline
+	with `add_segment`. Returns the Subscription name."""
+	from central.billing.catalog import subscriptions
+
+	ensure_atlas_instance(cluster)
+	if not frappe.db.get_value("Billing Profile", team, "currency"):
+		complete_billing_profile(team, currency=kwargs.pop("currency", "INR"))
+	sub = subscriptions.create_subscription(
+		team=team, cluster=cluster, plan=plan, start_date=start_date, **kwargs
+	)
+	if clear_changes:
+		frappe.db.delete("Subscription Change", {"subscription": sub.name})
+	return sub.name
+
+
+def add_segment(subscription, change_type, rate, effective_at, plan=None, currency="INR"):
+	"""Author one Subscription Change run-segment directly — the unit billing
+	day-weights over in the new model. `change_type` is Created / Plan Changed /
+	Cancelled; a Cancelled marker carries no rate (it just closes the prior segment)."""
+	return frappe.get_doc(
+		{
+			"doctype": "Subscription Change",
+			"subscription": subscription,
+			"change_type": change_type,
+			"new_value": plan,
+			"locked_rate": None if change_type == "Cancelled" else rate,
+			"currency": currency,
+			"effective_at": effective_at,
+		}
+	).insert(ignore_permissions=True)
+
+
 def set_team_tier(team, level="t1", max_spend=None, manual_override=1):
 	"""Pin a team's trust tier on its Billing Profile — the per-team tier carrier
 	since the standalone Trust Tier doctype was folded in (#62). Ensures a profile

--- a/central/billing/tests/utils.py
+++ b/central/billing/tests/utils.py
@@ -180,6 +180,7 @@ def make_billing_subscription(team, cluster, plan, start_date=None, clear_change
 	from central.billing.catalog import subscriptions
 
 	ensure_atlas_instance(cluster)
+	ensure_team(team)
 	if not frappe.db.get_value("Billing Profile", team, "currency"):
 		complete_billing_profile(team, currency=kwargs.pop("currency", "INR"))
 	sub = subscriptions.create_subscription(


### PR DESCRIPTION
Commits cdea38e (cluster moved Subscription→Asset) and 874cdf7 (fixed lines from Subscription Change snapshots) rearchitected billing but left the agentless provisioning path and the test suite on the old price-lock model, so ~40 tests failed on a fresh DB (Invoice None cascade, Unknown column 'cluster', missing Atlas Instance seeds). This finishes that migration.

Production:
- catalog/subscriptions.py: create_subscription/provision_subscription now mint an Asset (carrying the region) and link the Subscription via asset_id, so billing resolves cluster + the rate snapshot through the Asset.
- subscription.py: the 'Created' segment opens at start_date (not wall-clock insert time) so a backdated subscription bills its real period; on_update no longer double-logs a 'Plan Changed' during the initial insert.
- api/admin/teams.py + _shared.py: source a subscription's cluster from its Asset instead of the removed Subscription. cluster column.
- invoicing/lines.py: deterministic secondary sort (creation) so changes sharing an effective_at (same-instant provision+cancel) can't misorder.

Tests:
- tests/utils.py: make_billing_subscription (seeds Atlas Instance + Billing Profile, clears the auto segment) and add_segment (authors a Subscription Change run-segment) — the unit billing day-weights over in the new model.
- Migrated test_billing/_commitments/_tax/_metering/_trials/_dashboard/_hardening /_sync and the subscription(_change) doctype tests to the Asset model.

