### PR TITLE
feat(billing): gate create/resize plan menu by live cluster capacity

### DIFF
--- a/central/billing/api/dashboard/catalog.py
+++ b/central/billing/api/dashboard/catalog.py
@@ -104,7 +104,7 @@ def get_eligible_plans(
 	# headroom (capacity). None = don't gate — the flag is off, no Atlas is registered, or
 	# the check couldn't be reached (fail-soft).
 	is_resize = bool(exclude_subscription)
-	capacity = _resize_capacity(cluster, exclude_subscription) if is_resize else _region_capacity(cluster)
+	capacity = _resize_capacity(cluster, exclude_subscription, team) if is_resize else _region_capacity(cluster)
 	capacity_block = _capacity_block(capacity)
 
 	header = {
@@ -426,17 +426,21 @@ def _region_capacity(cluster: str | None) -> dict | None:
 	)
 
 
-def _resize_capacity(cluster: str | None, subscription: str | None) -> dict | None:
+def _resize_capacity(cluster: str | None, subscription: str | None, team: str) -> dict | None:
 	"""The largest shape the server behind `subscription` can resize to on its current
 	host (atlas.atlas.api.provision.resize_capacity), or None to skip the gate.
 
 	A resize reshapes a VM in place, so the ceiling is its host's free room with its own
 	footprint added back — the running size always fits, and growth is capped to what the
 	host can seat. None when the subscription has no linked Asset yet (nothing to resize)
-	or the region isn't capacity-gated / reachable."""
+	or the region isn't capacity-gated / reachable.
+
+	The subscription is scoped to `team`: a caller can only resize-gate against a
+	subscription their own team owns, so a supplied `exclude_subscription` can't be used
+	to read another team's host-capacity shape (`largest_vm`)."""
 	if not subscription:
 		return None
-	asset_id = frappe.db.get_value("Subscription", subscription, "asset_id")
+	asset_id = frappe.db.get_value("Subscription", {"name": subscription, "team": team}, "asset_id")
 	if not asset_id:
 		return None
 	return _gated_capacity(

--- a/central/billing/api/dashboard/catalog.py
+++ b/central/billing/api/dashboard/catalog.py
@@ -4,10 +4,12 @@
 
 Lists the active plans a team can actually provision on a given cluster: priced
 for the team's currency on that cluster, admitted by the trust tier's allow-lists,
-and within the team's *remaining* trust-tier headroom — the spend cap minus what
-its already-running resources consume. The cluster's provisioning check still has
-the final say at provision time (run-rate vs the live cap, ADR 0006); this read
-only narrows the menu the customer is shown.
+within the team's *remaining* trust-tier headroom — the spend cap minus what its
+already-running resources consume — and fitting the cluster's *live capacity* (the
+region's Atlas reports the largest VM it can seat right now; a plan bigger than that
+is hidden). The cluster's provisioning check still has the final say at provision
+time (run-rate vs the live cap, ADR 0006; placement's NoCapacityError vs the live
+fleet); this read only narrows the menu the customer is shown.
 """
 
 import frappe
@@ -15,7 +17,13 @@ from frappe import _
 
 from central.billing import authz
 from central.billing.api.dashboard._shared import _resolve_team, _team_currency
-from central.billing.catalog.composition import parse_vcpu_steps
+from central.billing.catalog.composition import (
+	COMPUTE,
+	DISK,
+	MEMORY,
+	composition_quantities,
+	parse_vcpu_steps,
+)
 from central.billing.catalog.entitlements import get_team_caps
 from central.billing.catalog.pricing import resolve_component_rate, resolve_rate
 from central.billing.catalog.rate_card import COMPONENT_UNITS
@@ -59,11 +67,26 @@ def get_eligible_plans(
 	  - its rate fits the team's *remaining* headroom: the trust-tier spend cap
 	    (`max_spend`) minus the run-rate of its already-running resources. A team
 	    on a 4000 cap already running 1000 only sees plans priced 3000 or less.
-	    An untiered team has a 0 cap and so no headroom.
+	    An untiered team has a 0 cap and so no headroom;
+	  - its compute shape fits the cluster's live capacity — the largest VM the
+	    region's Atlas can seat right now (`Atlas Instance.validate_capacity`, on by
+	    default; off, or an unreachable Atlas, shows the full menu). A region with no
+	    room at all yields an empty map (nothing provisionable there).
+
+	The `capacity` block carries this last signal to the client: `{gated, available,
+	unmeasured, largest_vm}` — `available` False means "region full, show a message",
+	and `largest_vm` is the composed slider's hard ceiling.
 
 	`exclude_subscription` drops one subscription from the run-rate — passed when
 	resizing, so the server being resized frees its own spend back into the headroom
-	the new size (preset or custom) is measured against.
+	the new size (preset or custom) is measured against. It also marks the call as a
+	resize, which changes *which* capacity ceiling applies: a resize reshapes a VM in
+	place on the host it already occupies, so the ceiling is that host's free room with
+	the VM's own footprint added back (Atlas `resize_capacity`), not the fleet's best-host
+	free headroom used for a new machine. That guarantees the running size always fits
+	(no hidden current plan, downsizes allowed) while still capping growth to what the
+	host can actually seat — so an oversized resize can't be requested only to fail on the
+	host.
 	"""
 	team = _resolve_team(team)
 	currency = _team_currency(team)
@@ -76,9 +99,18 @@ def get_eligible_plans(
 	allowed_plans = _allowlist(caps.allowed_plans)
 	allowed_clusters = _allowlist(caps.allowed_clusters)
 
+	# What can this region physically seat right now? A resize is capped by its own host's
+	# free room + own footprint (resize_capacity); a new machine by the best host's free
+	# headroom (capacity). None = don't gate — the flag is off, no Atlas is registered, or
+	# the check couldn't be reached (fail-soft).
+	is_resize = bool(exclude_subscription)
+	capacity = _resize_capacity(cluster, exclude_subscription) if is_resize else _region_capacity(cluster)
+	capacity_block = _capacity_block(capacity)
+
 	header = {
 		"team": team, "cluster": cluster, "currency": currency, "tier": caps.tier,
 		"max_spend": spend_cap, "current_spend": current_spend, "available": available,
+		"capacity": capacity_block,
 	}
 	# A "design your own" config needs the same three things the slider does: the
 	# per-resource rate card, the profile bounds, and the headroom ceiling (#83).
@@ -87,6 +119,14 @@ def get_eligible_plans(
 	# The tier forbids this cluster outright — nothing is provisionable here, and the
 	# rate card / profiles come back empty too (no composed configs offered either).
 	if cluster and allowed_clusters is not None and cluster not in allowed_clusters:
+		return empty
+
+	# The region can't seat a new VM at all (no Active host with room, or not even the
+	# smallest preset fits) → nothing is provisionable here, presets and composed configs
+	# alike. The client reads `capacity.available` to show a "region is full" message.
+	# A resize is never a dead end this way — it always at least fits its current size —
+	# so this "region full" short-circuit is create-only; a resize just clamps to the host.
+	if capacity is not None and not is_resize and not capacity.get("available"):
 		return empty
 
 	# Only families that provision a server belong in the create-server menu — AI
@@ -129,7 +169,10 @@ def get_eligible_plans(
 			continue  # not priced for this currency/cluster → not available here
 		if frappe.utils.flt(rate) > available:
 			continue  # would push the team past its remaining trust-tier headroom
-		plans.append(_plan_row(p, currency, cluster, rate, includes_by_plan.get(p.name, [])))
+		row = _plan_row(p, currency, cluster, rate, includes_by_plan.get(p.name, []))
+		if capacity and capacity.get("largest_vm") and not _plan_fits(row, capacity["largest_vm"]):
+			continue  # won't fit the largest VM the region can seat right now
+		plans.append(row)
 
 	# Cheapest first; the title-ordered iteration above is a stable tiebreaker.
 	plans.sort(key=lambda p: frappe.utils.flt(p["rate"]))
@@ -344,6 +387,98 @@ def _current_run_rate(team: str, exclude: str | None = None) -> float:
 	from central.billing.catalog.subscriptions import team_run_rate
 
 	return team_run_rate(team, exclude=exclude)
+
+
+def _gated_capacity(cluster: str | None, fetch, *, log: str) -> dict | None:
+	"""Resolve `cluster`'s Atlas Instance and, when capacity gating is on and the Atlas
+	reachable, return `fetch(client)`'s capacity shape — else None (don't gate).
+
+	Gated by the region's `Atlas Instance.validate_capacity` (default on): off, no Atlas
+	registered, or a Disabled Atlas → show the full priced menu. Best-effort and
+	fail-soft — an unreachable Atlas returns None (let placement's create-time gate
+	decide), never an error to the customer."""
+	if not cluster:
+		return None
+	instance = frappe.db.get_value(
+		"Atlas Instance",
+		{"region": cluster},
+		["name", "validate_capacity", "status"],
+		as_dict=True,
+	)
+	if not instance or not instance.validate_capacity or instance.status == "Disabled":
+		return None
+
+	from central.integrations.atlas import AtlasClient
+
+	try:
+		return fetch(AtlasClient(frappe.get_doc("Atlas Instance", instance.name)))
+	except Exception:
+		frappe.log_error(title=log)
+		return None
+
+
+def _region_capacity(cluster: str | None) -> dict | None:
+	"""What `cluster` can seat as a NEW machine right now, for narrowing the create-server
+	menu — the best host's free headroom (`{available, unmeasured, largest_vm}` from
+	atlas.atlas.api.provision.capacity), or None to skip the gate."""
+	return _gated_capacity(
+		cluster, lambda client: client.capacity(), log=f"Capacity check failed for region {cluster}"
+	)
+
+
+def _resize_capacity(cluster: str | None, subscription: str | None) -> dict | None:
+	"""The largest shape the server behind `subscription` can resize to on its current
+	host (atlas.atlas.api.provision.resize_capacity), or None to skip the gate.
+
+	A resize reshapes a VM in place, so the ceiling is its host's free room with its own
+	footprint added back — the running size always fits, and growth is capped to what the
+	host can seat. None when the subscription has no linked Asset yet (nothing to resize)
+	or the region isn't capacity-gated / reachable."""
+	if not subscription:
+		return None
+	asset_id = frappe.db.get_value("Subscription", subscription, "asset_id")
+	if not asset_id:
+		return None
+	return _gated_capacity(
+		cluster,
+		lambda client: client.resize_capacity(asset_id),
+		log=f"Resize capacity check failed for {subscription}",
+	)
+
+
+def _capacity_block(capacity: dict | None) -> dict:
+	"""The client-facing capacity summary the create-server menu renders from.
+
+	`gated` says whether live capacity narrowed this menu at all; `available` whether
+	the region can seat any new VM right now (False → the client shows a "region is
+	full" message); `largest_vm` is the biggest placeable shape, the composed slider's
+	hard ceiling; `unmeasured` flags a host with an unreported axis (sentinel numbers,
+	so treat the ceiling as "size unknown"). Not gated → available with no ceiling; the
+	create-time gate on Atlas still has the final say."""
+	if capacity is None:
+		return {"gated": False, "available": True, "unmeasured": False, "largest_vm": None}
+	return {
+		"gated": True,
+		"available": bool(capacity.get("available")),
+		"unmeasured": bool(capacity.get("unmeasured")),
+		"largest_vm": capacity.get("largest_vm"),
+	}
+
+
+def _plan_fits(row: dict, largest: dict) -> bool:
+	"""Does this preset plan's compute shape fit the largest VM the region can seat now?
+
+	`largest` is Atlas's `{vcpus, memory_megabytes, disk_gigabytes}` — the free headroom
+	on the region's best host, a genuinely co-schedulable shape (a VM lands on one host).
+	Plan Memory is in GB, so scale to MB for the axis compare. A plan with no declared
+	composition (unknown shape → all-zero) trivially fits; placement's create-time gate
+	is authoritative regardless."""
+	qty = composition_quantities(row["includes"])
+	return (
+		qty.get(COMPUTE, 0.0) <= largest["vcpus"]
+		and qty.get(MEMORY, 0.0) * 1024 <= largest["memory_megabytes"]
+		and qty.get(DISK, 0.0) <= largest["disk_gigabytes"]
+	)
 
 
 def _plan_row(plan, currency: str, cluster: str | None, rate, includes) -> dict:

--- a/central/billing/api/dashboard/catalog.py
+++ b/central/billing/api/dashboard/catalog.py
@@ -411,10 +411,45 @@ def _gated_capacity(cluster: str | None, fetch, *, log: str) -> dict | None:
 	from central.integrations.atlas import AtlasClient
 
 	try:
-		return fetch(AtlasClient(frappe.get_doc("Atlas Instance", instance.name)))
+		raw = fetch(AtlasClient(frappe.get_doc("Atlas Instance", instance.name)))
 	except Exception:
+		# Unreachable / timed-out / auth failure — fail soft (show the full menu).
 		frappe.log_error(title=log)
 		return None
+
+	capacity = _valid_capacity(raw)
+	if capacity is None:
+		# A 200 with a shape we don't trust (partial JSON, schema drift). Treat it as
+		# "don't gate" rather than let a later `largest_vm["vcpus"]` KeyError 500 the
+		# whole menu — the fail-soft intent must hold for malformed-but-successful replies.
+		frappe.log_error(title=f"{log}: malformed capacity response", message=repr(raw))
+	return capacity
+
+
+def _valid_capacity(raw) -> dict | None:
+	"""Coerce a raw Atlas capacity reply into a trusted shape, or None if malformed.
+
+	Guarantees callers a well-formed `{available, unmeasured, largest_vm}` where
+	`largest_vm` is either None or a dict with numeric `vcpus`/`memory_megabytes`/
+	`disk_gigabytes` — so `_plan_fits`/`_capacity_block` can index it without a KeyError.
+	Anything that doesn't fit that shape returns None (→ don't gate); a successful call
+	must never crash the menu just because Atlas returned an unexpected body."""
+	if not isinstance(raw, dict) or not all(
+		key in raw for key in ("available", "unmeasured", "largest_vm")
+	):
+		return None
+	largest = raw.get("largest_vm")
+	if largest is not None:
+		if not isinstance(largest, dict) or not all(
+			isinstance(largest.get(axis), (int, float))
+			for axis in ("vcpus", "memory_megabytes", "disk_gigabytes")
+		):
+			return None
+	return {
+		"available": bool(raw.get("available")),
+		"unmeasured": bool(raw.get("unmeasured")),
+		"largest_vm": largest,
+	}
 
 
 def _region_capacity(cluster: str | None) -> dict | None:

--- a/central/billing/tests/test_capacity_filter.py
+++ b/central/billing/tests/test_capacity_filter.py
@@ -205,6 +205,23 @@ class TestCapacityFilter(IntegrationTestCase):
 		self.assertIn(SMALL, plans)
 		self.assertIn(BIG, plans)
 
+	def test_malformed_largest_vm_fails_soft(self):
+		# A 200 whose largest_vm is missing an axis must not KeyError-500 the menu — it's
+		# treated as "don't gate" and the full priced list shows.
+		bad = {"available": True, "unmeasured": False, "largest_vm": {"vcpus": 4, "memory_megabytes": 8192}}
+		with patch.object(AtlasClient, "capacity", return_value=bad):
+			out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
+		self.assertFalse(out["capacity"]["gated"])
+		self.assertIn(BIG, _titles(out))
+
+	def test_missing_top_level_key_fails_soft(self):
+		# A body missing `available`/`unmeasured` is untrusted → ungated, full menu (not
+		# mistaken for a region-full empty menu).
+		with patch.object(AtlasClient, "capacity", return_value={"largest_vm": None}):
+			out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
+		self.assertFalse(out["capacity"]["gated"])
+		self.assertIn(BIG, _titles(out))
+
 	def test_unmeasured_host_admits_everything(self):
 		# An unreported axis surfaces as a huge sentinel → every plan fits (uncatalogued
 		# = unlimited, the same vouch-by-Active rule placement uses).

--- a/central/billing/tests/test_capacity_filter.py
+++ b/central/billing/tests/test_capacity_filter.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Create/resize plan menu: the live-capacity gate (Atlas Instance.validate_capacity).
+
+get_eligible_plans hides plans whose compute shape won't fit the largest VM the
+region's Atlas can seat right now. The Atlas capacity call is mocked here — this
+suite proves the gate's wiring (fit compare, no-room → empty, flag off / unreachable
+→ show everything), not Atlas's own accounting."""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from central.billing.api.dashboard.catalog import get_eligible_plans
+from central.billing.tests.utils import (
+	clear_team_tier,
+	complete_billing_profile,
+	ensure_atlas_instance,
+	ensure_team,
+	make_plan,
+	set_team_tier,
+)
+from central.integrations.atlas import AtlasClient
+
+TEAM = "team-capacity-filter"
+CLUSTER = "ap-south-1"
+
+SMALL = "cap-small"  # 1 vCPU / 2 GB / 20 GB
+BIG = "cap-big"      # 8 vCPU / 32 GB / 500 GB
+
+
+def _shape(vcpu, memory_gb, disk_gb):
+	return [
+		{"resource_type": "Compute", "quantity": vcpu, "unit": "vCPU"},
+		{"resource_type": "Memory", "quantity": memory_gb, "unit": "GB"},
+		{"resource_type": "Disk", "quantity": disk_gb, "unit": "GB"},
+	]
+
+
+def _ensure_tier_level(name):
+	if frappe.db.exists("Trust Tier Level", name):
+		frappe.delete_doc("Trust Tier Level", name, force=True)
+	frappe.get_doc(
+		{
+			"doctype": "Trust Tier Level", "__newname": name, "tier": name,
+			"sequence": 1, "is_default": 0, "max_resource_count": 50, "min_paid_invoices": 0,
+			"thresholds": [{"currency": "INR", "max_spend": 100000, "min_cumulative_paid": 0}],
+		}
+	).insert(ignore_permissions=True)
+
+
+def _titles(out):
+	return {p["plan"] for rows in out["plans"].values() for p in rows}
+
+
+class TestCapacityFilter(IntegrationTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+		ensure_team(TEAM)
+		complete_billing_profile(TEAM, currency="INR")
+		clear_team_tier(TEAM)
+		for name in frappe.get_all("Subscription", filters={"team": TEAM}, pluck="name"):
+			frappe.db.delete("Subscription Change", {"subscription": name})
+			frappe.delete_doc("Subscription", name, force=True)
+		_ensure_tier_level("t1")
+		set_team_tier(TEAM, max_spend=100000)  # ample headroom — the gate under test is capacity
+		make_plan(SMALL, rates=[{"cluster": "", "currency": "INR", "rate": 1000}], includes=_shape(1, 2, 20))
+		make_plan(BIG, rates=[{"cluster": "", "currency": "INR", "rate": 2000}], includes=_shape(8, 32, 500))
+		ensure_atlas_instance(CLUSTER)
+		frappe.db.set_value("Atlas Instance", CLUSTER, "validate_capacity", 1)
+		frappe.set_user("Administrator")
+
+	def _capacity(self, vcpus, memory_mb, disk_gb, available=True):
+		return {
+			"available": available,
+			"unmeasured": False,
+			"largest_vm": {"vcpus": vcpus, "memory_megabytes": memory_mb, "disk_gigabytes": disk_gb},
+		}
+
+	def test_hides_plans_that_dont_fit_the_region(self):
+		# The region's best host can seat 4 vCPU / 8 GB / 200 GB: SMALL fits, BIG doesn't.
+		cap = self._capacity(4, 8 * 1024, 200)
+		with patch.object(AtlasClient, "capacity", return_value=cap):
+			out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
+		plans = _titles(out)
+		self.assertIn(SMALL, plans)
+		self.assertNotIn(BIG, plans)
+
+	def test_fitting_plans_all_show(self):
+		# Roomy host — everything fits.
+		cap = self._capacity(16, 64 * 1024, 1000)
+		with patch.object(AtlasClient, "capacity", return_value=cap):
+			out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
+		plans = _titles(out)
+		self.assertIn(SMALL, plans)
+		self.assertIn(BIG, plans)
+
+	def test_memory_axis_is_scaled_to_mb(self):
+		# 3 GB free would swallow BIG's 32 GB if the axis were compared in GB by mistake.
+		cap = self._capacity(16, 3, 1000)  # 3 MB of RAM — nothing fits
+		with patch.object(AtlasClient, "capacity", return_value=cap):
+			out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
+		self.assertEqual(_titles(out), set())
+
+	def test_no_room_yields_empty_menu(self):
+		# largest_vm None → no Active host with room → the whole menu is empty, composed
+		# configs included (rate card / profiles come back empty too). The capacity block
+		# tells the client to show a "region is full" message.
+		nothing = {"available": False, "unmeasured": False, "largest_vm": None}
+		with patch.object(AtlasClient, "capacity", return_value=nothing):
+			out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
+		self.assertEqual(out["plans"], {})
+		self.assertEqual(out["rate_card"], {})
+		self.assertEqual(out["profiles"], [])
+		self.assertEqual(out["capacity"], {"gated": True, "available": False, "unmeasured": False, "largest_vm": None})
+
+	def test_smallest_preset_not_fitting_yields_empty_menu(self):
+		# `available` False even with a (tiny) largest_vm — Atlas says nothing provisions
+		# here — is the same dead end: empty menu, region-full signal.
+		full = self._capacity(1, 512, 5, available=False)
+		with patch.object(AtlasClient, "capacity", return_value=full):
+			out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
+		self.assertEqual(out["plans"], {})
+		self.assertEqual(out["rate_card"], {})
+		self.assertFalse(out["capacity"]["available"])
+
+	def test_capacity_block_reports_the_ceiling(self):
+		cap = self._capacity(4, 8 * 1024, 200)
+		with patch.object(AtlasClient, "capacity", return_value=cap):
+			out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
+		self.assertEqual(
+			out["capacity"],
+			{"gated": True, "available": True, "unmeasured": False,
+			 "largest_vm": {"vcpus": 4, "memory_megabytes": 8 * 1024, "disk_gigabytes": 200}},
+		)
+
+	def test_resize_uses_per_host_capacity(self):
+		# A resize is gated by its OWN host's headroom (resize_capacity), not the fleet
+		# best-host ceiling (capacity). The running size always fits; growth is capped.
+		from central.billing.catalog import subscriptions
+
+		sub = subscriptions.create_subscription(TEAM, CLUSTER, plan=SMALL).name  # links an Asset
+		cap = self._capacity(4, 8 * 1024, 200)  # fits SMALL, not BIG
+		with (
+			patch.object(AtlasClient, "resize_capacity", return_value=cap) as mock_resize,
+			patch.object(AtlasClient, "capacity") as mock_create,
+		):
+			out = get_eligible_plans(cluster=CLUSTER, team=TEAM, exclude_subscription=sub)
+		mock_create.assert_not_called()   # the create-machine ceiling isn't used for a resize
+		mock_resize.assert_called_once()  # the per-host resize ceiling is
+		plans = _titles(out)
+		self.assertIn(SMALL, plans)       # the running size always fits its own host
+		self.assertNotIn(BIG, plans)      # growth capped to what the host can seat
+		self.assertTrue(out["capacity"]["gated"])
+
+	def test_resize_without_linked_asset_skips_the_gate(self):
+		# A subscription with no Asset yet (nothing placed to resize) → don't gate, and
+		# don't reach for either capacity endpoint.
+		with (
+			patch.object(AtlasClient, "resize_capacity") as mock_resize,
+			patch.object(AtlasClient, "capacity") as mock_create,
+		):
+			out = get_eligible_plans(cluster=CLUSTER, team=TEAM, exclude_subscription="no-such-sub")
+		mock_resize.assert_not_called()
+		mock_create.assert_not_called()
+		self.assertFalse(out["capacity"]["gated"])
+		self.assertIn(BIG, _titles(out))
+
+	def test_flag_off_skips_the_capacity_call(self):
+		# validate_capacity off → the full priced menu, and Atlas is never asked.
+		frappe.db.set_value("Atlas Instance", CLUSTER, "validate_capacity", 0)
+		with patch.object(AtlasClient, "capacity") as mock_capacity:
+			out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
+		mock_capacity.assert_not_called()
+		plans = _titles(out)
+		self.assertIn(SMALL, plans)
+		self.assertIn(BIG, plans)
+
+	def test_unreachable_atlas_is_fail_soft(self):
+		# The capacity call blowing up must not break the menu — show everything and let
+		# placement's create-time gate decide.
+		with patch.object(AtlasClient, "capacity", side_effect=Exception("atlas down")):
+			out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
+		plans = _titles(out)
+		self.assertIn(SMALL, plans)
+		self.assertIn(BIG, plans)
+
+	def test_unmeasured_host_admits_everything(self):
+		# An unreported axis surfaces as a huge sentinel → every plan fits (uncatalogued
+		# = unlimited, the same vouch-by-Active rule placement uses).
+		cap = {
+			"available": True, "unmeasured": True,
+			"largest_vm": {"vcpus": 1024, "memory_megabytes": 1024 * 1024, "disk_gigabytes": 1024 * 1024},
+		}
+		with patch.object(AtlasClient, "capacity", return_value=cap):
+			out = get_eligible_plans(cluster=CLUSTER, team=TEAM)
+		plans = _titles(out)
+		self.assertIn(SMALL, plans)
+		self.assertIn(BIG, plans)

--- a/central/billing/tests/test_capacity_filter.py
+++ b/central/billing/tests/test_capacity_filter.py
@@ -154,6 +154,25 @@ class TestCapacityFilter(IntegrationTestCase):
 		self.assertNotIn(BIG, plans)      # growth capped to what the host can seat
 		self.assertTrue(out["capacity"]["gated"])
 
+	def test_resize_cannot_gate_on_another_teams_subscription(self):
+		# IDOR guard: exclude_subscription is scoped to the caller's team, so a subscription
+		# owned by a different team resolves no asset → gate skipped, Atlas never queried.
+		# (Otherwise the caller could read another team's host-capacity shape.)
+		from central.billing.catalog import subscriptions
+
+		other = ensure_team("team-capacity-other")
+		complete_billing_profile(other, currency="INR")
+		other_sub = subscriptions.create_subscription(other, CLUSTER, plan=SMALL).name
+		with (
+			patch.object(AtlasClient, "resize_capacity") as mock_resize,
+			patch.object(AtlasClient, "capacity") as mock_create,
+		):
+			out = get_eligible_plans(cluster=CLUSTER, team=TEAM, exclude_subscription=other_sub)
+		mock_resize.assert_not_called()
+		mock_create.assert_not_called()
+		self.assertFalse(out["capacity"]["gated"])
+		self.assertIn(BIG, _titles(out))
+
 	def test_resize_without_linked_asset_skips_the_gate(self):
 		# A subscription with no Asset yet (nothing placed to resize) → don't gate, and
 		# don't reach for either capacity endpoint.

--- a/central/billing/tests/test_dashboard_catalog.py
+++ b/central/billing/tests/test_dashboard_catalog.py
@@ -68,6 +68,11 @@ class TestEligiblePlans(IntegrationTestCase):
 		make_plan(PRICEY, rates=_rates(5000))
 		# Priced only on CLUSTER (no global INR row) → invisible elsewhere.
 		make_plan(REGIONAL, rates=[{"cluster": CLUSTER, "currency": "INR", "rate": 1500}])
+		# These tests exercise the tier/currency filter, not live capacity — the pricing
+		# above created the CLUSTER Atlas Instance (validate_capacity on by default); turn
+		# it off so get_eligible_plans doesn't reach for the region's capacity API.
+		# The capacity gate has its own suite (test_capacity_filter.py).
+		frappe.db.set_value("Atlas Instance", CLUSTER, "validate_capacity", 0)
 		frappe.set_user("Administrator")
 
 	def _titles(self, cluster=CLUSTER):

--- a/central/billing/tests/test_eligibility_composed.py
+++ b/central/billing/tests/test_eligibility_composed.py
@@ -37,6 +37,11 @@ class TestEligibilityComposed(IntegrationTestCase):
 		frappe.set_user("Administrator")  # a prior test may have left a customer user
 		ensure_atlas_instance(CLUSTER)
 		ensure_atlas_instance(OTHER)
+		# This suite covers the composed rate card / bounds, not live capacity — keep the
+		# capacity gate off so get_eligible_plans doesn't reach for the region's Atlas
+		# (its own coverage lives in test_capacity_filter.py).
+		frappe.db.set_value("Atlas Instance", CLUSTER, "validate_capacity", 0)
+		frappe.db.set_value("Atlas Instance", OTHER, "validate_capacity", 0)
 		ensure_team(TEAM)
 		complete_billing_profile(TEAM, currency="INR")
 		set_team_tier(TEAM, max_spend=100000)

--- a/central/central/doctype/atlas_instance/atlas_instance.json
+++ b/central/central/doctype/atlas_instance/atlas_instance.json
@@ -8,6 +8,7 @@
   "region",
   "base_url",
   "status",
+  "validate_capacity",
   "column_break_auth",
   "api_key",
   "api_secret",
@@ -52,6 +53,13 @@
    "label": "Status",
    "options": "Active\nDraining\nDisabled",
    "reqd": 1
+  },
+  {
+   "default": "1",
+   "description": "Only offer plans that fit this region's live capacity when creating or resizing a server (checked against the Atlas capacity API). Off = show the full priced menu and let placement's create-time gate have the final say.",
+   "fieldname": "validate_capacity",
+   "fieldtype": "Check",
+   "label": "Validate Capacity"
   },
   {
    "fieldname": "column_break_auth",

--- a/central/central/doctype/atlas_instance/atlas_instance.py
+++ b/central/central/doctype/atlas_instance/atlas_instance.py
@@ -29,6 +29,7 @@ class AtlasInstance(Document):
 		tunnel_ip: DF.Data | None
 		tunnel_status: DF.Literal["Unregistered", "Provisioning", "Active", "Inactive"]
 		tunnel_url: DF.Data | None
+		validate_capacity: DF.Check
 	# end: auto-generated types
 
 	def validate(self) -> None:

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -127,6 +127,27 @@ class AtlasClient:
 			params["cpu_max_cores"] = cpu_max_cores
 		return self.client().post_api("atlas.atlas.api.provision.create_vm", params=params)
 
+	def capacity(self) -> dict:
+		"""Ask this region what it can seat right now: `{available, unmeasured, largest_vm}`.
+
+		Central speaks in resources, never hosts — placement is Atlas's concern
+		(spec/16-central.md). `largest_vm` is the biggest single VM shape placeable now
+		(`{vcpus, memory_megabytes, disk_gigabytes}`, or null when no Active host exists);
+		the create-server menu hides plans that don't fit it. Advisory only — placement's
+		create-time gate is authoritative, since capacity can move between this read and
+		the create."""
+		return self.client().get_api("atlas.atlas.api.provision.capacity")
+
+	def resize_capacity(self, vm: str) -> dict:
+		"""The largest shape `vm` can resize to on its current host: `{available,
+		unmeasured, largest_vm}`. The in-place twin of `capacity()` — the ceiling includes
+		the VM's own footprint (a resize frees it before re-reserving), so the VM can always
+		keep its size or shrink. The create-server menu caps the resize slider to this so an
+		oversized resize can't be requested. Advisory — the host resize path is authoritative."""
+		return self.client().get_api(
+			"atlas.atlas.api.provision.resize_capacity", params={"vm": vm}
+		)
+
 	def central_vms(self, team: str | None = None) -> list[dict]:
 		"""Tenant-tagged VMs on this Atlas for the mirror reconcile (optionally one
 		team). One dict per VM: name, team, status, gateway_url."""

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -26,6 +26,12 @@ from central.host_task import run_host_task
 # --- outbound: Central → Atlas ----------------------------------------------
 
 
+# Hard timeout (seconds) for the capacity reads on the create-server / resize menu path.
+# Short on purpose: these run on every menu render and fail soft (a timeout just shows the
+# full menu), so a degraded Atlas must not hold a worker longer than a page can wait.
+CAPACITY_TIMEOUT = 3
+
+
 class AtlasError(frappe.ValidationError):
 	pass
 
@@ -136,7 +142,7 @@ class AtlasClient:
 		the create-server menu hides plans that don't fit it. Advisory only — placement's
 		create-time gate is authoritative, since capacity can move between this read and
 		the create."""
-		return self.client().get_api("atlas.atlas.api.provision.capacity")
+		return self._get_bounded("atlas.atlas.api.provision.capacity")
 
 	def resize_capacity(self, vm: str) -> dict:
 		"""The largest shape `vm` can resize to on its current host: `{available,
@@ -144,9 +150,30 @@ class AtlasClient:
 		the VM's own footprint (a resize frees it before re-reserving), so the VM can always
 		keep its size or shrink. The create-server menu caps the resize slider to this so an
 		oversized resize can't be requested. Advisory — the host resize path is authoritative."""
-		return self.client().get_api(
-			"atlas.atlas.api.provision.resize_capacity", params={"vm": vm}
+		return self._get_bounded("atlas.atlas.api.provision.resize_capacity", {"vm": vm})
+
+	def _get_bounded(self, method: str, params: dict | None = None, timeout: int = CAPACITY_TIMEOUT) -> dict:
+		"""Admin-auth GET against the data path with a HARD timeout — the bounded twin of
+		`client().get_api`. The capacity reads run on every create-server / resize menu
+		render, and FrappeClient (like requests) has no default timeout, so a silently-hung
+		Atlas (slow net, overloaded host) would otherwise pin a Gunicorn worker on the OS
+		TCP timeout and stall every user in that region. A timeout raises here and the
+		caller's fail-soft path treats it as 'don't gate' (show the full menu). Returns the
+		endpoint's `message` payload."""
+		if self.instance.status == "Disabled":
+			frappe.throw(f"Atlas '{self.instance.region}' is disabled.", AtlasError)
+		if not self.instance.api_key:
+			frappe.throw(f"Atlas '{self.instance.region}' has no admin API key.", AtlasError)
+		url = self._data_url().rstrip("/") + "/api/method/" + method
+		secret = self.instance.get_password("api_secret")
+		response = requests.get(
+			url,
+			headers={"Authorization": f"token {self.instance.api_key}:{secret}"},
+			params=params or {},
+			timeout=timeout,
 		)
+		response.raise_for_status()
+		return response.json().get("message", {})
 
 	def central_vms(self, team: str | None = None) -> list[dict]:
 		"""Tenant-tagged VMs on this Atlas for the mirror reconcile (optionally one

--- a/console/src/components/servers/ConfigDesigner.vue
+++ b/console/src/components/servers/ConfigDesigner.vue
@@ -3,15 +3,18 @@ import { computed, ref, watch } from 'vue'
 import { Slider } from 'frappe-ui'
 import LadderSelect from '@/components/servers/LadderSelect.vue'
 import {
+  capacityLimits,
   clamp,
   estimateConfig,
   formatGb,
   formatVcpu,
   maxAffordableDisk,
   maxAffordableVcpu,
+  maxDiskForCapacity,
+  maxVcpuForCapacity,
   ramFor,
 } from '@/lib/composed'
-import type { ComposedConfig, Profile, RateCard } from '@/types/api'
+import type { Capacity, ComposedConfig, Profile, RateCard } from '@/types/api'
 
 // Design-your-own config controls (#84). Compute and Storage are both discrete
 // ladders the slider snaps to (vCPU from the configurator's set incl. fractions;
@@ -23,6 +26,9 @@ const props = defineProps<{
   profiles: Profile[]
   rateCard: RateCard
   available: number
+  // The region's live capacity — the slider's second hard stop (below headroom), so a
+  // customer can't design a config the region can't currently seat. Absent → no cap.
+  capacity?: Capacity | null
   // Pre-fill the controls with a running config's shape (resize, #82/#84).
   initial?: ComposedConfig | null
 }>()
@@ -57,18 +63,42 @@ const diskModel = computed<number[]>({
 })
 const ram = computed<number>(() => (profile.value ? ramFor(vcpus.value, profile.value) : 0))
 
-// Hard stops: the largest vCPU / storage rung that still fits the remaining
-// headroom, each given the other's current value.
+// Hard stops: the largest vCPU / storage rung that still fits the remaining headroom
+// AND the region's live capacity (the more restrictive of the two), each given the
+// other's current value.
 const maxVcpuIndex = computed<number>(() =>
   profile.value
-    ? indexOf(vcpuSteps.value, maxAffordableVcpu(profile.value, props.rateCard, props.available, diskGb.value))
+    ? indexOf(
+        vcpuSteps.value,
+        Math.min(
+          maxAffordableVcpu(profile.value, props.rateCard, props.available, diskGb.value),
+          maxVcpuForCapacity(profile.value, props.capacity),
+        ),
+      )
     : 0,
 )
 const maxDiskIndex = computed<number>(() =>
   profile.value
-    ? indexOf(diskSteps.value, maxAffordableDisk(profile.value, props.rateCard, props.available, vcpus.value))
+    ? indexOf(
+        diskSteps.value,
+        Math.min(
+          maxAffordableDisk(profile.value, props.rateCard, props.available, vcpus.value),
+          maxDiskForCapacity(profile.value, props.capacity),
+        ),
+      )
     : 0,
 )
+
+// Whether the region's capacity — not headroom — is what's holding the slider back, so
+// the copy can name the real reason (a full region reads differently from a spent limit).
+const cappedByCapacity = computed<boolean>(() => {
+  if (!profile.value || !capacityLimits(props.capacity)) return false
+  const capVcpu = maxVcpuForCapacity(profile.value, props.capacity)
+  const capDisk = maxDiskForCapacity(profile.value, props.capacity)
+  const affordVcpu = maxAffordableVcpu(profile.value, props.rateCard, props.available, diskGb.value)
+  const affordDisk = maxAffordableDisk(profile.value, props.rateCard, props.available, vcpus.value)
+  return capVcpu <= affordVcpu || capDisk <= affordDisk
+})
 
 // Dropdown ladders (the precise-pick companion to the sliders). Rungs past the
 // headroom hard stop are disabled. RAM is keyed by its vCPU rung, so picking a RAM
@@ -210,6 +240,9 @@ function indexOf(ladder: number[], value: number): number {
 
       <p v-if="overHeadroom" class="text-p-xs text-ink-red-5">
         This config is over your remaining spending limit.
+      </p>
+      <p v-else-if="cappedByCapacity" class="text-p-xs text-ink-gray-5">
+        Sizes are limited by this region's available capacity right now.
       </p>
     </template>
   </div>

--- a/console/src/components/servers/PlanGroup.vue
+++ b/console/src/components/servers/PlanGroup.vue
@@ -4,7 +4,7 @@ import ConfigDesigner from '@/components/servers/ConfigDesigner.vue'
 import { planSpecs, planPrice } from '@/lib/plans'
 import { money } from '@/lib/format'
 import { configSpecs, estimateConfig } from '@/lib/composed'
-import type { ComposedConfig, Plan, Profile, RateCard } from '@/types/api'
+import type { Capacity, ComposedConfig, Plan, Profile, RateCard } from '@/types/api'
 
 // One optimisation profile's slice of the plan picker: its preset rows plus a
 // "Custom" row that designs a config within *this* profile (#84). Used flat (a
@@ -16,6 +16,8 @@ const props = defineProps<{
   rateCard: RateCard
   available: number
   currency: string
+  // The region's live capacity — passed through to cap the custom designer's sliders.
+  capacity?: Capacity | null
   // Pre-fill the custom designer with a running config's shape (resize, #82/#84).
   initial?: ComposedConfig | null
 }>()
@@ -110,6 +112,7 @@ const matchingPreset = computed<Plan | null>(() => {
               :profiles="[profile]"
               :rate-card="rateCard"
               :available="available"
+              :capacity="capacity"
               :initial="initial"
             />
             <p v-if="matchingPreset" class="mt-3 text-p-xs text-ink-gray-5">

--- a/console/src/components/servers/ResizeServerDialog.vue
+++ b/console/src/components/servers/ResizeServerDialog.vue
@@ -48,10 +48,8 @@ const subscription = computed(() => configCall.data?.subscription ?? null)
 
 // The region's menu, with this server's own spend freed back into the headroom so it
 // can grow into its own budget (exclude_subscription).
-const { groups, classes, plans, rateCard, profiles, available, currency, loading: plansLoading } = usePlans(
-  region,
-  subscription,
-)
+const { groups, classes, plans, rateCard, profiles, available, currency, capacity, loading: plansLoading } =
+  usePlans(region, subscription)
 
 const open = computed({
   get: () => !!props.server,
@@ -227,6 +225,7 @@ async function confirm() {
               :rate-card="rateCard"
               :available="available ?? 0"
               :currency="currency ?? 'USD'"
+              :capacity="capacity"
               :initial="initialFor(designableProfile(tab.label))"
               v-model:selected-plan="selectedPlan"
               v-model:composed-config="composedConfig"
@@ -240,6 +239,7 @@ async function confirm() {
           :rate-card="rateCard"
           :available="available ?? 0"
           :currency="currency ?? 'USD'"
+          :capacity="capacity"
           :initial="initialFor(flatProfile)"
           v-model:selected-plan="selectedPlan"
           v-model:composed-config="composedConfig"

--- a/console/src/composables/usePlans.ts
+++ b/console/src/composables/usePlans.ts
@@ -2,7 +2,10 @@ import { computed, watch, type Ref } from 'vue'
 import { useCall } from 'frappe-ui'
 import { API, method } from '@/api/methods'
 import { useSession } from '@/composables/useSession'
-import type { Plan, Profile, ProvisionablePlans, RateCard } from '@/types/api'
+import type { Capacity, Plan, Profile, ProvisionablePlans, RateCard } from '@/types/api'
+
+// Ungated fallback while the menu is loading (or on a resize, which isn't capacity-gated).
+const UNGATED: Capacity = { gated: false, available: true, unmeasured: false, largest_vm: null }
 
 // Plans a team can provision in the selected region, from the billing catalog
 // (central.billing.api.dashboard.catalog.get_eligible_plans). The menu is
@@ -53,6 +56,9 @@ export function usePlans(cluster: Ref<string | null>, excludeSubscription?: Ref<
     // "Design your own" inputs: the per-resource rate card + the profile bounds.
     rateCard: computed<RateCard>(() => call.data?.rate_card ?? {}),
     profiles: computed<Profile[]>(() => call.data?.profiles ?? []),
+    // Live provisioning capacity for this region: caps the custom slider and explains an
+    // empty menu when the region is full (`available` false).
+    capacity: computed<Capacity>(() => call.data?.capacity ?? UNGATED),
     loading: computed(() => call.loading),
   }
 }

--- a/console/src/lib/composed.ts
+++ b/console/src/lib/composed.ts
@@ -71,11 +71,13 @@ function largestWithin(ladder: number[], ceiling: number): number {
   return best
 }
 
-/** Whether live capacity actually bounds the slider: gated, measured, and with a known
- *  shape. Ungated / unmeasured (sentinel numbers) → no practical limit here; the
- *  create-time gate on Atlas still decides. */
+/** Whether live capacity bounds the slider at all: gated, with a known shape. We clamp by
+ *  the raw `largest_vm` numbers — the same thing the backend preset filter (`_plan_fits`)
+ *  does — so the slider and the preset list agree. An axis the agent hasn't measured comes
+ *  back as a huge sentinel, which naturally imposes no limit on that axis, while a measured
+ *  axis (e.g. a slug-catalogued CPU) still clamps; hence `unmeasured` is NOT a bail-out. */
 export function capacityLimits(capacity: Capacity | null | undefined): boolean {
-  return !!(capacity?.gated && !capacity.unmeasured && capacity.largest_vm)
+  return !!(capacity?.gated && capacity.largest_vm)
 }
 
 /** The largest vCPU rung the region can physically seat: bounded by both the host's free

--- a/console/src/lib/composed.ts
+++ b/console/src/lib/composed.ts
@@ -3,7 +3,7 @@
 // composition, bounds, and headroom); these helpers just keep the slider on-shape
 // and inside headroom so the customer can't drag into a config they can't afford.
 
-import type { ComposedConfig, Profile, RateCard } from '@/types/api'
+import type { Capacity, ComposedConfig, Profile, RateCard } from '@/types/api'
 
 /** RAM follows vCPU by the profile's ratio — never independently chosen, so an
  *  off-ratio shape can't be expressed. */
@@ -61,6 +61,37 @@ function largestAffordable(ladder: number[], costOf: (rung: number) => number, a
   let best = rungs[0] ?? 0
   for (const rung of rungs) if (costOf(rung) <= available) best = rung
   return best
+}
+
+/** The largest ladder rung that is ≤ `ceiling`; the smallest rung if none are. */
+function largestWithin(ladder: number[], ceiling: number): number {
+  const rungs = [...ladder].sort((a, b) => a - b)
+  let best = rungs[0] ?? 0
+  for (const rung of rungs) if (rung <= ceiling) best = rung
+  return best
+}
+
+/** Whether live capacity actually bounds the slider: gated, measured, and with a known
+ *  shape. Ungated / unmeasured (sentinel numbers) → no practical limit here; the
+ *  create-time gate on Atlas still decides. */
+export function capacityLimits(capacity: Capacity | null | undefined): boolean {
+  return !!(capacity?.gated && !capacity.unmeasured && capacity.largest_vm)
+}
+
+/** The largest vCPU rung the region can physically seat: bounded by both the host's free
+ *  vCPU and its free RAM (RAM = vCPU × ratio, so a memory ceiling caps vCPU too). No
+ *  capacity limit → the top rung. */
+export function maxVcpuForCapacity(profile: Profile, capacity: Capacity | null | undefined): number {
+  if (!capacityLimits(capacity)) return largestWithin(profile.vcpu_steps, Infinity)
+  const lv = capacity!.largest_vm!
+  const byMemory = profile.ram_ratio > 0 ? lv.memory_megabytes / 1024 / profile.ram_ratio : Infinity
+  return largestWithin(profile.vcpu_steps, Math.min(lv.vcpus, byMemory))
+}
+
+/** The largest storage rung the region can physically seat. No capacity limit → the top rung. */
+export function maxDiskForCapacity(profile: Profile, capacity: Capacity | null | undefined): number {
+  const ceiling = capacityLimits(capacity) ? capacity!.largest_vm!.disk_gigabytes : Infinity
+  return largestWithin(profile.disk_steps, ceiling)
 }
 
 export function clamp(value: number, min: number, max: number): number {

--- a/console/src/pages/servers/NewServerPage.vue
+++ b/console/src/pages/servers/NewServerPage.vue
@@ -30,7 +30,7 @@ const name = ref('')
 const selectedPlan = ref<string | null>(null)
 const composedConfig = ref<ComposedConfig | null>(null)
 
-const { plans, groups, classes, rateCard, profiles, available, currency, loading: plansLoading } =
+const { plans, groups, classes, rateCard, profiles, available, currency, capacity, loading: plansLoading } =
   usePlans(selectedRegion)
 
 const canDesign = computed(() => rateCardComplete(rateCard.value) && profiles.value.length > 0)
@@ -97,6 +97,13 @@ const bracketExhausted = computed(
     cheapestDesignCost.value > availableHeadroom.value,
 )
 
+// The region itself is full: capacity gating is on and Atlas can't seat any new VM
+// right now. A capacity dead-end, not a budget one — show a distinct message (and it
+// takes priority, since there's nothing to provision here at any size).
+const regionFull = computed(
+  () => !!selectedRegion.value && !plansLoading.value && capacity.value.gated && !capacity.value.available,
+)
+
 // Switching region re-prices the menu: reset the tab and drop a selection the new
 // region no longer offers (a preset that's gone, or a custom profile it lacks).
 watch(classes, () => {
@@ -115,6 +122,7 @@ watch([plans, canDesign], () => {
 const submitting = computed(() => creating.value || creatingComposed.value)
 const canSubmit = computed(() => {
   if (!canCreateServer.value || !selectedRegion.value || !name.value.trim()) return false
+  if (regionFull.value) return false // the region can't seat a new server right now
   if (bracketExhausted.value) return false // nothing here fits the budget
   return isCustom.value ? !!composedConfig.value : !!selectedPlanObj.value
 })
@@ -213,6 +221,17 @@ async function submit() {
         <p v-else-if="plansLoading" class="text-p-sm text-ink-gray-5">Loading plans…</p>
 
         <div
+          v-else-if="regionFull"
+          class="rounded-lg border border-outline-amber-1 bg-surface-amber-1 px-4 py-3"
+        >
+          <p class="text-p-sm font-medium text-ink-gray-8">This region is at capacity</p>
+          <p class="mt-1 text-p-sm text-ink-gray-6">
+            {{ selectedRegion }} can't fit a new server right now. Try another region, or check
+            back shortly — capacity frees up as machines are removed.
+          </p>
+        </div>
+
+        <div
           v-else-if="bracketExhausted"
           class="rounded-lg border border-outline-gray-2 bg-surface-gray-1 px-4 py-3"
         >
@@ -236,6 +255,7 @@ async function submit() {
               :rate-card="rateCard"
               :available="available ?? 0"
               :currency="currency ?? 'USD'"
+              :capacity="capacity"
               v-model:selected-plan="selectedPlan"
               v-model:composed-config="composedConfig"
             />
@@ -249,6 +269,7 @@ async function submit() {
           :rate-card="rateCard"
           :available="available ?? 0"
           :currency="currency ?? 'USD'"
+          :capacity="capacity"
           v-model:selected-plan="selectedPlan"
           v-model:composed-config="composedConfig"
         />

--- a/console/src/types/api.ts
+++ b/console/src/types/api.ts
@@ -112,6 +112,28 @@ export interface ProvisionablePlans {
   rate_card: RateCard
   /** Optimisation-profile bounds the slider snaps + clamps to (#81). */
   profiles: Profile[]
+  /** The region's live provisioning capacity — narrows the menu and caps the slider. */
+  capacity: Capacity
+}
+
+/** The largest single VM a region can seat right now (Atlas capacity API). */
+export interface LargestVm {
+  vcpus: number
+  memory_megabytes: number
+  disk_gigabytes: number
+}
+
+/** Live-capacity summary for the create-server menu (get_eligible_plans). */
+export interface Capacity {
+  /** Whether live capacity narrowed this menu (Atlas Instance.validate_capacity). */
+  gated: boolean
+  /** Whether the region can seat any new VM right now — False → show "region is full". */
+  available: boolean
+  /** The winning host has an unreported axis → `largest_vm` is sentinel, size unknown. */
+  unmeasured: boolean
+  /** The biggest placeable shape — the composed slider's hard ceiling. Null when ungated
+   *  or when the region has no room at all. */
+  largest_vm: LargestVm | null
 }
 
 /** The per-resource rate card: `{ Compute: { rate, unit }, … }`. */


### PR DESCRIPTION
Only offer plans a region can actually seat right now, so a customer can't pick a shape that will fail to provision.

get_eligible_plans now asks the region's Atlas for its live capacity and narrows the menu to fitting plans, per a new Atlas Instance.validate_capacity flag (default on; off / unreachable / no Atlas -> full menu, fail-soft, since placement's create-time gate stays authoritative). Two ceilings:

- create: the best host's free headroom (AtlasClient.capacity). A region with no room returns an empty menu; the response carries a capacity block {gated, available, unmeasured, largest_vm} so the console shows a "region is at capacity" message.
- resize: the server's OWN host headroom with its footprint added back (AtlasClient.resize_capacity), so the running size always fits and downsizes are allowed, while growth is capped to what the host can seat.

Console: the "design your own" slider clamps to largest_vm (min with the spend-headroom stop) in both the New Server and Resize flows.

dependency on : https://github.com/adityahase/atlas/pull/21