### PR TITLE
fix(console): use local Skeleton component instead of missing frappe-ui export

### DIFF
--- a/console/src/components/common/Skeleton.vue
+++ b/console/src/components/common/Skeleton.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+// Lightweight loading placeholder. frappe-ui does not ship a Skeleton
+// component in the pinned version, so we provide our own. Size and radius
+// are controlled by the caller via passed-through utility classes.
+</script>
+
+<template>
+  <div class="animate-pulse rounded bg-surface-gray-3" aria-hidden="true" />
+</template>

--- a/console/src/components/common/list-view/ListView.vue
+++ b/console/src/components/common/list-view/ListView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts" generic="TData extends object">
 import { computed, h, ref } from 'vue'
-import { Button, Checkbox, Combobox, TextInput, Skeleton } from 'frappe-ui'
+import { Button, Checkbox, Combobox, TextInput } from 'frappe-ui'
+import Skeleton from '../Skeleton.vue'
 import {
   FlexRender,
   getCoreRowModel,

--- a/console/src/components/common/list-view/ListViewPagination.vue
+++ b/console/src/components/common/list-view/ListViewPagination.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { Button, TabButtons, Skeleton } from 'frappe-ui'
+import { Button, TabButtons } from 'frappe-ui'
+import Skeleton from '../Skeleton.vue'
 
 const pageSizeOptions = [10, 20, 50] as const
 

--- a/console/src/components/team/ReceivedInvitationsPanel.vue
+++ b/console/src/components/team/ReceivedInvitationsPanel.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
-import { Avatar, Button, Skeleton } from 'frappe-ui'
+import { Avatar, Button } from 'frappe-ui'
+import Skeleton from '../common/Skeleton.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
 import ListViewState from '@/components/common/list-view/ListViewState.vue'
 import { useMyInvitations } from '@/composables/useMyInvitations'

--- a/console/src/components/team/RolesPanel.vue
+++ b/console/src/components/team/RolesPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { Button, Skeleton } from 'frappe-ui'
+import { Button } from 'frappe-ui'
+import Skeleton from '../common/Skeleton.vue'
 import RoleMatrix from '@/components/team/RoleMatrix.vue'
 import RoleBuilderDialog from '@/components/team/RoleBuilderDialog.vue'
 import { useCapabilities } from '@/composables/useCapabilities'


### PR DESCRIPTION
frappe-ui@1.0.0-beta.11 does not export a Skeleton component, so the loading-state imports added for the list view and team panels broke the production build. Add a small local Skeleton (animate-pulse placeholder using semantic tokens) and point the four importers at it.

```
node_modules/reka-ui/node_modules/@vueuse/core/dist/index.js (3362:0): A comment

"/* #__PURE__ */"

in "node_modules/reka-ui/node_modules/@vueuse/core/dist/index.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
node_modules/reka-ui/node_modules/@vueuse/core/dist/index.js (5780:22): A comment

"/* #__PURE__ */"

in "node_modules/reka-ui/node_modules/@vueuse/core/dist/index.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
✓ 2253 modules transformed.
x Build failed in 10.33s
error during build:
src/components/common/list-view/ListViewPagination.vue?vue&type=script&setup=true&lang.ts (20:29): "Skeleton" is not exported by "node_modules/frappe-ui/src/index.ts", imported by "src/components/common/list-view/ListViewPagination.vue?vue&type=script&setup=true&lang.ts".
file: /Users/frappe/workspace-2/cenral-bench/apps/central/console/src/components/common/list-view/ListViewPagination.vue?vue&type=script&setup=true&lang.ts:20:29

18: const _hoisted_6 = { class: "flex items-center" }
19:
20: import { Button, TabButtons, Skeleton } from 'frappe-ui'
                                 ^

    at getRollupError (file:///Users/frappe/workspace-2/cenral-bench/apps/central/console/node_modules/rollup/dist/es/shared/parseAst.js:317:41)
    at error (file:///Users/frappe/workspace-2/cenral-bench/apps/central/console/node_modules/rollup/dist/es/shared/parseAst.js:313:42)
    at Module.error (file:///Users/frappe/workspace-2/cenral-bench/apps/central/console/node_modules/rollup/dist/es/shared/node-entry.js:17391:16)
    at Module.traceVariable (file:///Users/frappe/workspace-2/cenral-bench/apps/central/console/node_modules/rollup/dist/es/shared/node-entry.js:17824:29)
    at ModuleScope.findVariable (file:///Users/frappe/workspace-2/cenral-bench/apps/central/console/node_modules/rollup/dist/es/shared/node-entry.js:15414:39)
    at ChildScope.findVariable (file:///Users/frappe/workspace-2/cenral-bench/apps/central/console/node_modules/rollup/dist/es/shared/node-entry.js:5682:38)
    at FunctionScope.findVariable (file:///Users/frappe/workspace-2/cenral-bench/apps/central/console/node_modules/rollup/dist/es/shared/node-entry.js:5682:38)
    at FunctionBodyScope.findVariable (file:///Users/frappe/workspace-2/cenral-bench/apps/central/console/node_modules/rollup/dist/es/shared/node-entry.js:5682:38)
    at ReturnValueScope.findVariable (file:///Users/frappe/workspace-2/cenral-bench/apps/central/console/node_modules/rollup/dist/es/shared/node-entry.js:5682:38)
    at FunctionBodyScope.findVariable (file:///Users/frappe/workspace-2/cenral-bench/apps/central/console/node_modules/rollup/dist/es/shared/node-entry.js:5682:38)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Command failed: yarn build
    at genericNodeError (node:internal/errors:985:15)
    at wrappedFn (node:internal/errors:539:14)
    at checkExecSyncError (node:child_process:925:11)
    at execSync (node:child_process:997:15)
    at run_build_command_for_apps (/Users/frappe/workspace-2/cenral-bench/apps/frappe/esbuild/esbuild.js:568:3)
    at execute (/Users/frappe/workspace-2/cenral-bench/apps/frappe/esbuild/esbuild.js:142:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 34518,
  stdout: null,
  stderr: null
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Traceback (most recent call last):
  File "/Users/frappe/workspace-2/cenral-bench/apps/frappe/frappe/utils/bench_helper.py", line 48, in invoke
    return super().invoke(ctx)
           ~~~~~~~~~~~~~~^^^^^
  File "/Users/frappe/workspace-2/cenral-bench/env/lib/python3.14/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/frappe/workspace-2/cenral-bench/env/lib/python3.14/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/frappe/workspace-2/cenral-bench/env/lib/python3.14/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/Users/frappe/workspace-2/cenral-bench/apps/frappe/frappe/commands/utils.py", line 90, in build
    bundle(
    ~~~~~~^
    	mode,
     ^^^^^
    ...<6 lines>...
    	esbuild_target=esbuild_target,
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/frappe/workspace-2/cenral-bench/apps/frappe/frappe/build.py", line 262, in bundle
    frappe.commands.popen(command, cwd=frappe_app_path, env=get_node_env(), raise_err=True)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/frappe/workspace-2/cenral-bench/apps/frappe/frappe/commands/__init__.py", line 97, in popen
    raise subprocess.CalledProcessError(return_, command)
subprocess.CalledProcessError: Command 'yarn run production --apps central --run-build-command' returned non-zero exit status 1.

Command 'yarn run production --apps central --run-build-command' returned non-zero exit status 1.
```