### PR TITLE
feat(signups): enhance signup and verification flow with product-specific routing

### DIFF
--- a/central/api/auth.py
+++ b/central/api/auth.py
@@ -9,12 +9,13 @@ from frappe.utils.oauth import get_oauth2_authorize_url, get_oauth_keys
 from frappe.utils.password import get_decrypted_password
 
 from central.iam import get_user_team_names
+from central.users import CENTRAL_USER_ROLE
 
-# SMB signup is OTP-based: `sign_up` emails a 6-digit code and caches the pending
+# Signup is OTP-based: `sign_up` emails a 6-digit code and caches the pending
 # signup (no User yet, so an abandoned signup leaves nothing behind — simpler than
-# a holding DocType). `verify_signup` creates the User on a correct code, which
-# fires `bootstrap_user_team` (central/users.py) to make the personal Team, then
-# logs the user in so the onboarding flow continues authenticated.
+# a holding DocType). `verify_signup` creates the User on a correct code — which
+# fires `bootstrap_user_team` (central/users.py) to provision the Central role and
+# personal Team — then logs the new user in so onboarding continues authenticated.
 
 # 2 hours
 OTP_TTL_SECONDS = 2 * 60 * 60
@@ -59,8 +60,8 @@ def verify_signup(email: str, code: str) -> dict:
 	pending = frappe.cache.get_value(_otp_key(email))
 
 	# for developer mode, any 6-digit code passes
-	if frappe.conf.developer_mode and len(code) == 6 and code.isdigit():
-		pending = {"full_name": "Developer", "code": code, "attempts": 0}
+	if frappe.conf.developer_mode and pending and len(code) == 6 and code.isdigit():
+		pending["code"] = code
 
 	if not pending:
 		frappe.throw(_("Your verification code expired. Please sign up again."), frappe.ValidationError)
@@ -124,17 +125,23 @@ def _create_verified_user(email: str, full_name: str):
 			"enabled": 1,
 			"new_password": random_string(10),
 			"user_type": "Website User",
+			"roles": [{"role": role} for role in _signup_roles()],
 		}
 	)
 	user.flags.ignore_permissions = True
 	user.flags.ignore_password_policy = True
 	user.flags.no_welcome_mail = True
-	user.insert()
-
-	default_role = frappe.get_single_value("Portal Settings", "default_role")
-	if default_role:
-		user.add_roles(default_role)
+	# ignore permissions because we are inserting a user as a website user
+	user.insert(ignore_permissions=True)
 	return user
+
+
+def _signup_roles() -> list[str]:
+	roles = [CENTRAL_USER_ROLE]
+	default_role = frappe.get_single_value("Portal Settings", "default_role")
+	if default_role and default_role not in roles:
+		roles.append(default_role)
+	return roles
 
 
 def build_auth_context() -> dict:

--- a/central/tests/test_auth.py
+++ b/central/tests/test_auth.py
@@ -28,16 +28,33 @@ class TestAuth(IntegrationTestCase):
 		self.assertEqual(status, 1)
 		self.assertFalse(frappe.db.exists("User", email))
 
-		# Step 2: the cached code creates the Website User and (via bootstrap_user_team)
-		# its personal team, then logs the user in. login_manager only exists on a real
-		# request, so stub it here.
+		# Step 2: the cached code creates the Website User, logs it in, then provisions
+		# its Central role and personal team as the authenticated user. login_manager
+		# only exists on a real request, so stub the session transition here.
 		code = frappe.cache.get_value(_otp_key(email))["code"]
-		with patch("frappe.local.login_manager", create=True):
+		with patch("frappe.local.login_manager", create=True) as login_manager:
+			login_manager.login_as.side_effect = frappe.set_user
 			result = verify_signup(email, code)
 
+		self.assertEqual(frappe.session.user, email)
 		self.assertEqual(frappe.db.get_value("User", email, "user_type"), "Website User")
+		self.assertIn("Central User", frappe.get_roles(email))
 		self.assertTrue(result["team"])
 		self.assertIsNone(frappe.cache.get_value(_otp_key(email)))
+
+	def test_developer_otp_bypass_still_requires_a_pending_signup(self):
+		frappe.set_user("Guest")
+		email = "central-missing-signup-test@example.test"
+		self.addCleanup(frappe.cache.delete_value, _otp_key(email))
+		original_developer_mode = frappe.conf.developer_mode
+		frappe.conf.developer_mode = 1
+		self.addCleanup(setattr, frappe.conf, "developer_mode", original_developer_mode)
+
+		with self.assertRaises(frappe.ValidationError):
+			with patch("frappe.local.login_manager", create=True):
+				verify_signup(email, "123456")
+
+		self.assertFalse(frappe.db.exists("User", email))
 
 	def test_signup_rejects_existing_user(self):
 		status, message = sign_up("Administrator", "Administrator")

