### PR TITLE
fix: Update comments to reflect the correct configuration file for pilot credentials

### DIFF
--- a/central/api/pilot.py
+++ b/central/api/pilot.py
@@ -9,7 +9,7 @@ from frappe import _
 from central.central.doctype.pilot_credential.pilot_credential import PilotCredential
 
 # The pilot→Central surface. The pilot (the on-VM agent, ~/pilot) authenticates with
-# the opaque token Central minted for it (stored in the bench's common_site_config).
+# the opaque token Central minted for it (stored in the bench's bench.toml).
 # The token rides an X-Pilot-Token header, NOT Authorization: Frappe's validate_auth()
 # claims the Authorization header and 401s any scheme it can't map to a real user,
 # before an allow_guest endpoint runs. The decorator resolves the token to its Pilot

--- a/central/central/doctype/pilot_credential/pilot_credential.py
+++ b/central/central/doctype/pilot_credential/pilot_credential.py
@@ -110,7 +110,7 @@ class PilotCredential(Document):
 	@classmethod
 	def rotate_by_id(cls, pilot_credential_id: str) -> str:
 		"""Re-issue a live pilot's token (entry point for Atlas-driven rotation). Returns
-		the new plaintext once, for Atlas to push into the bench's common_site_config."""
+		the new plaintext once, for Atlas to push into the bench's bench.toml."""
 		return frappe.get_doc(cls._DOCTYPE_NAME, pilot_credential_id).rotate()
 
 	def _issue_token(self) -> str:

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -189,7 +189,7 @@ class AtlasClient:
 		params.update(self._pilot_credential(team))
 
 		# Durability handoff: the token is about to leave for Atlas → the bench's
-		# common_site_config. Commit it BEFORE the call so a rollback of the enclosing
+		# bench.toml. Commit it BEFORE the call so a rollback of the enclosing
 		# request (e.g. the Site-mirror save right after this returns) can't wipe the
 		# credential and strand the bench with a token Central can't verify — a permanent
 		# 401 with no self-heal. The inverse failure is benign: if the Atlas call fails,
@@ -202,7 +202,7 @@ class AtlasClient:
 	def _pilot_credential(self, team: str) -> dict:
 		"""
 		Mint this pilot's Central credential and hand Atlas the token + callback URL to
-		store on the bench (common_site_config), so later pilot→Central calls authenticate.
+		store on the bench (bench.toml), so later pilot→Central calls authenticate.
 		Atlas binds pilot_credential_id to the pilot and echoes it back to join events. The
 		plaintext token leaves Central only here — never in the reply to Central's caller
 		"""


### PR DESCRIPTION
Changed references from 'common_site_config' to 'bench.toml' in pilot.py, pilot_credential.py, and atlas.py for clarity on where the pilot's token is stored and managed.