### PR TITLE
docs(billing): architecture/debugging map + setup-and-demo runbook

### DIFF
--- a/central/billing/ARCHITECTURE.md
+++ b/central/billing/ARCHITECTURE.md
@@ -1,0 +1,431 @@
+# Billing — Architecture & Debugging Map
+
+> A glance-view of the `central.billing` module: what the sub-modules are, how they
+> link, what triggers them, and where to look when something breaks. Start here, then
+> jump to the named file. Paths are relative to `central/billing/`.
+>
+> 👉 To **stand up & demonstrate** billing from an empty site, see
+> [`SETUP-AND-DEMO.md`](./SETUP-AND-DEMO.md).
+
+Billing is a **postpaid, in-arrears** money system: Central provisions resources, records
+the runtime it bills from, draws up an invoice in arrears, settles it (credits → card),
+and chases the unpaid ones. There is **no Subscription Agent** (ADR 0006) — Central
+provisions/records/enforces directly. Authorisation is Central's capability IAM
+(ADR 0004), not billing-owned roles.
+
+- **36 DocTypes**, **~10 sub-packages**, **87 whitelisted endpoints**.
+- Money is **integer minor units** (paisa/cent) everywhere; rates are minor×10⁶ (ADR 0003).
+
+---
+
+## 1. Layered sub-module map
+
+```mermaid
+flowchart TD
+    subgraph API["API layer (87 @whitelist)"]
+        DASH["api/dashboard/<br/>customer SPA"]
+        ADMIN["api/admin/<br/>Billing-Admin"]
+    end
+    subgraph CORE["Core billing"]
+        CAT["catalog/<br/>product + pricing + subscriptions + trust tier"]
+        REV["revenue/<br/>invoicing · metering · credits · tax · dunning"]
+        PAY["payments/<br/>charges · collection · mandates · webhooks · refunds"]
+    end
+    subgraph EDGE["Edges"]
+        GW["gateways/<br/>Stripe · Razorpay · PayPal adapters"]
+        PLAT["platform/<br/>notifications · sync"]
+        AUTHZ["authz.py → central.iam"]
+    end
+    EXT["Payment gateways<br/>(Stripe/Razorpay/PayPal)"]
+    CM["cluster-manager API<br/>(provision/enforce)"]
+
+    DASH --> CAT & REV & PAY
+    ADMIN --> CAT & REV & PAY
+    CAT --> PLAT
+    REV --> PAY & PLAT
+    PAY --> GW
+    GW <--> EXT
+    CAT --> CM
+    API -.authz.-> AUTHZ
+    EXT -.webhooks.-> PAY
+```
+
+Read top-to-bottom — each layer calls the one below it.
+
+| Layer | Package | What it owns |
+|---|---|---|
+| **API — customer** | `api/dashboard/` | Team-scoped reads/actions for the customer SPA (`account`, `catalog`, `invoices`, `methods`). |
+| **API — admin** | `api/admin/` | Billing-Admin views: `catalog`, `revenue` (cost-explorer), `teams`, `gateways`. |
+| **Catalog** | `catalog/` | The product & pricing authority: taxonomy masters, Plan Configurator, composed-config pricing, rate resolution, subscriptions (intent + state), trust tiers, entitlement signing. |
+| **Revenue** | `revenue/` | Turning usage into money: `invoicing/` (draft→open→collect), `metering`, `credits`, `tax`, `commitments` discount, `dunning`, `pricelock`, `erpnext_sync`. |
+| **Payments** | `payments/` | Moving the money: `charges`, `collection` (fallback), `collection_mode` (INR ₹15k gate), `mandates` (UPI), `emandate` (RBI), `payments` (cards), `webhooks`, `reconciliation`, `refunds`, `settlement`, `profile`. |
+| **Gateways** | `gateways/` | The adapter seam: `base.GatewayAdapter` + `stripe`/`razorpay`/`paypal` + `registry`. |
+| **Platform** | `platform/` | `notifications` (sole sender), `sync` (record the runtime billed from). |
+| **Authz** | `authz.py` | Capability checks (delegates to `central.iam`). |
+
+Cross-cutting reference data: `india_gst.py`, `regions.py`, `catalog/taxonomy_setup.py`.
+
+---
+
+## 2. Data model — the DocType graph
+
+```mermaid
+erDiagram
+    Team ||--o{ Subscription : has
+    Team ||--|| BillingProfile : has
+    Team ||--o{ Invoice : billed
+    Team ||--o{ PaymentMethod : owns
+    Team ||--o{ CreditLedgerEntry : wallet
+    Team ||--|| CreditWallet : balance
+
+    Plan ||--o{ Subscription : instantiates
+    PlanCategory ||--o{ PlanSubCategory : groups
+    PlanCategory ||--o{ Plan : groups
+    PlanConfigurator ||--o{ Plan : generates
+
+    Subscription ||--o{ SubscriptionChange : "append-only history (locked_rate)"
+    Subscription ||--o| Asset : provisions
+    Subscription ||--o{ Invoice : "billed from"
+
+    Invoice ||--o{ InvoiceLineItem : contains
+    Invoice ||--o{ PaymentAttempt : "settled by"
+    PaymentAttempt ||--o{ Refund : "reversed by"
+    PaymentMethod ||--o{ PaymentAttempt : charges
+
+    BillingProfile }o--|| TrustTierLevel : tier
+    TrustTierLevel ||--o{ TrustTierThreshold : "per-currency"
+    Team ||--o| EntitlementToken : "signed cap"
+
+    PaymentGateway ||--o{ PaymentGatewayCurrency : routes
+    Team ||--o{ GatewayCustomer : "id per gateway"
+    CatalogRate }o--|| Atlas : "per cluster"
+```
+
+Grouped by concern. `→` = Link field; **[C]** = child table; **[S]** = submittable; **[1]** = single.
+
+**Catalog / product**
+```
+Resource Type
+Plan Category ──allowed_resource_types─→ [C]Plan Category Resource Type ─→ Resource Type
+Plan Sub-Category ──category─→ Plan Category
+Plan ──category─→ Plan Category, ──sub_category─→ Plan Sub-Category, ──includes─→ [C]Plan Includes ─→ Resource Type
+Catalog Rate ──priced_doctype─→ DocType, ──priced_for─(dynamic)→, ──cluster─→ Atlas Instance, ──currency
+Plan Configurator ─→ Category, Sub-Category, [C]base_rates, [C]rungs(─→Plan), [C]simple_plans(─→Plan)
+```
+
+**Subscription / state**
+```
+Subscription ──team, ──plan, ──sub_category, ──includes, ──default_payment_method,
+             ──gateway, ──asset_id─→ Asset
+Subscription Change ──subscription, ──team, ──currency      (append-only history + locked_rate)
+Price Lock ──team, ──plan                                    (RETIRED — see §6; rate now lives on Subscription Change)
+```
+
+**Invoice / money**
+```
+Invoice [S] ──team, ──subscription, ──items─→ [C]Invoice Line Item
+Payment Attempt ──invoice, ──team, ──gateway, ──payment_method
+Refund ──payment_attempt, ──invoice, ──team
+Credit Ledger Entry ──team, ──currency        (append-only)
+Credit Wallet ──team                           (lock anchor / cached balance)
+Commitment [S] ──team, ──currency              (spend floor)
+Usage Rollup ──team                            (metered aggregation)
+```
+
+**Payment plumbing**
+```
+Billing Profile ──team, ──currency, ──country, ──trust_tier_level   (currency = source of truth, locks after activity)
+Payment Method ──team, ──gateway
+Payment Gateway ──currencies─→ [C]Payment Gateway Currency
+Gateway Customer ──team, ──gateway             ((team,gateway) → customer_id)
+Tax Profile ──team
+```
+
+**Trust tier / entitlement**
+```
+Trust Tier Level ──thresholds─→ [C]Trust Tier Threshold ──currency   (per-currency thresholds)
+Entitlement Token ──team       (Ed25519-signed cap)
+```
+
+**Plumbing / logs**
+```
+Webhook Event ──gateway        | Billing Notification Log ──team | Notification Preference ──team
+```
+
+---
+
+## 3. Trigger surface — what fires what
+
+```mermaid
+flowchart LR
+    subgraph SCHED["scheduler_events (hooks.py)"]
+        D1["daily"]
+        H1["hourly"]
+        M1["monthly"]
+    end
+    D1 --> RD["run_dunning"]
+    D1 --> RR["run_reconciliation"]
+    D1 --> CP["cleanup_payment_logs"]
+    D1 --> EM["run_emandate_cycle"]
+    D1 --> BF["backfill_missing_subscriptions"]
+    H1 --> RF["retry_failed_syncs (ERPNext)"]
+    M1 --> EX["expire_payment_methods"]
+
+    subgraph MANUAL["⚠️ NOT scheduled — manual/demo"]
+        GDI["generate_draft_invoices (28th)"]
+        OD["open_drafts (1st)"]
+    end
+
+    subgraph INSTALL["install/migrate/before_tests"]
+        ECM["ensure_catalog_masters"]
+    end
+
+    EXT["Gateway webhook"] --> WH["webhooks.@stripe / @razorpay"]
+    WH --> PW["process_webhook → handle_webhook_event → apply_webhook"]
+    UI["Customer SPA / Admin"] --> API["@whitelist endpoints"]
+```
+
+### Scheduled (`central/hooks.py` → `scheduler_events`)
+| Cadence | Entry point | Purpose |
+|---|---|---|
+| daily | `revenue.dunning.run_dunning` | Day 1/3/7 retries → past_due → suspend → terminate |
+| daily | `payments.reconciliation.run_reconciliation` | charged-but-never-webhooked gateway scan |
+| daily | `payments.charges.cleanup_payment_logs` | prune Payment Attempt / Webhook Event |
+| daily | `payments.emandate.run_emandate_cycle` | INR ≤₹15k pre-debit notice → debit after 24h |
+| daily | `catalog.subscriptions.backfill_missing_subscriptions` | Subscription for any Running Asset missing one |
+| hourly | `revenue.erpnext_sync.retry_failed_syncs` | retry Sales Invoice push (backoff window elapsed) |
+| monthly | `payments.payments.expire_payment_methods` | flip cards past their printed month |
+
+> ⚠️ **Invoice generation is NOT in `scheduler_events`.** The 28th-draft / 1st-open phases
+> (`revenue.invoicing.generate_draft_invoices`, `open_drafts`) are designed for those dates
+> but are currently invoked **manually / by demo scenarios**, not by the scheduler. If
+> invoices "aren't appearing on the 28th", this is why — check who's calling them.
+
+### Lifecycle / install hooks
+- `after_install` / `after_migrate` / `before_tests` → `catalog.taxonomy_setup.ensure_catalog_masters` (idempotent seed of catalog masters — ADR 0007).
+- `doc_events` has **no billing entries** — billing reacts to API calls and the scheduler, not to generic DocType saves.
+- `override_doctype_dashboards["Currency"]` → `api.dashboard_overrides.currency_dashboard`.
+
+### Inbound webhooks (`payments/webhooks.py`)
+`@stripe` / `@razorpay` (whitelisted, signature-first) → `process_webhook` → adapter `verify_signature`/`normalise_event` → `handle_webhook_event` → `charges.apply_webhook` (settle the Payment Attempt). Raw payload persisted to **Webhook Event** for dedupe/replay.
+
+### API entry points (87 `@frappe.whitelist`) — see §5 per package.
+
+---
+
+## 4. Key end-to-end flows
+
+### A. Provision a composed config (customer creates a server)
+```mermaid
+sequenceDiagram
+    participant UI as Customer SPA
+    participant API as api/dashboard/catalog
+    participant COMP as catalog.composition
+    participant PRICE as catalog.pricing
+    participant SUB as catalog.subscriptions
+    participant CM as cluster-manager
+    UI->>API: provision_composed_config(config)
+    API->>COMP: validate_composition (bounds)
+    API->>PRICE: resolve_config_rate (region×currency)
+    API->>SUB: provision_composed_subscription
+    SUB->>SUB: create Subscription + Subscription Change (locked_rate)
+    SUB->>CM: provision Asset
+    CM-->>SUB: asset_id
+    SUB-->>UI: subscription
+```
+```
+api/dashboard/catalog.provision_composed_config
+  → catalog.composition.validate_composition        (shape vs sub-category bounds)
+  → catalog.pricing.resolve_config_rate             (region × currency component rate card)
+  → catalog.subscriptions.provision_composed_subscription
+      → creates Subscription (intent) + Subscription Change row (carries locked_rate)
+      → cluster-manager API provisions the Asset
+```
+Resize: `resize_composed_config → resize_composed_subscription` → new Subscription Change (re-prices).
+
+### B. Bill a period (draft → open → collect)
+```mermaid
+flowchart TD
+    S28(["28th · off-peak"]) --> GDI["generate_draft_invoices"]
+    GDI --> GTI["generate_team_invoice (per team)"]
+    GTI --> RS["reconcile_subscription (fix drift)"]
+    GTI --> LINES["lines.compute_line_items<br/>day-weighted from Sub Change segments"]
+    GTI --> MET["+ metering.metered_line_items<br/>max(0, qty−allowance)×rate"]
+    GTI --> DISC["+ commitments discount"]
+    GTI --> TAX["+ tax.resolve_tax<br/>GST / SEZ / TDS"]
+    LINES & MET & DISC & TAX --> DRAFT[["Invoice: Draft"]]
+
+    S1(["1st · light/parallel"]) --> OD["open_drafts"]
+    DRAFT --> OD
+    OD --> OAC["open_and_collect (enqueued per invoice)"]
+    OAC --> WF{"settlement waterfall"}
+    WF -->|credits| CR["settlement.py"]
+    WF -->|then card| CARD["charges.pay_invoice"]
+    CR & CARD --> OPEN[["Invoice: Open"]]
+    OPEN -->|webhook Paid| PAID[["Invoice: Paid"]]
+    PAID --> SYNC["erpnext_sync.enqueue_invoice_sync"]
+```
+```
+[28th, off-peak]  revenue.invoicing.generate_draft_invoices
+  → generate_team_invoice (per team, aggregates clusters)
+      → reconcile_subscription (correct drift if stale)
+      → lines.compute_line_items  (day-weighted, from Subscription Change rate-snapshot segments)
+      → + metering.metered_line_items   (max(0, qty−allowance) × rate)
+      → + commitments discount, + tax.resolve_tax (GST additive / SEZ zero / TDS withhold)
+  → Invoice (Draft)
+
+[1st, light/parallel]  revenue.invoicing.open_drafts
+  → open_and_collect (per invoice; enqueued)
+      → settlement waterfall: credits (settlement.py) → card (charges.pay_invoice)
+      → Invoice Draft → Open → (on webhook) Paid
+      → on Paid: erpnext_sync.enqueue_invoice_sync
+```
+
+### C. Collect / settle a charge
+```mermaid
+sequenceDiagram
+    participant CH as charges.pay_invoice
+    participant GW as gateway adapter
+    participant EXT as Gateway (Stripe/Razorpay)
+    participant WH as payments.webhooks
+    participant COL as collection
+    CH->>GW: create_invoice_payment_order
+    alt INR > ₹15k (collection_mode.evaluate)
+        GW-->>CH: Action Required (manual checkout / prepaid)
+    else off-session
+        GW->>EXT: charge
+        EXT-->>WH: webhook (async)
+        WH->>CH: apply_webhook → Payment Attempt Paid → Invoice Paid
+    end
+    Note over COL: on failure
+    CH--xCOL: collect_invoice walks primary → backup (escalate, don't repeat)
+```
+```
+charges.pay_invoice → create_invoice_payment_order (via gateway adapter)
+  → gateway charges off-session OR returns Action Required (INR > ₹15k, collection_mode.evaluate)
+  → webhook arrives → apply_webhook → Payment Attempt Paid → Invoice Paid
+  → failure → collection.collect_invoice walks primary → backup methods (escalate, don't repeat)
+```
+
+### D. Dunning (unpaid invoice)
+```mermaid
+stateDiagram-v2
+    [*] --> Current
+    Current --> Day1: invoice unpaid
+    Day1 --> Day3: retry_payment fails
+    Day3 --> Day7: retry_payment fails
+    Day7 --> PastDue: still unpaid
+    PastDue --> Suspended: grace elapsed
+    Suspended --> Terminated: no recovery
+    Day1 --> Current: paid
+    Day3 --> Current: paid
+    Day7 --> Current: paid
+    PastDue --> Current: paid
+    note right of Suspended
+        Asset keeps running until the
+        issued Entitlement Token expires
+    end note
+```
+```
+daily run_dunning → process_invoice_dunning(invoice)
+  → retry_payment on Day 1/3/7 → account_standing past_due → suspend → terminate
+  → Agent/cluster enforcement: an already-issued token keeps the asset running until expiry
+```
+
+### E. Metering
+```
+platform.sync.record_meter_rollups  (Central writes the runtime it bills)
+  → revenue.metering.ingest_rollup → Usage Rollup
+  → metering.metered_line_items at invoice time → line items
+```
+
+### F. Credits waterfall & wallet gating
+```
+revenue.credits.purchase → Credit Ledger Entry (append-only) + Credit Wallet (FOR UPDATE lock anchor)
+settlement.effective_spend_cap = min(trust-tier cap, wallet)   (credits-only mode)
+settlement.can_accept_spend gates money movement; 80% forecast warning
+```
+
+### G. Trust tier / entitlement
+```mermaid
+flowchart LR
+    H["billing history"] --> RT["recompute_trust_tier(team)"]
+    RT --> ET["evaluate_tier vs<br/>per-currency Trust Tier Threshold ladder"]
+    ET --> BP["fold into Billing Profile.trust_tier_level"]
+    BP --> IT["issue_token"]
+    IT --> SIGN["catalog.signing (Ed25519)"]
+    SIGN --> TOK[["Entitlement Token<br/>(offline cluster enforcement)"]]
+    BP -.live read.-> GTC["get_team_caps<br/>(no per-team doctype)"]
+```
+```
+catalog.entitlements.recompute_trust_tier(team)
+  → evaluate_tier against per-currency Trust Tier Threshold ladder
+  → folds into Billing Profile.trust_tier_level
+  → issue_token → catalog.signing (Ed25519) → Entitlement Token (offline cluster enforcement)
+get_team_caps resolves caps live (no per-team Trust Tier doctype — dropped)
+```
+
+---
+
+## 5. API surface (by package)
+
+**`api/dashboard/`** (customer, team-scoped)
+- `account.py`: whoami, get/save_billing_profile, billing_geo, get/save_billing_settings, get/set_collection_status/mode, team_overview, trust_tier, switchable_teams, notifications + preferences.
+- `catalog.py`: get_eligible_plans, provision/get/resize_composed_config.
+- `invoices.py`: get_forecast, list/pause/resume_subscription, list/get_invoice, payment_attempts, credit_balance/ledger, purchase_credits, pay_invoice(+checkout/confirm), topup order/confirm.
+- `methods.py`: list/options, card setup + confirm, add_demo_card, fallback-order setup/confirm/reorder, set_default, remove.
+
+**`api/admin/`** (Billing-Admin)
+- `catalog.py`: get_catalog, update_plan_rate, update_component_rate, cluster/plan_consumption, conversion, trial_detail/costs.
+- `revenue.py`: summary, revenue_trend, cluster/team_breakdown, payment_analytics, overdue_aging, free_trial_costs, list_all_invoices.
+- `teams.py`: team_billing, retention, metrics, list_teams, payment_failures, delinquent_teams.
+- `gateways.py`: get_gateways, effective_routing, set_default_gateway.
+
+**Other whitelisted**: `catalog/plans.py` (create_configured_plan, get_plan_pricing), `revenue/credits.py` (purchase, adjust_credits, get_balance), `revenue/erpnext_sync.py` (sync_invoice), `payments/charges.py` (pay_invoice), `payments/payments.py` (initiate/confirm payment method, set_default, reorder, delete), `payments/webhooks.py` (stripe, razorpay), `india_gst.py`, and the `payment_gateway` / `plan_configurator` doctype controllers.
+
+> **Gotcha:** dashboard *mutations* must declare `methods=["POST"]` — frappe-ui `useCall`
+> defaults to GET, and Frappe rolls back writes on GET (the toast lies, nothing persists).
+
+---
+
+## 6. Retired / moved — don't chase ghosts
+
+- **Price Lock doctype + event log** → RETIRED (ADR 0010). The grandfathered rate now lives as
+  `locked_rate` on each **Subscription Change** row. `revenue/pricelock.py` is the thin
+  shim. The `price_lock` doctype still exists but is legacy.
+- **Subscription Agent / `press_billing_agent`** → gone (ADR 0006, agentless). Central calls the
+  cluster-manager API directly.
+- **Per-team Trust Tier doctype** → dropped; caps resolve live via `get_team_caps`.
+- **billing-owned roles + `platform/security.py` + `billing_team` field** → deleted; uses
+  Central capability IAM (`authz.py` → `central.iam`). Team is a `Link(Team)`, not a Data slug.
+- **`billing_mode` field** → removed (v09); Billing Profile currency is the gate.
+
+---
+
+## 7. Debugging cheat-sheet — symptom → where to look
+
+| Symptom | Start at |
+|---|---|
+| Invoice never generated | invoicing not scheduled (§3 ⚠️); check caller of `generate_draft_invoices`; `lines.compute_line_items` for empty segments |
+| Invoice wrong amount | `lines.compute_line_items` (day-weighting), `metering.metered_line_items`, `commitments` discount, `tax.resolve_tax`; verify Subscription Change `locked_rate` segments |
+| Charge stuck "Open"/unpaid | `payments/webhooks.py` (signature failed? Webhook Event row?), `charges.apply_webhook`, `collection.collect_invoice` fallback chain |
+| Webhook ignored | `webhooks.process_webhook` signature check; gateway `verify_signature`; dedupe against existing Webhook Event |
+| Money movement blocked | `settlement.can_accept_spend` / `effective_spend_cap`; Billing Profile complete? currency set? `collection_mode.evaluate` (INR ₹15k gate) |
+| Wrong price | rate resolution: `catalog/pricing.py` (`resolve_rate`/`resolve_config_rate`), `rate_card`, Plan Configurator is the single pricing authority (ADR 0011) |
+| Tier/cap wrong | `catalog.entitlements` (`get_team_caps`, `evaluate_tier`, per-currency Trust Tier Threshold) |
+| Provisioning failed | `catalog.subscriptions.provision_*`, `composition.validate_composition` bounds, cluster-manager call |
+| Card declined repeatedly | `collection` (escalate don't repeat), `mandates.effective_cap`, dunning Day 1/3/7 |
+| ERPNext out of sync | `erpnext_sync` (async, never rolls back the invoice; check retry backoff) |
+| Catalog masters missing | `taxonomy_setup.ensure_catalog_masters` (runs on install/migrate/before_tests) |
+| Money rounding off | minor-units (ADR 0003): rates are minor×10⁶, round **once**; check own ISO-4217 factor table |
+
+---
+
+## 8. Tests & migrations
+
+- **Tests** live in `tests/` (one `test_<area>.py` per concern) — the fastest way to learn a
+  flow is to read its test. `tests/utils.py` (`ensure_team`) + `tests/e2e.py`.
+- **Migrations** in `patches/` are `vNN_*` ordered; the most recent shape the catalog
+  taxonomy (`v15`–`v24`), trust-tier currency (`v12`/`v13`), gateway customer (`v10`/`v11`),
+  and team Link migration (`v03`). Check here when a field "moved" or "disappeared".
+- **End-to-end Playwright** suite lives in the app root `e2e/billing/` (no-mock, real Stripe test).

--- a/central/billing/SETUP-AND-DEMO.md
+++ b/central/billing/SETUP-AND-DEMO.md
@@ -1,0 +1,219 @@
+# Billing — Setup & Demo Runbook (empty site → working billing)
+
+> How to stand up billing on a **fresh `central.local` site** and demonstrate it, as the
+> admin, from scratch. Two paths:
+>
+> - **Path A — Seed** (recommended for a demo): one command builds a rich, self-consistent
+>   set of teams covering every feature. Use this to *show* billing.
+> - **Path B — Manual** (to *understand* the config surface): configure each piece by hand,
+>   the way a real operator onboards a fresh deployment.
+>
+> Companion docs: [`ARCHITECTURE.md`](./ARCHITECTURE.md) (how the code is wired),
+> `../../spec/README.md` (specs). Paths below are relative to `central/billing/`; bench
+> commands run from the bench root (`cenral-bench/`).
+
+---
+
+## 0. Prerequisites (both paths)
+
+1. **A bench + site.** App installed on the site (this runs `after_install` →
+   `catalog.taxonomy_setup.ensure_catalog_masters`, which seeds the catalog taxonomy
+   masters — Plan Category / Sub-Category / Resource Type — that nothing else can run
+   without).
+   ```bash
+   bench new-site central.local
+   bench --site central.local install-app central
+   ```
+2. **Gateway test keys** in `sites/common_site_config.json` (never commit these; the
+   adapters read them via `frappe.conf`):
+   ```json
+   {
+     "stripe_secret_key": "sk_test_…",  "stripe_publishable_key": "pk_test_…",
+     "razorpay_key_id": "rzp_test_…",   "razorpay_key_secret": "…"
+   }
+   ```
+   The **seed** path uses placeholder keys (`skip_credential_validation`) and runs offline;
+   only real charges / top-ups / e2e need live test keys.
+3. **Bench running** (node ≥ 24 on PATH or honcho tears the bench down):
+   ```bash
+   PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH" bench start
+   ```
+4. Build the dashboard SPA if you'll click through the UI: `cd apps/central && yarn build`.
+
+---
+
+## Path A — Seed a demo in one command
+
+```bash
+# Rich, full-spectrum dataset (10 teams: tiers t0–t3, INR/EUR/USD, every collection
+# mode + standing — Active, Grandfathered, Overdue, Suspended, Trial, Refund, Credits):
+bench --site central.local execute central.billing.demo.demo_scenarios.seed_all
+
+# …or the compact feature-coverage set (each settlement path exercised once,
+# one 24-instance fleet team to fill the invoice line-item table):
+bench --site central.local execute central.billing.demo.demo_scenarios.seed_demo
+
+# Sanity counts proving each criterion is covered:
+bench --site central.local execute central.billing.demo.demo_scenarios.summary
+```
+
+What `seed_all` builds (in order): trust tiers → catalog (Atlas clusters, Plans, rates,
+the metered Bandwidth Overage) → gateways (Stripe per-currency, Razorpay INR, PayPal) →
+Ed25519 signing key → then per team: members, billing profile, tier, tax, subscriptions,
+historical Paid invoices, the current (June) invoice in the team's terminal state.
+
+The seed is **idempotent + destructive**: it `_wipe_all()`s billing data first, so re-run
+freely. Administrator is a System Manager and lands on a team with data — just open
+`http://central.local:8011` and go to the billing dashboard.
+
+### What each demo team demonstrates
+| Team | Currency | Tier | State | Shows |
+|---|---|---|---|---|
+| acme-corp | INR | t3 | Grandfathered | price-lock / locked rate, e-mandate > ₹15k → Action Required |
+| globex / initech | EUR / USD | t3 / t2 | Active | standard card postpaid, multi-region fleet |
+| umbrella / wayne-ent | INR | t2 | Active | Manual Checkout / e-mandate pre-debit ≤ ₹15k |
+| stark-ind | INR | t1 | Overdue | dunning retry trail → past_due |
+| cyberdyne | EUR | t1 | Suspended | suspension end-state |
+| hooli | INR | t1 | Credits | prepaid wallet settlement |
+| soylent | USD | t1 | Refund | refund to wallet / source |
+| piedpiper | INR | t0 | Trial | entry-tier free-credits model |
+
+---
+
+## Path B — Configure from scratch as admin
+
+The order matters: **reference data → catalog → gateways → customer → money**. Each step
+names the UI doctype and the programmatic call so you can do either.
+
+```mermaid
+flowchart TD
+    I["install-app<br/>(auto: taxonomy masters)"] --> G["1 · Payment Gateways<br/>+ currencies + default"]
+    G --> C["2 · Catalog: Plans + rates<br/>(Plan Configurator)"]
+    C --> R["3 · Trust tiers + Tax (reference)"]
+    R --> T["4 · Customer Team<br/>+ complete Billing Profile"]
+    T --> M["5 · Payment method / fund wallet"]
+    M --> S["6 · Provision subscription (server)"]
+    S --> INV["7 · Generate invoice (draft→open)"]
+    INV --> COL["8 · Collect / settle"]
+    COL --> DUN["9 · Dunning (if unpaid)"]
+```
+
+### Step 1 · Payment Gateways
+Create a **Payment Gateway** per rail. Required: `title`, `adapter_key`
+(`Stripe` / `Razorpay` / `Paypal`), the secret fields, `is_enabled`, and a **currencies**
+child row with `is_default` set for the currency it serves. Razorpay needs
+`supports_mandates` for UPI Autopay / e-mandate.
+- **UI:** Desk → *Payment Gateway* → New (one per currency for Stripe; one INR Razorpay).
+- **Admin API:** `api/admin/gateways` → `get_gateways`, `set_default_gateway`,
+  `get_effective_routing` (which gateway wins for a currency).
+- Routing rule: `gateways/registry.resolve_gateway_for_currency` picks the default-enabled
+  gateway for the invoice currency.
+
+### Step 2 · Catalog — Plans & rates
+Taxonomy masters are already seeded. Now create **Plans** and **price them per cluster ×
+currency** (rates live in standalone **Catalog Rate**, not on the Plan).
+- **Preferred:** the **Plan Configurator** is the single pricing authority (ADR 0011).
+  Desk → *Plan Configurator*: pick a category/sub-category, set base rates + a t-shirt-size
+  ladder, then `generate_plans` / `apply_pricing` mints the Plans and their rates.
+  (`catalog/configurator.py`; whitelisted via the doctype controller.)
+- **Direct:** `catalog/plans.create_configured_plan`, then
+  `catalog/pricing.set_catalog_rates("Plan", plan, [{cluster, currency, rate}, …])`.
+- Verify a price: `catalog/pricing.resolve_rate` / `get_plan_pricing`.
+
+### Step 3 · Trust tiers & Tax (reference data)
+- **Trust Tier Level** rows with per-currency **Trust Tier Threshold** children define the
+  spend caps a team climbs through. Caps resolve live (`catalog/entitlements.get_team_caps`);
+  there is no per-team tier doctype.
+- **Tax Profile** per team drives GST (additive) / SEZ (zero-with-reason) / TDS (withholding)
+  — `revenue/tax.resolve_tax`. India GST codes live in `india_gst.py`.
+
+### Step 4 · Customer Team + Billing Profile
+Money movement is **gated on a complete Billing Profile** — its `currency` is the source of
+truth (gateway-backed, locks after first activity).
+```bash
+bench --site central.local execute central.billing.payments.profile.create_or_update_billing_profile \
+  --kwargs '{"team": "<TEAM>"}'
+```
+- **UI:** the customer SPA first-run wizard (`api/dashboard/account.save_billing_profile`).
+- Set currency + country (GST state for INR) before any charge.
+
+### Step 5 · Payment method or wallet funding
+- **Card:** `api/dashboard/methods.initiate_card_setup` → `confirm_card` (real Stripe
+  SetupIntent), or `add_demo_card` for an offline demo.
+- **Wallet top-up:** `api/dashboard/invoices.create_topup_order` → `confirm_topup`, or
+  programmatically `revenue.credits.purchase(team, amount, currency, …)` → appends a
+  **Credit Ledger Entry** and updates the **Credit Wallet**.
+- INR rails: `payments/collection_mode` enforces the ₹15k silent-debit ceiling (ADR 0005);
+  set the team's mode (Stripe Auto / E-Mandate / Manual Checkout / Prepaid).
+
+### Step 6 · Provision a subscription (a "server")
+```bash
+bench --site central.local execute central.billing.catalog.subscriptions.provision_subscription \
+  --kwargs '{"team":"<TEAM>","cluster":"in-mumbai","plan":"plan-2vcpu","billing_cycle":"Monthly"}'
+```
+Creates the **Subscription** (intent) + first **Subscription Change** row carrying the
+`locked_rate`, and provisions the Asset via cluster-manager. Composed configs:
+`provision_composed_subscription(team, cluster, includes, sub_category, …)` or the UI
+`api/dashboard/catalog.provision_composed_config`.
+
+### Step 7 · Generate the invoice
+> ⚠️ Invoice generation is **not on the scheduler** (see `ARCHITECTURE.md` §3) — drive it
+> by hand for a demo.
+```bash
+# One team, one period (in arrears):
+bench --site central.local execute central.billing.revenue.invoicing.generate_team_invoice \
+  --kwargs '{"team":"<TEAM>","period_start":"2026-06-01","period_end":"2026-06-30"}'
+# …or all teams for the period (the 28th "draft" phase):
+bench --site central.local execute central.billing.revenue.invoicing.generate_draft_invoices \
+  --kwargs '{"period_start":"2026-06-01","period_end":"2026-06-30"}'
+```
+Lines come from `invoicing/lines.compute_line_items` (day-weighted Subscription Change
+segments) + metered overage + commitment discount + tax. Result: **Invoice (Draft)**.
+
+### Step 8 · Open & collect (settle)
+```bash
+# The 1st "open" phase — runs the credits→card waterfall per draft:
+bench --site central.local execute central.billing.revenue.invoicing.open_drafts \
+  --kwargs '{"period_end":"2026-06-30"}'
+```
+`open_and_collect` applies credits first, charges the card for the remainder, and flips
+Draft → Open → (on webhook) Paid. On a local bench you won't receive a live webhook — the
+e2e suite delivers it via `tests/e2e.py:deliver_webhook` from a real captured txn id; for a
+manual demo, the seed path already shows Paid invoices.
+
+### Step 9 · Dunning (unpaid path)
+Leave an invoice unpaid and run the daily job to walk the Day 1/3/7 retries → past_due →
+suspend:
+```bash
+bench --site central.local execute central.billing.revenue.dunning.run_dunning
+```
+
+---
+
+## Reset / teardown
+
+```bash
+# Re-seeding wipes billing data first, so just re-run the seed to reset:
+bench --site central.local execute central.billing.demo.demo_scenarios.seed_all
+
+# Or wipe billing records only (leaves catalog/gateway config):
+bench --site central.local execute central.billing.demo._factory._wipe_all
+```
+
+For e2e isolation, each Playwright spec seeds + tears down its own sandbox via
+`central/billing/tests/e2e.py` (`seed`/`teardown`, gated behind `allow_tests: true`). See
+`e2e/README.md`.
+
+---
+
+## Quick reference — what's automatic vs. manual
+
+| Piece | Auto (on install/migrate) | Manual (admin) |
+|---|---|---|
+| Catalog taxonomy masters | ✅ `ensure_catalog_masters` | — |
+| Payment Gateways + keys | — | ✅ Desk / admin API + `common_site_config.json` |
+| Plans + rates | — | ✅ Plan Configurator |
+| Trust tiers / Tax profiles | — | ✅ reference data |
+| Billing Profile (per team) | — | ✅ wizard (gates money) |
+| Invoice generation | ❌ **not scheduled** | ✅ run `generate_*` / `open_drafts` |
+| Dunning / reconciliation / e-mandate / card expiry | ✅ scheduled | — |


### PR DESCRIPTION
Add two navigational docs for the billing module:

- ARCHITECTURE.md — glance-view of central.billing: layered sub-module map, DocType relationship graph, trigger surface (scheduler/webhooks/install), key end-to-end flows, API surface, retired pieces, and a symptom→file debugging cheat-sheet. Includes 8 mermaid diagrams.
- SETUP-AND-DEMO.md — empty-site → working billing runbook: a one-command seed path and a from-scratch manual admin path (gateways → catalog → trust tiers/tax → team + billing profile → provision → invoice → collect → dunning), grounded in the demo seed code with verified bench commands.

Notes that invoice generation is not wired into scheduler_events and must be driven by hand for a demo.