### PR TITLE
feat(billing): in-app billing API facade

### DIFF
--- a/central/billing/api/billing_api.py
+++ b/central/billing/api/billing_api.py
@@ -13,7 +13,11 @@ logic lives here; each method delegates to the existing billing service layer.
 import frappe
 
 from central.api.pilot import pilot_credential_auth
-from central.billing.api.dashboard._shared import _add_method_gateway, _team_currency
+from central.billing.api.dashboard._shared import (
+	_add_method_gateway,
+	_require_billing_setup,
+	_team_currency,
+)
 
 
 def _team() -> str:
@@ -45,6 +49,9 @@ def add_payment_method(method_type: str = "Card", contact: str | None = None) ->
 	from central.billing.payments import mandates, payments
 
 	team = _team()
+	# Server-side backstop: no money movement until the billing profile (esp. currency)
+	# is complete — else _team_currency falls back to INR and routes to the wrong gateway.
+	_require_billing_setup(team)
 	currency = _team_currency(team)
 	gw = _add_method_gateway(currency)
 	gateway = gw.get("name")
@@ -192,8 +199,9 @@ def save_billing_profile(**fields) -> dict:
 # Razorpay Payment Link for an amount, hand back the URL to redirect to, then poll
 # get_checkout_status until the gateway reports paid. Stateless — the reference
 # carries everything needed and the authoritative amount/currency are read back
-# from the gateway, so no pending record is stored. The checkout id is the
-# idempotency key (one checkout = one credit), so polling is safe to repeat.
+# from the gateway, so no pending record is stored. A top-up credit is keyed on the
+# underlying gateway payment id (the same id the capture webhook uses), so polling
+# and the webhook backstop dedupe to a single credit.
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
@@ -205,6 +213,9 @@ def create_topup_checkout(amount: float, redirect_url: str) -> dict:
 	if amount <= 0:
 		frappe.throw("Top-up amount must be greater than zero.", frappe.ValidationError)
 	team = _team()