--- a/central/users.py
+++ b/central/users.py
@@ -36,7 +36,8 @@ def bootstrap_user_team(doc, method: str | None = None) -> None:
 			}
 		)
 		team.flags.from_user_bootstrap = True
-		# User.after_insert can run as Guest during self-signup.
+		# User.after_insert runs as Guest during self-signup; this is trusted
+		# provisioning of the user's own team, gated upstream by OTP verification.
 		team.insert(ignore_permissions=True)
 
 	_accept_pending_invitations(doc.name)

--- a/central/www/dashboard.html
+++ b/central/www/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Central Console</title>
-    <script type="module" crossorigin src="/assets/central/dashboard/assets/index-B-gwE0qa.js"></script>
+    <script type="module" crossorigin src="/assets/central/dashboard/assets/index-BByb_xaj.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/central/dashboard/assets/index-CS9UeAVW.css">
   </head>
   <body>

--- a/console/src/pages/auth/SignupPage.vue
+++ b/console/src/pages/auth/SignupPage.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { Button, ErrorMessage } from 'frappe-ui'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter, type LocationQueryRaw } from 'vue-router'
 import AuthShell from '@/components/auth/AuthShell.vue'
 import SocialLoginButtons from '@/components/auth/SocialLoginButtons.vue'
 import { useAuth } from '@/composables/useAuth'
 import ValidatedFormControl from '@/components/common/formComponents/ValidatedFormControl.vue'
 import { emailError, frappeErrorMessage, postFrappe, requiredError } from '@/lib/auth'
 
+const route = useRoute()
 const router = useRouter()
 const fullName = ref('')
 const email = ref('')
@@ -16,6 +17,14 @@ const loading = ref(false)
 const error = ref('')
 
 const { providerLogins } = useAuth()
+const product = computed(() => queryString(route.query.product))
+const isProductSignup = computed(() => Boolean(product.value))
+const signupSteps = computed(() => (isProductSignup.value ? 4 : 2))
+const subheading = computed(() => (
+  isProductSignup.value
+    ? 'A couple of minutes from here to naming your first site.'
+    : 'Verify your email to start managing Central instances.'
+))
 
 async function signup() {
   submitted.value = true
@@ -38,7 +47,7 @@ async function signup() {
     }
     await router.push({
       path: '/signup/verify',
-      query: { email: email.value.trim() },
+      query: verificationQuery(),
     })
   } catch (exception) {
     error.value = frappeErrorMessage(exception, 'Unable to create your account.')
@@ -46,15 +55,33 @@ async function signup() {
     loading.value = false
   }
 }
+
+function verificationQuery(): LocationQueryRaw {
+  return {
+    email: email.value.trim(),
+    ...(product.value ? { product: product.value } : {}),
+  }
+}
+
+function loginQuery(): LocationQueryRaw | undefined {
+  if (!isProductSignup.value) return undefined
+  return { 'redirect-to': '/dashboard/onboarding/site' }
+}
+
+function queryString(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) return queryString(value[0])
+  return ''
+}
 </script>
 
 <template>
-  <AuthShell show-progress>
+  <AuthShell show-progress :steps="signupSteps">
     <h1 class="text-2xl font-semibold text-ink-gray-9">
       Create your account
     </h1>
     <p class="mt-1 text-base text-ink-gray-5">
-      A couple of minutes from here to managing your first server.
+      {{ subheading }}
     </p>
 
     <form class="mt-8 space-y-4" novalidate @submit.prevent="signup">
@@ -63,7 +90,7 @@ async function signup() {
         label="Full name"
         autocomplete="name"
         placeholder="Jane Doe"
-autofocus
+        autofocus
         :validator="requiredError('Full name')"
         :submitted="submitted"
       />
@@ -89,7 +116,7 @@ autofocus
       Already have an account?
       <RouterLink
         class="font-medium text-ink-gray-8 hover:text-ink-gray-9"
-        to="/login"
+        :to="{ path: '/login', query: loginQuery() }"
       >
         Sign in
       </RouterLink>

--- a/console/src/pages/auth/VerifyEmailPage.vue
+++ b/console/src/pages/auth/VerifyEmailPage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { Button, ErrorMessage } from 'frappe-ui'
-import { useRoute, useRouter } from 'vue-router'
+import { useRoute, useRouter, type LocationQueryRaw } from 'vue-router'
 import AuthShell from '@/components/auth/AuthShell.vue'
 import OtpInput from '@/components/common/OtpInput.vue'
 import { API } from '@/api/methods'
@@ -9,7 +9,10 @@ import { frappeErrorMessage, methodUrl, postFrappe } from '@/lib/auth'
 
 const route = useRoute()
 const router = useRouter()
-const email = String(route.query.email ?? '')
+const email = queryString(route.query.email)
+const product = computed(() => queryString(route.query.product))
+const isProductSignup = computed(() => Boolean(product.value))
+const signupSteps = computed(() => (isProductSignup.value ? 4 : 2))
 
 const otp = ref('')
 const loading = ref(false)
@@ -25,8 +28,8 @@ async function verify() {
     await postFrappe(methodUrl(API.verifySignup), { email, code: otp.value })
     // Full navigation so the SPA re-boots with the now-authenticated session.
     // `replace` (not `href`) so the verify page leaves the back stack — Back from
-    // onboarding then can't land on it (the guard also resumes onboarding if it does).
-    window.location.replace('/dashboard/onboarding/site')
+    // the next screen can't land on it (the guard also resumes authenticated state).
+    window.location.replace(signupDestination())
   } catch (exception) {
     error.value = frappeErrorMessage(exception, 'That code did not work. Please try again.')
     otp.value = ''
@@ -49,10 +52,25 @@ async function resend() {
     loading.value = false
   }
 }
+
+function signupDestination(): string {
+  return isProductSignup.value ? '/dashboard/onboarding/site' : '/dashboard/servers'
+}
+
+function signupQuery(): LocationQueryRaw | undefined {
+  if (!isProductSignup.value) return undefined
+  return { product: product.value }
+}
+
+function queryString(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) return queryString(value[0])
+  return ''
+}
 </script>
 
 <template>
-  <AuthShell show-progress :step="2">
+  <AuthShell show-progress :step="2" :steps="signupSteps">
     <h1 class="text-2xl font-semibold text-ink-gray-9">Verify your email</h1>
     <p class="mt-2 text-base text-ink-gray-5">
       Enter the 6-digit code we sent to
@@ -90,7 +108,7 @@ async function resend() {
       <button
         type="button"
         class="font-medium text-ink-gray-8 hover:text-ink-gray-9"
-        @click="router.push('/signup')"
+        @click="router.push({ path: '/signup', query: signupQuery() })"
       >
         Use a different email
       </button>

--- a/e2e/onboarding/smb-signup.spec.js
+++ b/e2e/onboarding/smb-signup.spec.js
@@ -1,8 +1,7 @@
 import { test, expect } from '@playwright/test'
 
-// SMB onboarding — the signup half (Create account → Verify email → Name your
-// site), driven against the real bench with NO MOCKS. It uses the developer_mode
-// OTP bypass (any 6 digits), so no mailbox is needed.
+// Signup routing, driven against the real bench with NO MOCKS. It uses the
+// developer_mode OTP bypass (any 6 digits), so no mailbox is needed.
 //
 // The site-provisioning screens (subdomain availability + the Running handoff)
 // need a configured Atlas region — an active Root Domain and a golden bench
@@ -16,10 +15,10 @@ import { test, expect } from '@playwright/test'
 // pass once.
 const uniqueEmail = () => `smb-${Date.now()}@example.com`
 
-test('signup → OTP verify → reaches Name your site', async ({ page }) => {
+test('product signup → OTP verify → reaches Name your site', async ({ page }) => {
   const email = uniqueEmail()
 
-  await page.goto('/dashboard/signup')
+  await page.goto('/dashboard/signup?product=erpnext')
   await page.getByLabel('Full name').fill('SMB Tester')
   await page.getByLabel('Work email').fill(email)
   await page.getByRole('button', { name: 'Continue' }).click()
@@ -34,4 +33,21 @@ test('signup → OTP verify → reaches Name your site', async ({ page }) => {
   // verify() creates the User + personal Team, logs in, and full-navigates to the
   // authenticated onboarding route.
   await expect(page.getByRole('heading', { name: 'Name your site' })).toBeVisible()
+})
+
+test('central signup → OTP verify → reaches Servers', async ({ page }) => {
+  const email = uniqueEmail()
+
+  await page.goto('/dashboard/signup')
+  await page.getByLabel('Full name').fill('Central Tester')
+  await page.getByLabel('Work email').fill(email)
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page.getByRole('heading', { name: 'Verify your email' })).toBeVisible()
+
+  await page.locator('[data-otp-input]').first().click()
+  await page.keyboard.type('123456')
+
+  await expect(page).toHaveURL(/\/dashboard\/servers$/)
+  await expect(page.getByRole('heading', { name: 'Servers' })).toBeVisible()
 })


### PR DESCRIPTION

- This completes and separates the Signup flow logic for SMB(single site) and Power users.
- Updated user team bootstrap logic to clarify trusted provisioning during self-signup.
- Improved comments in auth.py for better understanding of signup and verification processes.
- Added product-based routing in SignupPage and VerifyEmailPage components to streamline user experience.
- Enhanced tests to cover new signup flows and ensure proper role assignment for new users.