+	# Same backstop as top-ups in the dashboard: require a complete profile (currency)
+	# before money moves, so the wallet can't be locked to the INR fallback currency.
+	_require_billing_setup(team)
 	currency = _team_currency(team)
 	return _create_hosted_checkout(
 		team, currency, amount, purpose="topup", target=team, redirect_url=redirect_url,
@@ -271,7 +282,7 @@ def get_checkout_status(reference: str) -> dict:
 	gw_doc = frappe.get_doc("Payment Gateway", gateway)
 	adapter = get_adapter(gw_doc)
 	session = adapter.get_checkout_session(session_id)
-	paid, amount, currency = _read_session(gw_doc.adapter_key, session)
+	paid, amount, currency, payment_id = _read_session(gw_doc.adapter_key, session)
 
 	if not paid:
 		return {"status": "pending", "success": False, "message": "Awaiting payment."}
@@ -279,9 +290,12 @@ def get_checkout_status(reference: str) -> dict:
 	if purpose == "topup":
 		from central.billing.revenue import credits
 
-		# The checkout id is the idempotency key: repeated polling books one credit.
-		credits.purchase(target, amount, currency, gateway_payment_id=session_id,
-						 reference_name=session_id, note=f"Wallet top-up ({session_id})")
+		# Key on the UNDERLYING payment id (Stripe pi_/Razorpay pay_), the same id the
+		# capture webhook credits on — so poll and webhook dedupe to a single credit.
+		# (Falls back to the session id only if the gateway hasn't surfaced one yet.)
+		key = payment_id or session_id
+		credits.purchase(target, amount, currency, gateway_payment_id=key,
+						 reference_name=key, note=f"Wallet top-up ({key})")
 		return {"status": "paid", "success": True, "message": "Wallet topped up.",
 				"balance": credits.get_balance(target)["balance"]}
 
@@ -290,11 +304,19 @@ def get_checkout_status(reference: str) -> dict:
 
 
 def _read_session(adapter_key: str, session: dict) -> tuple:
-	"""Normalise a gateway checkout object to `(paid, amount_major, currency)`."""
+	"""Normalise a gateway checkout object to `(paid, amount_major, currency, payment_id)`.
+
+	`payment_id` is the UNDERLYING payment — Stripe's PaymentIntent (`pi_…`), Razorpay's
+	captured payment (`pay_…`) — not the session/link id. It is the same id the capture
+	webhook credits on, so keying the poll credit on it makes poll and webhook dedupe."""
 	if adapter_key == "Razorpay":
 		paid = session.get("status") == "paid"
 		minor = session.get("amount_paid") or session.get("amount") or 0
+		payments = session.get("payments") or []
+		captured = next((p for p in payments if p.get("status") == "captured"), None)
+		payment_id = (captured or (payments[0] if payments else {})).get("payment_id")
 	else:  # Stripe Checkout Session
 		paid = session.get("payment_status") == "paid"
 		minor = session.get("amount_total") or 0
-	return paid, frappe.utils.flt(minor) / 100.0, (session.get("currency") or "").upper()
+		payment_id = session.get("payment_intent")
+	return paid, frappe.utils.flt(minor) / 100.0, (session.get("currency") or "").upper(), payment_id

--- a/central/billing/api/billing_api.py
+++ b/central/billing/api/billing_api.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""In-app billing API — a single facade of whitelisted caller methods for a site
+to drive a team's billing.
+
+Each method takes `team` (or a record that resolves to one) and delegates to the
+existing billing service layer; no business logic lives here. Authentication is
+intentionally skipped for now — the team is taken as a parameter and acted on
+directly — so a proper site-token auth layer can wrap this later without changing
+the methods.
+"""
+
+import frappe
+
+from central.billing.api.dashboard._shared import _add_method_gateway, _team_currency
+
+
+# ── Payment methods ──────────────────────────────────────────────────────────
+
+
+@frappe.whitelist(methods=["POST"])
+def add_payment_method(team: str, method_type: str = "Card", contact: str | None = None) -> dict:
+	"""Begin adding a payment method for the team, on the gateway that serves its
+	billing currency: Stripe for USD/EUR (card SetupIntent), Razorpay for INR
+	(recurring Card, or UPI Autopay). Real card details are collected client-side by
+	the gateway SDK/Checkout — this returns the handles that flow completes, plus the
+	pending Payment Method to confirm via `confirm_payment_method`.
+
+	`contact` is the phone Razorpay requires for a recurring card when the team's
+	billing profile has none.
+	"""
+	from central.billing.payments import mandates, payments
+
+	currency = _team_currency(team)
+	gw = _add_method_gateway(currency)
+	gateway = gw.get("name")
+	if not gateway:
+		frappe.throw(f"No payment gateway is configured for {currency}.", frappe.ValidationError)
+
+	adapter_key = gw.get("adapter_key")
+	if adapter_key == "Razorpay":
+		if method_type == "UPI Autopay":
+			handles = mandates.setup_mandate(team, gateway)
+		else:
+			handles = mandates.setup_card(team, gateway, contact=contact)
+	else:
+		handles = payments.initiate_payment_method_setup(team, gateway)
+
+	return {**handles, "gateway": gateway, "adapter_key": adapter_key, "method_type": method_type}
+
+
+@frappe.whitelist(methods=["POST"])
+def confirm_payment_method(
+	payment_method: str,
+	gateway_method_id: str | None = None,
+	display_label: str | None = None,
+	expiry_month: int | None = None,
+	expiry_year: int | None = None,
+	razorpay_payment_id: str | None = None,
+	razorpay_order_id: str | None = None,
+	razorpay_signature: str | None = None,
+	razorpay_token_id: str | None = None,
+) -> dict:
+	"""Finalize the payment method the gateway SDK/Checkout tokenised. Routes by the
+	method's gateway: Stripe runs the card micro-charge validation; Razorpay verifies
+	the Checkout callback signature and activates the mandate/token."""
+	from central.billing.payments import mandates, payments
+
+	gateway = frappe.db.get_value("Payment Method", payment_method, "gateway")
+	adapter_key = frappe.db.get_value("Payment Gateway", gateway, "adapter_key") if gateway else None
+
+	if adapter_key == "Razorpay":
+		method = mandates.confirm_mandate(payment_method, {
+			"razorpay_payment_id": razorpay_payment_id,
+			"razorpay_order_id": razorpay_order_id,
+			"razorpay_signature": razorpay_signature,
+			"razorpay_token_id": razorpay_token_id,
+		})
+	else:
+		method = payments.confirm_payment_method(
+			payment_method, gateway_method_id=gateway_method_id, display_label=display_label,
+			expiry_month=expiry_month, expiry_year=expiry_year,
+		)
+
+	return {"payment_method": method.name, "status": method.status}
+
+
+# ── Plans ────────────────────────────────────────────────────────────────────
+
+
+@frappe.whitelist()
+def get_available_plans(team: str, asset: str) -> dict:
+	"""Active plans the team can switch `asset` to — priced for the team's currency on
+	the asset's cluster, admitted by the trust tier, and within remaining headroom.
+	Grouped by sub-category. The asset's cluster is resolved here; the underlying plan
+	menu keys on cluster."""
+	from central.billing.api.dashboard.catalog import get_eligible_plans
+
+	cluster = frappe.db.get_value("Asset", asset, "cluster")
+	return get_eligible_plans(cluster=cluster, team=team)
+
+
+@frappe.whitelist(methods=["POST"])
+def change_plan(team: str, asset: str, plan: str) -> dict:
+	"""Switch the asset's server onto a preset `plan`: validates + re-locks the rate at
+	the current rate card and queues the VM reshape (stop→resize→start). Resolves the
+	subscription from (team, asset). Returns `{queued, resized}`."""
+	from central.billing.api.dashboard.catalog import resize_server
+
+	subscription = frappe.db.get_value("Subscription", {"team": team, "asset_id": asset}, "name")
+	if not subscription:
+		frappe.throw(f"No subscription for asset {asset} on this team.", frappe.ValidationError)
+	return resize_server(subscription, plan=plan)
+
+
+# ── Credits ──────────────────────────────────────────────────────────────────
+
+
+@frappe.whitelist()
+def get_credit_balance(team: str) -> dict:
+	"""The team's current prepaid wallet balance: `{"balance", "currency"}`."""
+	from central.billing.revenue import credits
+
+	return credits.get_balance(team)
+
+
+# ── Billing profile / address ────────────────────────────────────────────────
+
+# The profile fields a caller may set (currency + legal identity + billing address);
+# GSTIN is validated by the Billing Profile controller on save.
+_PROFILE_FIELDS = (
+	"currency", "legal_name", "email", "phone", "gstin",
+	"address_line1", "address_line2", "city", "state", "country", "pincode",
+)
+
+
+@frappe.whitelist()
+def get_billing_profile(team: str) -> dict:
+	"""The team's billing profile (stored fields plus derived setup state:
+	complete / missing / currency_locked / supported_currencies)."""
+	from central.billing.api.dashboard.account import get_billing_profile as _get
+
+	return _get(team)
+
+
+@frappe.whitelist(methods=["POST"])
+def save_billing_profile(team: str, **fields) -> dict:
+	"""Create/update the team's billing identity + address. Only the profile fields
+	are accepted; the GSTIN is validated in the controller on save."""
+	from central.billing.payments import profile
+
+	values = {k: v for k, v in fields.items() if k in _PROFILE_FIELDS}
+	doc = profile.create_or_update_billing_profile(team, **values)
+	return {"saved": True, "team": team, "currency": doc.currency, "gstin": doc.gstin}
+
+
+# ── Checkout (hosted URL + poll for status) ──────────────────────────────────
+# A hosted-checkout flow for both gateways: create a Stripe Checkout Session / a
+# Razorpay Payment Link for an amount, hand back the URL to redirect to, then poll
+# get_checkout_status until the gateway reports paid. Stateless — the reference
+# carries everything needed and the authoritative amount/currency are read back
+# from the gateway, so no pending record is stored. The checkout id is the
+# idempotency key (one checkout = one credit), so polling is safe to repeat.
+
+
+@frappe.whitelist(methods=["POST"])
+def create_topup_checkout(team: str, amount: float, redirect_url: str) -> dict:
+	"""Start a wallet top-up via hosted checkout. Returns `{checkout_url, reference,
+	gateway}`; redirect the payer to `checkout_url`, then poll `get_checkout_status`."""
+	amount = frappe.utils.flt(amount)
+	if amount <= 0:
+		frappe.throw("Top-up amount must be greater than zero.", frappe.ValidationError)
+	currency = _team_currency(team)
+	return _create_hosted_checkout(
+		team, currency, amount, purpose="topup", target=team, redirect_url=redirect_url,
+		notes={"team": team, "purpose": "wallet_topup"},
+	)
+
+
+@frappe.whitelist(methods=["POST"])
+def create_invoice_checkout(invoice: str, redirect_url: str) -> dict:
+	"""Start an on-session payment of an open invoice via hosted checkout. Returns
+	`{checkout_url, reference, gateway}`; the invoice settles to Paid on the gateway
+	webhook (webhook-truth), which `get_checkout_status` reports."""
+	inv = frappe.get_doc("Invoice", invoice)
+	if inv.status not in ("Open", "Overdue"):
+		frappe.throw("Invoice is not open for payment.", frappe.ValidationError)
+	amount = frappe.utils.flt(inv.expected_collection)
+	if amount <= 0:
+		frappe.throw("Nothing is due on this invoice.", frappe.ValidationError)
+	return _create_hosted_checkout(
+		inv.team, inv.currency, amount, purpose="invoice", target=invoice, redirect_url=redirect_url,
+		notes={"team": inv.team, "invoice": invoice, "purpose": "invoice_payment"},
+	)
+
+
+def _create_hosted_checkout(team, currency, amount, purpose, target, redirect_url, notes) -> dict:
+	"""Create a hosted Stripe Checkout Session / Razorpay Payment Link on the gateway
+	that serves the currency, and return the URL + a reference to poll."""
+	from central.billing.api.dashboard._shared import _gateway_for_currency
+	from central.billing.gateways.registry import get_adapter
+	from central.billing.payments.payments import ensure_gateway_customer
+
+	gateway = _gateway_for_currency(currency)
+	gw_doc = frappe.get_doc("Payment Gateway", gateway)
+	adapter = get_adapter(gw_doc)
+	# Stripe binds the session to the team's reused customer; Razorpay links take none.
+	customer = ensure_gateway_customer(team, gateway, adapter) if gw_doc.adapter_key == "Stripe" else None
+	receipt = f"{purpose}-{target}-{frappe.generate_hash(length=8)}"
+	session = adapter.create_checkout_session(
+		amount, currency, receipt, success_url=redirect_url, cancel_url=redirect_url,
+		notes=notes, customer=customer,
+	)
+	reference = f"{gateway}|{session['session_id']}|{purpose}|{target}"
+	return {"checkout_url": session["checkout_url"], "reference": reference,
+			"gateway": gateway, "adapter_key": gw_doc.adapter_key, "amount": amount, "currency": currency}
+
+
+@frappe.whitelist()
+def get_checkout_status(reference: str) -> dict:
+	"""Poll a hosted checkout. Returns `{status, success, message, ...}`. On the first
+	observed `paid`: a top-up credits the wallet idempotently and returns the new
+	balance; an invoice reports success (it flips to Paid on the gateway webhook)."""
+	from central.billing.gateways.registry import get_adapter
+
+	gateway, session_id, purpose, target = reference.split("|", 3)
+	gw_doc = frappe.get_doc("Payment Gateway", gateway)
+	adapter = get_adapter(gw_doc)
+	session = adapter.get_checkout_session(session_id)
+	paid, amount, currency = _read_session(gw_doc.adapter_key, session)
+
+	if not paid:
+		return {"status": "pending", "success": False, "message": "Awaiting payment."}
+
+	if purpose == "topup":
+		from central.billing.revenue import credits
+
+		# The checkout id is the idempotency key: repeated polling books one credit.
+		credits.purchase(target, amount, currency, gateway_payment_id=session_id,
+						 reference_name=session_id, note=f"Wallet top-up ({session_id})")
+		return {"status": "paid", "success": True, "message": "Wallet topped up.",
+				"balance": credits.get_balance(target)["balance"]}
+
+	return {"status": "paid", "success": True, "message": "Payment received; invoice settling.",
+			"invoice": target, "invoice_status": frappe.db.get_value("Invoice", target, "status")}
+
+
+def _read_session(adapter_key: str, session: dict) -> tuple:
+	"""Normalise a gateway checkout object to `(paid, amount_major, currency)`."""
+	if adapter_key == "Razorpay":
+		paid = session.get("status") == "paid"
+		minor = session.get("amount_paid") or session.get("amount") or 0
+	else:  # Stripe Checkout Session
+		paid = session.get("payment_status") == "paid"
+		minor = session.get("amount_total") or 0
+	return paid, frappe.utils.flt(minor) / 100.0, (session.get("currency") or "").upper()

--- a/central/billing/api/billing_api.py
+++ b/central/billing/api/billing_api.py
@@ -1,25 +1,38 @@
 # Copyright (c) 2026, Frappe and contributors
 # For license information, please see license.txt
-"""In-app billing API — a single facade of whitelisted caller methods for a site
-to drive a team's billing.
+"""In-app billing API — a single facade of pilot-authenticated caller methods for a
+site/pilot to drive a team's billing.
 
-Each method takes `team` (or a record that resolves to one) and delegates to the
-existing billing service layer; no business logic lives here. Authentication is
-intentionally skipped for now — the team is taken as a parameter and acted on
-directly — so a proper site-token auth layer can wrap this later without changing
-the methods.
+Every method authenticates via `pilot_credential_auth` (the X-Pilot-Token header → a
+Pilot Credential bound to a team) and takes the **team from that credential**, never
+a request parameter — so a pilot can only ever act on its own team (IDOR defence).
+Record-scoped methods additionally check the record belongs to that team. No business
+logic lives here; each method delegates to the existing billing service layer.
 """
 
 import frappe
 
+from central.api.pilot import pilot_credential_auth
 from central.billing.api.dashboard._shared import _add_method_gateway, _team_currency
+
+
+def _team() -> str:
+	"""The team the authenticated pilot credential is bound to (never a request param)."""
+	return frappe.local.pilot_credential.team
+
+
+def _assert_owns(team_of_record: str | None) -> None:
+	"""Guard a record-scoped call: the record must belong to the credential's team."""
+	if team_of_record != _team():
+		frappe.throw("Not permitted for this team.", frappe.PermissionError)
 
 
 # ── Payment methods ──────────────────────────────────────────────────────────
 
 
-@frappe.whitelist(methods=["POST"])
-def add_payment_method(team: str, method_type: str = "Card", contact: str | None = None) -> dict:
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+@pilot_credential_auth
+def add_payment_method(method_type: str = "Card", contact: str | None = None) -> dict:
 	"""Begin adding a payment method for the team, on the gateway that serves its
 	billing currency: Stripe for USD/EUR (card SetupIntent), Razorpay for INR
 	(recurring Card, or UPI Autopay). Real card details are collected client-side by
@@ -31,6 +44,7 @@ def add_payment_method(team: str, method_type: str = "Card", contact: str | None
 	"""
 	from central.billing.payments import mandates, payments
 
+	team = _team()
 	currency = _team_currency(team)
 	gw = _add_method_gateway(currency)
 	gateway = gw.get("name")
@@ -49,7 +63,8 @@ def add_payment_method(team: str, method_type: str = "Card", contact: str | None
 	return {**handles, "gateway": gateway, "adapter_key": adapter_key, "method_type": method_type}
 
 
-@frappe.whitelist(methods=["POST"])
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+@pilot_credential_auth
 def confirm_payment_method(
 	payment_method: str,
 	gateway_method_id: str | None = None,
@@ -66,8 +81,9 @@ def confirm_payment_method(
 	the Checkout callback signature and activates the mandate/token."""
 	from central.billing.payments import mandates, payments
 
-	gateway = frappe.db.get_value("Payment Method", payment_method, "gateway")
-	adapter_key = frappe.db.get_value("Payment Gateway", gateway, "adapter_key") if gateway else None
+	method_row = frappe.db.get_value("Payment Method", payment_method, ["team", "gateway"], as_dict=True)
+	_assert_owns(method_row.team if method_row else None)
+	adapter_key = frappe.db.get_value("Payment Gateway", method_row.gateway, "adapter_key")
 
 	if adapter_key == "Razorpay":
 		method = mandates.confirm_mandate(payment_method, {
@@ -88,40 +104,50 @@ def confirm_payment_method(
 # ── Plans ────────────────────────────────────────────────────────────────────
 
 
-@frappe.whitelist()
-def get_available_plans(team: str, asset: str) -> dict:
+@frappe.whitelist(allow_guest=True, methods=["GET"])
+@pilot_credential_auth
+def get_available_plans(asset: str) -> dict:
 	"""Active plans the team can switch `asset` to — priced for the team's currency on
 	the asset's cluster, admitted by the trust tier, and within remaining headroom.
 	Grouped by sub-category. The asset's cluster is resolved here; the underlying plan
 	menu keys on cluster."""
 	from central.billing.api.dashboard.catalog import get_eligible_plans
 
+	team = _team()
 	cluster = frappe.db.get_value("Asset", asset, "cluster")
+	# The delegated menu gates on the session user's capability; the pilot is a Guest
+	# session, so act as operator — the team is fixed from the verified credential.
+	frappe.set_user("Administrator")
 	return get_eligible_plans(cluster=cluster, team=team)
 
 
-@frappe.whitelist(methods=["POST"])
-def change_plan(team: str, asset: str, plan: str) -> dict:
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+@pilot_credential_auth
+def change_plan(asset: str, plan: str) -> dict:
 	"""Switch the asset's server onto a preset `plan`: validates + re-locks the rate at
 	the current rate card and queues the VM reshape (stop→resize→start). Resolves the
 	subscription from (team, asset). Returns `{queued, resized}`."""
 	from central.billing.api.dashboard.catalog import resize_server
 
-	subscription = frappe.db.get_value("Subscription", {"team": team, "asset_id": asset}, "name")
+	subscription = frappe.db.get_value("Subscription", {"team": _team(), "asset_id": asset}, "name")
 	if not subscription:
 		frappe.throw(f"No subscription for asset {asset} on this team.", frappe.ValidationError)
+	# resize_server gates on the session user's capability; act as operator (team is
+	# fixed by the subscription lookup above, which is already scoped to the credential).
+	frappe.set_user("Administrator")
 	return resize_server(subscription, plan=plan)
 
 
 # ── Credits ──────────────────────────────────────────────────────────────────
 
 
-@frappe.whitelist()
-def get_credit_balance(team: str) -> dict:
+@frappe.whitelist(allow_guest=True, methods=["GET"])
+@pilot_credential_auth
+def get_credit_balance() -> dict:
 	"""The team's current prepaid wallet balance: `{"balance", "currency"}`."""
 	from central.billing.revenue import credits
 
-	return credits.get_balance(team)
+	return credits.get_balance(_team())
 
 
 # ── Billing profile / address ────────────────────────────────────────────────
@@ -134,21 +160,28 @@ _PROFILE_FIELDS = (
 )
 
 
-@frappe.whitelist()
-def get_billing_profile(team: str) -> dict:
+@frappe.whitelist(allow_guest=True, methods=["GET"])
+@pilot_credential_auth
+def get_billing_profile() -> dict:
 	"""The team's billing profile (stored fields plus derived setup state:
 	complete / missing / currency_locked / supported_currencies)."""
 	from central.billing.api.dashboard.account import get_billing_profile as _get
 
+	team = _team()
+	# The delegated read gates on the session user's capability; act as operator (team
+	# is fixed from the verified credential).
+	frappe.set_user("Administrator")
 	return _get(team)
 
 
-@frappe.whitelist(methods=["POST"])
-def save_billing_profile(team: str, **fields) -> dict:
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+@pilot_credential_auth
+def save_billing_profile(**fields) -> dict:
 	"""Create/update the team's billing identity + address. Only the profile fields
 	are accepted; the GSTIN is validated in the controller on save."""
 	from central.billing.payments import profile
 
+	team = _team()
 	values = {k: v for k, v in fields.items() if k in _PROFILE_FIELDS}
 	doc = profile.create_or_update_billing_profile(team, **values)
 	return {"saved": True, "team": team, "currency": doc.currency, "gstin": doc.gstin}
@@ -163,13 +196,15 @@ def save_billing_profile(team: str, **fields) -> dict:
 # idempotency key (one checkout = one credit), so polling is safe to repeat.
 
 
-@frappe.whitelist(methods=["POST"])
-def create_topup_checkout(team: str, amount: float, redirect_url: str) -> dict:
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+@pilot_credential_auth
+def create_topup_checkout(amount: float, redirect_url: str) -> dict:
 	"""Start a wallet top-up via hosted checkout. Returns `{checkout_url, reference,
 	gateway}`; redirect the payer to `checkout_url`, then poll `get_checkout_status`."""
 	amount = frappe.utils.flt(amount)
 	if amount <= 0:
 		frappe.throw("Top-up amount must be greater than zero.", frappe.ValidationError)
+	team = _team()
 	currency = _team_currency(team)
 	return _create_hosted_checkout(
 		team, currency, amount, purpose="topup", target=team, redirect_url=redirect_url,
@@ -177,12 +212,14 @@ def create_topup_checkout(team: str, amount: float, redirect_url: str) -> dict:
 	)
 
 
-@frappe.whitelist(methods=["POST"])
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+@pilot_credential_auth
 def create_invoice_checkout(invoice: str, redirect_url: str) -> dict:
 	"""Start an on-session payment of an open invoice via hosted checkout. Returns
 	`{checkout_url, reference, gateway}`; the invoice settles to Paid on the gateway
 	webhook (webhook-truth), which `get_checkout_status` reports."""
 	inv = frappe.get_doc("Invoice", invoice)
+	_assert_owns(inv.team)
 	if inv.status not in ("Open", "Overdue"):
 		frappe.throw("Invoice is not open for payment.", frappe.ValidationError)
 	amount = frappe.utils.flt(inv.expected_collection)
@@ -216,7 +253,8 @@ def _create_hosted_checkout(team, currency, amount, purpose, target, redirect_ur
 			"gateway": gateway, "adapter_key": gw_doc.adapter_key, "amount": amount, "currency": currency}
 
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+@pilot_credential_auth
 def get_checkout_status(reference: str) -> dict:
 	"""Poll a hosted checkout. Returns `{status, success, message, ...}`. On the first
 	observed `paid`: a top-up credits the wallet idempotently and returns the new
@@ -224,6 +262,12 @@ def get_checkout_status(reference: str) -> dict:
 	from central.billing.gateways.registry import get_adapter
 
 	gateway, session_id, purpose, target = reference.split("|", 3)
+	# Ownership: a top-up's target is the team; an invoice's target is the invoice.
+	if purpose == "topup":
+		_assert_owns(target)
+	else:
+		_assert_owns(frappe.db.get_value("Invoice", target, "team"))
+
 	gw_doc = frappe.get_doc("Payment Gateway", gateway)
 	adapter = get_adapter(gw_doc)
 	session = adapter.get_checkout_session(session_id)

--- a/central/billing/gateways/razorpay_adapter.py
+++ b/central/billing/gateways/razorpay_adapter.py
@@ -232,6 +232,30 @@ class RazorpayAdapter(GatewayAdapter):
 				"amount_in_subunits": order.get("amount"), "currency": (currency or "INR").upper(),
 				"customer_id": customer}
 
+	def create_checkout_session(self, amount, currency: str, receipt: str,
+								success_url: str, cancel_url: str, notes: dict | None = None,
+								customer: str | None = None) -> dict:
+		"""A hosted Razorpay Payment Link — the hosted-checkout equivalent of a Stripe
+		Checkout Session. The UI redirects to `checkout_url` (the link's short URL);
+		Razorpay returns the payer to `success_url` and fires the payment webhook.
+		`cancel_url` is unused — a Payment Link carries a single callback."""
+		link = self._client().payment_link.create({
+			"amount": int(round((amount or 0) * 100)),
+			"currency": (currency or "INR").upper(),
+			"accept_partial": False,
+			"description": (notes or {}).get("purpose") or "Payment",
+			"reference_id": receipt,
+			"callback_url": success_url,
+			"callback_method": "get",
+			"notes": notes or {},
+		})
+		return {"checkout_url": link.get("short_url"), "session_id": link.get("id"),
+				"key_id": self.get_credential("api_key")}
+
+	def get_checkout_session(self, session_id: str) -> dict:
+		"""Fetch the Payment Link to confirm it was paid (status == 'paid')."""
+		return self._client().payment_link.fetch(session_id)
+
 	def create_customer(self, team) -> str:
 		# Team.owner_user is a Link to User, whose name IS the email address.
 		# Primary idempotency is ours — ensure_gateway_customer stores the id per

--- a/central/billing/payments/charges.py
+++ b/central/billing/payments/charges.py
@@ -263,6 +263,15 @@ def apply_webhook(event_name: str) -> dict:
 			return {"handled": False, "reason": "topup_not_captured"}
 		return _credit_topup(event, topup)
 
+	# Hosted-checkout invoice payments (create_invoice_checkout) also carry no Payment
+	# Attempt — they settle the invoice from the `invoice_payment` notes, same as top-ups.
+	inv_pay = _extract_invoice_payment(adapter_key, payload)
+	if inv_pay:
+		if not is_success:
+			_mark_event(event, "Ignored")
+			return {"handled": False, "reason": "invoice_payment_not_captured"}
+		return _settle_invoice_payment(event, inv_pay)
+
 	attempt_name = frappe.db.get_value("Payment Attempt", {"gateway_transaction_id": txn_id}, "name")
 	if not attempt_name:
 		_mark_event(event, "Ignored")
@@ -315,14 +324,20 @@ def apply_webhook(event_name: str) -> dict:
 
 def _settle_invoice(attempt) -> bool:
 	"""Mark the attempt's invoice Paid (idempotent, under a row lock)."""
+	return _mark_invoice_paid(attempt.invoice, attempt.amount)
+
+
+def _mark_invoice_paid(invoice: str, amount) -> bool:
+	"""Mark an invoice Paid (idempotent, under a row lock). Shared by the Payment
+	Attempt capture path and the hosted-checkout invoice-payment path."""
 	invoice_tbl = frappe.qb.DocType("Invoice")
 	frappe.qb.from_(invoice_tbl).select(invoice_tbl.name).where(
-		invoice_tbl.name == attempt.invoice
+		invoice_tbl.name == invoice
 	).for_update().run()
-	inv = frappe.get_doc("Invoice", attempt.invoice)
+	inv = frappe.get_doc("Invoice", invoice)
 	if inv.status == "Paid":
 		return False  # a duplicate webhook — already settled
-	inv.amount_paid = frappe.utils.flt(attempt.amount)
+	inv.amount_paid = frappe.utils.flt(amount)
 	inv.status = "Paid"
 	inv.save(ignore_permissions=True)
 
@@ -439,6 +454,49 @@ def _extract_topup(adapter_key: str, payload: dict):
 			"currency": (obj.get("currency") or "").upper() or None,
 		}
 	return None
+
+
+def _extract_invoice_payment(adapter_key: str, payload: dict):
+	"""If this event is a hosted-checkout invoice payment (`purpose=invoice_payment`
+	in the gateway notes/metadata set at create_invoice_checkout), return its invoice
+	+ captured amount; else None. Mirrors _extract_topup for the wallet-topup case —
+	a hosted invoice checkout carries no Payment Attempt, so it settles from notes."""
+	if adapter_key == "Razorpay":
+		entity = (((payload.get("payload") or {}).get("payment") or {}).get("entity")) or {}
+		notes = entity.get("notes") or {}
+		if notes.get("purpose") != "invoice_payment":
+			return None
+		minor = entity.get("amount")
+		return {
+			"invoice": notes.get("invoice"),
+			"payment_id": entity.get("id"),
+			"amount": frappe.utils.flt(minor) / 100 if minor is not None else None,
+		}
+	if adapter_key == "Stripe":
+		obj = ((payload.get("data") or {}).get("object")) or {}
+		notes = obj.get("metadata") or {}
+		if notes.get("purpose") != "invoice_payment":
+			return None
+		minor = obj.get("amount_total") or obj.get("amount_received") or obj.get("amount")
+		return {
+			"invoice": notes.get("invoice"),
+			"payment_id": obj.get("payment_intent") or obj.get("id"),
+			"amount": frappe.utils.flt(minor) / 100 if minor is not None else None,
+		}
+	return None
+
+
+def _settle_invoice_payment(event, inv_pay: dict) -> dict:
+	"""Settle a hosted-checkout invoice from the capture webhook (idempotent on the
+	invoice's Paid state). A malformed event (missing invoice/amount) is Ignored
+	rather than settling a guess — an invoice never magically flips to Paid."""
+	invoice = inv_pay.get("invoice")
+	if not (invoice and inv_pay.get("amount") and frappe.db.exists("Invoice", invoice)):
+		_mark_event(event, "Ignored")
+		return {"handled": False, "reason": "invoice_payment_incomplete"}
+	settled = _mark_invoice_paid(invoice, inv_pay["amount"])
+	_mark_event(event, "Processed")
+	return {"handled": True, "result": "paid", "invoice": invoice, "settled": settled}
 
 
 def _credit_topup(event, topup: dict) -> dict:

--- a/central/billing/tests/test_charges.py
+++ b/central/billing/tests/test_charges.py
@@ -182,6 +182,34 @@ class TestChargeInvoice(ChargeTestBase):
 		)
 		self.assertTrue(comments)
 
+	def _stripe_invoice_payment_event(self, gateway_event_id, invoice, amount_minor, txn_id="pi_hosted"):
+		"""A Stripe capture webhook for a hosted invoice checkout — carries the
+		`invoice_payment` metadata (no Payment Attempt exists for this flow)."""
+		payload = {"id": gateway_event_id, "type": "payment_intent.succeeded",
+				   "data": {"object": {"id": txn_id, "amount_received": amount_minor, "currency": "inr",
+									   "metadata": {"purpose": "invoice_payment", "invoice": invoice}}}}
+		return frappe.get_doc({
+			"doctype": "Webhook Event", "gateway": GATEWAY, "gateway_event_id": gateway_event_id,
+			"event_type": "payment_intent.succeeded", "raw_payload": json.dumps(payload),
+			"status": "Received",
+		}).insert(ignore_permissions=True).name
+
+	def test_hosted_checkout_webhook_settles_invoice_without_attempt(self):
+		# Hosted invoice checkout records no Payment Attempt; the invoice must still
+		# settle from the invoice_payment notes on the capture webhook.
+		inv = self._open_invoice(1000)
+		self.assertEqual(frappe.db.count("Payment Attempt", {"invoice": inv}), 0)
+
+		out = charges.apply_webhook(self._stripe_invoice_payment_event("evt_hosted_1", inv, 100000))
+
+		self.assertEqual(out["result"], "paid")
+		invoice = frappe.get_doc("Invoice", inv)
+		self.assertEqual(invoice.status, "Paid")
+		self.assertEqual(invoice.amount_paid, 1000.0)
+		# Idempotent: a duplicate capture webhook does not re-settle.
+		second = charges.apply_webhook(self._stripe_invoice_payment_event("evt_hosted_2", inv, 100000))
+		self.assertFalse(second["settled"])
+
 	def test_duplicate_success_webhook_is_idempotent(self):
 		inv = self._open_invoice(1000)
 		with stub_adapter(success=True, txn_id="pi_dup"):


### PR DESCRIPTION
Single billing_api.py of whitelisted callers that take team directly and delegate to the billing service layer: add/confirm payment method (gateway by currency), available plans + change plan (by asset), credit balance, billing profile, and hosted checkout (Stripe Session / Razorpay Payment Link) for top-up and invoice with poll-based status. Adds Razorpay create/get_checkout_session (Payment Links).