### PR TITLE
feat(Billing): fix lost-webhook settlement, hourly resize billing, gateway gating & settling-state UI

### DIFF
--- a/central/billing/api/dashboard/_shared.py
+++ b/central/billing/api/dashboard/_shared.py
@@ -193,6 +193,14 @@ def _add_method_gateway(currency: str):
 	return gw or frappe._dict()
 
 
+def _card_gateway(currency: str) -> str | None:
+	"""The gateway that saves cards for this currency. Saved cards are a Stripe-only
+	rail (ADR 0005) in every currency — INR included, where Razorpay handles only the
+	UPI Autopay e-mandate. Returns an enabled Stripe gateway that handles the
+	currency, or None if there is no card rail for it."""
+	return _enabled_gateway_for_currency(currency, "Stripe")
+
+
 def _from_inr(amount: float, currency: str) -> float:
 	return frappe.utils.flt(frappe.utils.flt(amount) / _FX_TO_INR.get(currency, 1.0), 2)
 

--- a/central/billing/api/dashboard/_shared.py
+++ b/central/billing/api/dashboard/_shared.py
@@ -216,14 +216,21 @@ def _describe_line(team: str, li) -> dict:
 	row = {
 		"resource_type": li.resource_type, "plan": li.plan,
 		"subscription_resource": li.subscription_resource,
-		"days": li.days, "quantity": li.quantity, "rate": li.rate, "amount": li.amount,
-		"unit": li.unit,
+		"days": li.days, "hours": li.hours, "quantity": li.quantity,
+		"rate": li.rate, "amount": li.amount, "unit": li.unit,
 	}
 	if li.resource_type == "bundle":
 		title = frappe.db.get_value("Plan", li.plan, "title") if li.plan else None
 		row["item"] = title or li.plan or "Subscription plan"
 		row["kind"] = "Plan"
-		row["detail"] = f"{li.days} day(s) this period" if li.days else None
+		# Hourly lines come from a churn day (multiple resizes within 24h); daily
+		# lines are a whole-day stable segment.
+		if li.unit == "hour" and li.hours:
+			row["detail"] = f"{frappe.utils.flt(li.hours):g} hour(s) this period"
+		elif li.days:
+			row["detail"] = f"{li.days} day(s) this period"
+		else:
+			row["detail"] = None
 	else:
 		metered_plan = _metered_plan_for(li.resource_type)
 		title = frappe.db.get_value("Plan", metered_plan.name, "title") if metered_plan else None

--- a/central/billing/api/dashboard/invoices.py
+++ b/central/billing/api/dashboard/invoices.py
@@ -216,6 +216,14 @@ def get_invoice(name: str) -> dict:
 	team = frappe.db.get_value("Invoice", name, "team")
 	_require_view(team)
 	doc = frappe.get_doc("Invoice", name)
+	from central.billing.payments.charges import _IN_FLIGHT
+
+	# An attempt already charging (or captured and awaiting the settlement webhook)
+	# means the money is moving — the UI must show a "settling" state, not a Pay
+	# button, so the customer can't fire a second charge (#10).
+	payment_in_progress = bool(
+		frappe.db.exists("Payment Attempt", {"invoice": name, "status": ["in", _IN_FLIGHT]})
+	)
 	return {
 		"name": doc.name, "team": doc.team, "status": doc.status, "invoice_type": doc.invoice_type,
 		"period_start": str(doc.period_start), "period_end": str(doc.period_end),
@@ -224,6 +232,7 @@ def get_invoice(name: str) -> dict:
 		"zero_rating_reason": doc.zero_rating_reason, "total": doc.total,
 		"credit_applied": doc.credit_applied, "expected_collection": doc.expected_collection,
 		"amount_paid": doc.amount_paid, "due_date": str(doc.due_date) if doc.due_date else None,
+		"payment_in_progress": payment_in_progress,
 		"items": [_describe_line(doc.team, li) for li in doc.items],
 		"activity": _invoice_activity(doc),
 	}

--- a/central/billing/api/dashboard/methods.py
+++ b/central/billing/api/dashboard/methods.py
@@ -9,6 +9,8 @@ import frappe
 from central.billing import authz
 from central.billing.api.dashboard._shared import (
 	_add_method_gateway,
+	_card_gateway,
+	_enabled_gateway_for_currency,
 	_require_billing_setup,
 	_require_manage,
 	_resolve_team,
@@ -35,29 +37,37 @@ def list_payment_methods(team: str | None = None) -> list[dict]:
 
 @frappe.whitelist()
 def get_payment_method_options(team: str | None = None) -> dict:
-	"""What the team can set up, resolved from their billing currency: card + UPI
-	on Razorpay (INR), card-only on Stripe (USD/EUR). UPI is gated by the
-	₹1,00,000 recurring limit."""
+	"""What the team can set up, resolved from their billing currency (ADR 0005).
+
+	Saved cards are a Stripe-only rail in every currency, so Card is the primary
+	option wherever an enabled Stripe gateway handles the currency. INR additionally
+	offers a Razorpay UPI Autopay e-mandate (gated by the recurring limit); it rides
+	Razorpay independently of the card gateway. Foreign currencies are card-only."""
 	team = _resolve_team(team)
 	currency = _team_currency(team)
-	gw = _add_method_gateway(currency)
 
-	if gw.get("adapter_key") == "Razorpay":
+	methods: list[str] = []
+	publishable_key = None
+	card_gw = _card_gateway(currency)
+	if card_gw:
+		from central.billing.gateways.registry import get_adapter
+
+		publishable_key = get_adapter(frappe.get_doc("Payment Gateway", card_gw)).get_credential("api_key")
+		methods.append("Card")
+
+	# UPI Autopay is a Razorpay e-mandate (INR), offered only where an enabled
+	# Razorpay gateway handles the currency — independent of the card rail above.
+	upi = {"allow_upi": False, "upi_block_reason": None, "upi_limit": None}
+	if _enabled_gateway_for_currency(currency, "Razorpay"):
 		from central.billing.payments import mandates
 
 		elig = mandates.upi_eligibility(team)
-		return {"gateway": gw.name, "adapter_key": "Razorpay", "currency": currency,
-				"methods": ["Card", "UPI Autopay"], "allow_upi": elig["eligible"],
-				"upi_block_reason": elig["reason"], "upi_limit": elig["limit"]}
+		methods.append("UPI Autopay")
+		upi = {"allow_upi": elig["eligible"], "upi_block_reason": elig["reason"],
+			   "upi_limit": elig["limit"]}
 
-	publishable_key = None
-	if gw.get("adapter_key") == "Stripe":
-		from central.billing.gateways.registry import get_adapter
-
-		publishable_key = get_adapter(frappe.get_doc("Payment Gateway", gw.name)).get_credential("api_key")
-	return {"gateway": gw.get("name"), "adapter_key": gw.get("adapter_key"), "currency": currency,
-			"methods": ["Card"], "allow_upi": False, "upi_block_reason": None, "upi_limit": None,
-			"publishable_key": publishable_key}
+	return {"gateway": card_gw, "adapter_key": "Stripe" if card_gw else None,
+			"currency": currency, "methods": methods, "publishable_key": publishable_key, **upi}
 
 
 @frappe.whitelist(methods=["POST"])
@@ -66,9 +76,9 @@ def initiate_card_setup(team: str | None = None, gateway: str | None = None) -> 
 	collected client-side by the gateway SDK (PCI), never by our server."""
 	team = _resolve_team(team, authz.MANAGE)
 	_require_billing_setup(team)
-	# Default to the team's currency gateway (Stripe for USD/EUR) when the caller
-	# doesn't name one — same resolution the Razorpay setup path uses.
-	gateway = gateway or _add_method_gateway(_team_currency(team)).get("name")
+	# Saved cards are a Stripe-only rail (ADR 0005), so resolve the currency's Stripe
+	# gateway — for INR that's the Stripe gateway, not the Razorpay currency default.
+	gateway = gateway or _card_gateway(_team_currency(team))
 	from central.billing.payments import payments
 
 	return payments.initiate_payment_method_setup(team, gateway)

--- a/central/billing/doctype/invoice_line_item/invoice_line_item.json
+++ b/central/billing/doctype/invoice_line_item/invoice_line_item.json
@@ -2,7 +2,7 @@
  "actions": [],
  "allow_rename": 0,
  "creation": "2026-06-03 00:00:00.000000",
- "description": "Invoice line, generated once and never updated. Day-weighted from an event-log time window x the locked price.",
+ "description": "Invoice line, generated once and never updated. Time-weighted from an event-log window x the locked price: whole days for a stable config, exact hours on a day the machine churned (multiple resizes within 24h).",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
@@ -17,6 +17,7 @@
   "quantity",
   "rate",
   "days",
+  "hours",
   "amount"
  ],
  "fields": [
@@ -70,14 +71,21 @@
    "fieldtype": "Int",
    "in_list_view": 1,
    "label": "Days",
-   "description": "Whole units active in the period (with max-1 floor)"
+   "description": "Whole days active in the period, for a daily-billed (stable) segment"
+  },
+  {
+   "fieldname": "hours",
+   "fieldtype": "Float",
+   "label": "Hours",
+   "precision": "2",
+   "description": "Hours active, for a segment billed hourly on a churn day (multiple resizes within 24h)"
   },
   {
    "fieldname": "amount",
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Amount",
-   "description": "days x (rate / units_in_period)"
+   "description": "days x (rate / days_in_period), or hours x (rate / (days_in_period x 24)) for an hourly line"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/central/billing/payments/reconciliation.py
+++ b/central/billing/payments/reconciliation.py
@@ -16,6 +16,12 @@ Terminal-state model (the resolved HITL decision — see issue #21):
   no gateway record -> failed (safe; never dangling)
   still pending     -> leave; alert ops past the threshold
   provenance: resolved_by = reconciliation (vs webhook)
+
+A second, symmetric hole: the sync charge path lands an attempt at Captured and
+defers settlement to the capture webhook. If that webhook is lost the invoice is
+stranded Open with money already taken, and — being terminal — the attempt is
+invisible to the ambiguous scan. reconcile_captured_attempt re-confirms success
+at the gateway and settles it through the same idempotent path.
 """
 
 import frappe
@@ -23,6 +29,8 @@ import frappe
 _AMBIGUOUS = ("Initiated", "Authorised")
 _GATEWAY_SUCCESS = {"succeeded", "captured", "paid", "completed"}
 _GATEWAY_FAILED = {"failed", "canceled", "cancelled", "declined", "expired", "voided"}
+# A Captured attempt whose invoice sits in one of these lost its settlement webhook.
+_UNSETTLED_INVOICE = ("Open", "Overdue")
 
 GRACE_MINUTES = 30
 ALERT_AFTER_HOURS = 24
@@ -65,8 +73,50 @@ def reconcile_attempt(attempt_name: str, now=None) -> dict:
 	return {"attempt": attempt_name, "unresolved": status}
 
 
+def reconcile_captured_attempt(attempt_name: str, now=None) -> dict:
+	"""Settle a Captured attempt whose invoice was never marked Paid (read-only).
+
+	The sync charge path (charges.pay_invoice) advances an attempt to Captured the
+	moment the gateway reports success, then leaves settlement to the capture
+	webhook. If that webhook is lost the money is taken but the invoice is stranded
+	Open — and the ambiguous-state scan never looks at a terminal (Captured)
+	attempt. This closes that hole: re-confirm success at the gateway, then settle
+	through the same idempotent path the webhook uses.
+	"""
+	attempt = frappe.get_doc("Payment Attempt", attempt_name)
+	if attempt.status != "Captured":
+		return {"attempt": attempt_name, "skipped": "not_captured"}
+
+	inv_status = frappe.db.get_value("Invoice", attempt.invoice, "status")
+	if inv_status not in _UNSETTLED_INVOICE:
+		return {"attempt": attempt_name, "skipped": "invoice_settled"}
+
+	# Captured is local state; reconciliation only ever settles on fresh gateway
+	# truth. Without a confirmed success we don't guess — settle nothing.
+	status = ""
+	if attempt.gateway_transaction_id:
+		status = (_adapter(attempt.gateway).get_transaction_status(attempt.gateway_transaction_id) or "").lower()
+	if status not in _GATEWAY_SUCCESS:
+		now = frappe.utils.get_datetime(now or frappe.utils.now_datetime())
+		started = frappe.utils.get_datetime(attempt.initiated_at or attempt.creation)
+		if frappe.utils.time_diff_in_hours(now, started) >= ALERT_AFTER_HOURS:
+			_alert_ops(attempt, status or "unknown")
+			return {"attempt": attempt_name, "unresolved": status, "alerted": True}
+		return {"attempt": attempt_name, "unresolved": status}
+
+	from central.billing.payments import charges
+
+	settled = charges._settle_invoice(attempt)
+	if not attempt.completed_at or not attempt.resolved_by:
+		attempt.completed_at = attempt.completed_at or frappe.utils.now_datetime()
+		attempt.resolved_by = attempt.resolved_by or "Reconciliation"
+		attempt.save(ignore_permissions=True)
+	return {"attempt": attempt_name, "resolved": "paid", "gateway_status": status, "settled": settled}
+
+
 def run_reconciliation(now=None) -> list:
-	"""Daily scan: reconcile every ambiguous attempt past the grace window."""
+	"""Daily scan: resolve aged ambiguous attempts, then settle any captured-but-
+	open invoice whose capture webhook never landed."""
 	now = frappe.utils.get_datetime(now or frappe.utils.now_datetime())
 	cutoff = frappe.utils.add_to_date(now, minutes=-GRACE_MINUTES)
 	stuck = frappe.get_all(
@@ -74,7 +124,29 @@ def run_reconciliation(now=None) -> list:
 		filters=[["status", "in", list(_AMBIGUOUS)], ["initiated_at", "<=", cutoff]],
 		pluck="name",
 	)
-	return [reconcile_attempt(name, now=now) for name in stuck]
+	results = [reconcile_attempt(name, now=now) for name in stuck]
+
+	unsettled = _captured_unsettled_attempts(cutoff)
+	results += [reconcile_captured_attempt(name, now=now) for name in unsettled]
+	return results
+
+
+def _captured_unsettled_attempts(cutoff) -> list:
+	"""Captured attempts aged past the grace window whose invoice is still Open/
+	Overdue — a settlement webhook that never arrived. One join, no N+1."""
+	PA = frappe.qb.DocType("Payment Attempt")
+	INV = frappe.qb.DocType("Invoice")
+	return (
+		frappe.qb.from_(PA)
+		.join(INV)
+		.on(PA.invoice == INV.name)
+		.select(PA.name)
+		.where(
+			(PA.status == "Captured")
+			& (PA.initiated_at <= cutoff)
+			& (INV.status.isin(_UNSETTLED_INVOICE))
+		)
+	).run(pluck=True)
 
 
 def _resolve_paid(attempt):

--- a/central/billing/revenue/invoicing/lines.py
+++ b/central/billing/revenue/invoicing/lines.py
@@ -1,30 +1,56 @@
 # Copyright (c) 2026, Frappe and contributors
 # For license information, please see license.txt
-"""The day-weighted line-item engine — fixed charges from Subscription Change
+"""The time-weighted line-item engine — fixed charges from Subscription Change
 rate-snapshot segments. Shared by draft generation and the dashboard forecast.
+
+Billing is daily by default: a stable config (one held for 24h or more) bills a
+whole day at a time, so a normal month reads as a handful of clean day lines and
+a full day always costs one day's rate — the "daily cap".
+
+Hourly billing kicks in only when a machine *churns*: two config changes less
+than 24h apart (a resize twice in a day, or a peak-then-drop even across
+midnight). Any calendar date a churn segment touches is billed by the exact hours
+each config ran that date, which closes the sub-day gaming loophole and bills a
+short-lived config fairly. Because a date is billed either daily OR hourly — never
+both — the two passes partition the period and the total stays exact.
 """
 
+from datetime import datetime, time, timedelta
+
 import frappe
+
+CHURN_WINDOW_HOURS = 24
 
 
 def _days_in_period(period_start, period_end) -> int:
 	return (frappe.utils.getdate(period_end) - frappe.utils.getdate(period_start)).days + 1
 
 
-def compute_line_items(team: str, cluster: str, period_start, period_end) -> list[dict]:
-	"""Day-weighted line items for a (team, cluster) over the billing month.
+def _dates_touched(start_dt: datetime, end_dt: datetime) -> list:
+	"""Calendar dates the half-open [start, end) datetime interval overlaps."""
+	out = []
+	d = start_dt.date()
+	while datetime.combine(d, time.min) < end_dt:
+		out.append(d)
+		d += timedelta(days=1)
+	return out
 
-	One line per Subscription-Change run-segment overlapping the period: each
-	`Created`/`Plan Changed` row opens a segment at its `locked_rate` snapshot
-	that runs until the subscription's next change (or the period end, if still
-	open). `Cancelled` rows close the prior segment and carry no rate of their
-	own. A segment that opened and closed within a single day still bills one
-	day (the max(1,...) floor closes the same-day-churn free faucet).
+
+def compute_line_items(team: str, cluster: str, period_start, period_end) -> list[dict]:
+	"""Time-weighted line items for a (team, cluster) over the billing month.
+
+	Each `Created`/`Plan Changed` Subscription-Change row opens a segment at its
+	`locked_rate` snapshot that runs until the subscription's next change (or the
+	period end). `Cancelled` rows close the prior segment and carry no rate. A
+	segment held < 24h marks every date it touches as a churn date; those dates
+	bill hourly, all others bill daily.
 	"""
-	period_start = frappe.utils.getdate(period_start)
-	period_end = frappe.utils.getdate(period_end)
-	period_end_excl = frappe.utils.add_days(period_end, 1)
-	units = _days_in_period(period_start, period_end)
+	ps = frappe.utils.getdate(period_start)
+	pe = frappe.utils.getdate(period_end)
+	period_start_dt = datetime.combine(ps, time.min)
+	period_end_excl_dt = datetime.combine(pe + timedelta(days=1), time.min)
+	day_units = _days_in_period(ps, pe)  # daily denominator
+	hour_units = day_units * 24  # hourly denominator
 
 	subscriptions = frappe.get_all(
 		"Subscription", filters={"team": team}, fields=["name", "asset_id"]
@@ -45,37 +71,77 @@ def compute_line_items(team: str, cluster: str, period_start, period_end) -> lis
 			# were recorded — otherwise a Cancelled could sort ahead of its Created.
 			order_by="effective_at asc, creation asc",
 		)
+
+		# Build the billable segments (clamped to the period), flagging churn from the
+		# real held duration (unclamped) so a resize near the period edge still counts.
+		segs = []
 		for i, change in enumerate(changes):
 			if change.change_type == "Cancelled" or change.locked_rate is None:
 				continue  # terminal marker or no rate snapshot — not a billable segment
-
-			seg_start = frappe.utils.getdate(change.effective_at)
-			seg_end_excl = (
-				frappe.utils.getdate(changes[i + 1].effective_at)
+			seg_start_dt = frappe.utils.get_datetime(change.effective_at)
+			seg_end_dt = (
+				frappe.utils.get_datetime(changes[i + 1].effective_at)
 				if i + 1 < len(changes)
-				else period_end_excl
+				else period_end_excl_dt
 			)
-
-			# Clamp to the billing period.
-			start = max(seg_start, period_start)
-			end_excl = min(seg_end_excl, period_end_excl)
-			if start >= period_end_excl or end_excl <= period_start:
+			held_hours = (seg_end_dt - seg_start_dt).total_seconds() / 3600.0
+			start = max(seg_start_dt, period_start_dt)
+			end = min(seg_end_dt, period_end_excl_dt)
+			if start >= period_end_excl_dt or end <= period_start_dt:
 				continue  # no overlap with this month
+			segs.append({
+				"start": start, "end": end, "rate": frappe.utils.flt(change.locked_rate),
+				"plan": change.new_value, "asset": sub.asset_id, "cluster": cluster,
+				"churn": held_hours < CHURN_WINDOW_HOURS,
+			})
 
-			days = max(1, (end_excl - start).days)
-			rate = frappe.utils.flt(change.locked_rate)
-			amount = frappe.utils.flt(days * rate / units, 2)
-			lines.append(
-				{
-					"subscription_resource": sub.asset_id,
-					"plan": change.new_value,
-					"cluster": cluster,
-					"resource_type": "bundle",
-					"unit": "day",
-					"quantity": 1,
-					"rate": rate,
-					"days": days,
-					"amount": amount,
-				}
-			)
+		# A churn segment (< 24h) turns every date it touches into an hourly date; the
+		# 24h window spans midnight, so a cross-day churn marks both dates.
+		churn_dates = set()
+		for s in segs:
+			if s["churn"]:
+				churn_dates.update(_dates_touched(s["start"], s["end"]))
+
+		for s in segs:
+			# Daily pass — whole non-churn dates the segment owns. A date belongs to
+			# the config active at its start (the change-date boundary), so a single
+			# mid-day resize still sends the whole transition day to one plan.
+			d0 = max(s["start"].date(), ps)
+			d1 = min(s["end"].date(), pe + timedelta(days=1))  # exclusive
+			days = 0
+			d = d0
+			while d < d1:
+				if d not in churn_dates:
+					days += 1
+				d += timedelta(days=1)
+			if days:
+				lines.append(_daily_line(s, days, day_units))
+
+			# Hourly pass — this segment's real hours on each churn date it touches.
+			for cd in _dates_touched(s["start"], s["end"]):
+				if cd not in churn_dates:
+					continue
+				day_start = max(s["start"], datetime.combine(cd, time.min))
+				day_end = min(s["end"], datetime.combine(cd + timedelta(days=1), time.min))
+				hours = (day_end - day_start).total_seconds() / 3600.0
+				if hours > 0:
+					lines.append(_hourly_line(s, hours, hour_units))
 	return lines
+
+
+def _daily_line(seg: dict, days: int, day_units: int) -> dict:
+	return {
+		"subscription_resource": seg["asset"], "plan": seg["plan"], "cluster": seg["cluster"],
+		"resource_type": "bundle", "unit": "day", "quantity": 1, "rate": seg["rate"],
+		"days": days, "hours": None,
+		"amount": frappe.utils.flt(days * seg["rate"] / day_units, 2),
+	}
+
+
+def _hourly_line(seg: dict, hours: float, hour_units: int) -> dict:
+	return {
+		"subscription_resource": seg["asset"], "plan": seg["plan"], "cluster": seg["cluster"],
+		"resource_type": "bundle", "unit": "hour", "quantity": 1, "rate": seg["rate"],
+		"days": None, "hours": frappe.utils.flt(hours, 2),
+		"amount": frappe.utils.flt(hours * seg["rate"] / hour_units, 2),
+	}

--- a/central/billing/tests/test_billing.py
+++ b/central/billing/tests/test_billing.py
@@ -87,16 +87,59 @@ class TestDraftGeneration(BillingTestBase):
 		self.assertEqual(inv.total, 1400.0)
 		self.assertEqual(inv.expected_collection, 1400.0)
 
-	def test_same_day_provision_destroy_floors_to_one_day(self):
-		# Provisioned and cancelled on the same day → 1 day, not 0.
-		add_segment(self.sub, "Created", 1000, "2026-06-05 00:00:00")
-		add_segment(self.sub, "Cancelled", None, "2026-06-05 00:00:00")
+	def test_same_day_churn_bills_by_the_hour(self):
+		# Provisioned 09:00 and cancelled 18:00 the same day: a sub-24h run bills its
+		# real hours (9h), not a floored full day.
+		add_segment(self.sub, "Created", 1000, "2026-06-05 09:00:00")
+		add_segment(self.sub, "Cancelled", None, "2026-06-05 18:00:00")
 
 		name = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
 		inv = frappe.get_doc("Invoice", name)
 		self.assertEqual(len(inv.items), 1)  # cancelled marker is skipped
-		self.assertEqual(inv.items[0].days, 1)
-		self.assertEqual(inv.items[0].amount, round(1000 / 30, 2))
+		li = inv.items[0]
+		self.assertEqual(li.unit, "hour")
+		self.assertEqual(li.hours, 9.0)
+		self.assertEqual(li.amount, round(9 * 1000 / (30 * 24), 2))
+
+	def test_multiple_resizes_in_a_day_bill_that_day_hourly(self):
+		# 2000 all month; a peak-hours bump to 4000 (09:00) then back (18:00) on Jun 15.
+		# Only Jun 15 goes hourly; the rest of the month stays daily.
+		add_segment(self.sub, "Created", 2000, "2026-06-01 00:00:00")
+		add_segment(self.sub, "Plan Changed", 4000, "2026-06-15 09:00:00")
+		add_segment(self.sub, "Plan Changed", 2000, "2026-06-15 18:00:00")
+
+		name = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
+		inv = frappe.get_doc("Invoice", name)
+
+		daily = [li for li in inv.items if li.unit == "day"]
+		hourly = [li for li in inv.items if li.unit == "hour"]
+		# Jun 1–14 (14 days) + Jun 16–30 (15 days) at 2000 stay daily.
+		self.assertEqual(sorted(li.days for li in daily), [14, 15])
+		# Jun 15 itemised by the hour: 9h@2000, 9h@4000, 6h@2000.
+		self.assertEqual(
+			sorted((li.hours, li.rate) for li in hourly),
+			[(6.0, 2000.0), (9.0, 2000.0), (9.0, 4000.0)],
+		)
+		# 29 daily days + 24 hourly hours = exactly one 30-day month of runtime, with
+		# 9h billed at the higher 4000 rate. No double-count, no gap.
+		self.assertEqual(inv.subtotal, 2025.0)
+
+	def test_cross_midnight_churn_bills_both_days_hourly(self):
+		# Bump 23:00 Jun 10 → drop 01:00 Jun 11 (2h, < 24h): the 24h window straddles
+		# midnight, so both dates go hourly even though each has one change.
+		add_segment(self.sub, "Created", 2000, "2026-06-01 00:00:00")
+		add_segment(self.sub, "Plan Changed", 8000, "2026-06-10 23:00:00")
+		add_segment(self.sub, "Plan Changed", 2000, "2026-06-11 01:00:00")
+
+		name = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
+		inv = frappe.get_doc("Invoice", name)
+
+		hourly = [li for li in inv.items if li.unit == "hour"]
+		# 8000 ran exactly 1h on each side of midnight.
+		self.assertEqual(sorted(li.hours for li in hourly if li.rate == 8000.0), [1.0, 1.0])
+		# Jun 10 and Jun 11 are excluded from the daily lines (billed hourly instead).
+		daily_days = sum(li.days for li in inv.items if li.unit == "day")
+		self.assertEqual(daily_days, 28)  # 30 days − Jun 10 − Jun 11
 
 	def test_partial_first_month_billed_for_join_window(self):
 		add_segment(self.sub, "Created", 3000, "2026-06-15 00:00:00")

--- a/central/billing/tests/test_dashboard.py
+++ b/central/billing/tests/test_dashboard.py
@@ -530,3 +530,81 @@ class TestWriteEndpointsRejectGet(IntegrationTestCase):
 					allowed[fn], ["POST"],
 					f"{fn.__name__} must be methods=['POST'] so a GET cannot silently roll back its writes",
 				)
+
+
+class TestPaymentMethodOptions(IntegrationTestCase):
+	"""Saved cards are a Stripe-only rail (ADR 0005): the Card option is Stripe in
+	every currency; INR also offers a Razorpay UPI Autopay e-mandate."""
+
+	TEAM = "team-method-opts"
+	STRIPE = "GW-Opts-Stripe"
+	RAZORPAY = "GW-Opts-Razorpay"
+
+	def setUp(self):
+		from central.billing.catalog.entitlements import recompute_trust_tier
+		from central.billing.tests.test_entitlements import make_ladder
+		from central.billing.tests.utils import clear_team_tier
+
+		ensure_team(self.TEAM)
+		make_ladder()
+		self._stripe_gateway(["INR", "USD"])
+		self._razorpay_gateway("INR")
+		complete_billing_profile(self.TEAM)
+		frappe.db.set_value("Billing Profile", self.TEAM, "currency", "INR")
+		clear_team_tier(self.TEAM)
+		recompute_trust_tier(self.TEAM, paid_invoice_count=0, cumulative_paid=0)
+
+	def _stripe_gateway(self, currencies):
+		if frappe.db.exists("Payment Gateway", self.STRIPE):
+			frappe.delete_doc("Payment Gateway", self.STRIPE, force=True)
+		frappe.get_doc({
+			"doctype": "Payment Gateway", "__newname": self.STRIPE, "title": "Stripe (Opts)",
+			"adapter_key": "Stripe", "api_key": "pk_test_opts", "api_secret": "sk_test_opts",
+			"webhook_secret": "whsec_opts", "is_enabled": 1,
+			# INR non-default (Razorpay owns the currency default), USD default.
+			"currencies": [{"currency": c, "is_default": 1 if c == "USD" else 0} for c in currencies],
+		}).insert(ignore_permissions=True)
+
+	def _razorpay_gateway(self, currency):
+		if frappe.db.exists("Payment Gateway", self.RAZORPAY):
+			frappe.delete_doc("Payment Gateway", self.RAZORPAY, force=True)
+		frappe.get_doc({
+			"doctype": "Payment Gateway", "__newname": self.RAZORPAY, "title": "Razorpay (Opts)",
+			"adapter_key": "Razorpay", "api_key": "rzp_test", "api_secret": "rzp_secret",
+			"webhook_secret": "rzp_whsec", "is_enabled": 1, "supports_mandates": 1,
+			"currencies": [{"currency": currency, "is_default": 1}],
+		}).insert(ignore_permissions=True)
+
+	def test_india_offers_stripe_card_and_razorpay_upi(self):
+		from central.billing.api.dashboard import methods
+
+		out = methods.get_payment_method_options(self.TEAM)
+		self.assertEqual(out["currency"], "INR")
+		self.assertEqual(out["adapter_key"], "Stripe")  # Card rides Stripe, not Razorpay
+		self.assertEqual(out["methods"], ["Card", "UPI Autopay"])  # Card is primary
+		self.assertEqual(out["gateway"], self.STRIPE)
+		self.assertTrue(out["publishable_key"])
+		self.assertIn("allow_upi", out)  # UPI eligibility carried through
+
+	def test_india_card_setup_uses_stripe_gateway(self):
+		from central.billing.api.dashboard import methods
+		from unittest.mock import patch
+
+		captured = {}
+
+		def fake_setup(team, gateway):
+			captured["gateway"] = gateway
+			return {"client_secret": "cs", "payment_method": "pm"}
+
+		with patch("central.billing.payments.payments.initiate_payment_method_setup", fake_setup):
+			methods.initiate_card_setup(self.TEAM)
+		self.assertEqual(captured["gateway"], self.STRIPE)
+
+	def test_foreign_currency_is_stripe_card_only(self):
+		from central.billing.api.dashboard import methods
+
+		frappe.db.set_value("Billing Profile", self.TEAM, "currency", "USD")
+		out = methods.get_payment_method_options(self.TEAM)
+		self.assertEqual(out["adapter_key"], "Stripe")
+		self.assertEqual(out["methods"], ["Card"])  # no UPI outside INR
+		self.assertFalse(out["allow_upi"])

--- a/central/billing/tests/test_dashboard.py
+++ b/central/billing/tests/test_dashboard.py
@@ -106,6 +106,26 @@ class TestCustomerReads(CustomerDataBase):
 		self.assertEqual(detail["output_tax_amount"], 180)
 		self.assertEqual(len(detail["items"]), 1)
 
+	def test_get_invoice_flags_payment_in_progress(self):
+		# An Open invoice with a captured-but-unsettled attempt is mid-settlement:
+		# the flag lets the UI show a "settling" status instead of a Pay button.
+		inv = frappe.get_doc(
+			{"doctype": "Invoice", "team": TEAM, "invoice_type": "Billable", "status": "Open",
+			 "period_start": "2026-05-01", "period_end": "2026-05-31", "currency": "INR",
+			 "subtotal": 1000, "total": 1000, "expected_collection": 1000}
+		).insert(ignore_permissions=True).name
+		self.assertFalse(dashboard.get_invoice(inv)["payment_in_progress"])
+
+		attempt = frappe.get_doc(
+			{"doctype": "Payment Attempt", "invoice": inv, "team": TEAM, "amount": 1000,
+			 "currency": "INR", "status": "Captured", "gateway_transaction_id": "pi_x"}
+		).insert(ignore_permissions=True)
+		self.assertTrue(dashboard.get_invoice(inv)["payment_in_progress"])
+
+		# Once it settles/fails (terminal), the flag clears and Pay is offered again.
+		attempt.db_set("status", "Failed")
+		self.assertFalse(dashboard.get_invoice(inv)["payment_in_progress"])
+
 	def test_payment_methods_never_expose_secrets(self):
 		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
 

--- a/central/billing/tests/test_reconciliation.py
+++ b/central/billing/tests/test_reconciliation.py
@@ -60,6 +60,20 @@ class ReconTestBase(IntegrationTestCase):
 		frappe.db.set_value("Payment Attempt", name, "initiated_at", old)
 		return name
 
+	def _captured_attempt(self, invoice, txn="pi_x", minutes_old=60):
+		"""A sync charge that reached Captured but whose invoice never settled —
+		the lost-capture-webhook case (completed_at / resolved_by unset)."""
+		name = frappe.get_doc(
+			{
+				"doctype": "Payment Attempt", "invoice": invoice, "team": TEAM, "gateway": GATEWAY,
+				"amount": 1000, "currency": "INR", "status": "Captured",
+				"gateway_transaction_id": txn,
+			}
+		).insert(ignore_permissions=True).name
+		old = frappe.utils.add_to_date(frappe.utils.now_datetime(), minutes=-minutes_old)
+		frappe.db.set_value("Payment Attempt", name, "initiated_at", old)
+		return name
+
 
 class TestReconcile(ReconTestBase):
 	def test_gateway_success_settles_invoice_idempotently(self):
@@ -111,6 +125,57 @@ class TestReconcile(ReconTestBase):
 			"Comment", {"reference_doctype": "Invoice", "reference_name": inv}, pluck="content"
 		)
 		self.assertTrue(any("Reconciliation" in c for c in comments))
+
+
+class TestCapturedUnsettled(ReconTestBase):
+	"""The lost-capture-webhook hole: attempt Captured, invoice stranded Open."""
+
+	def test_captured_but_open_invoice_is_settled_on_gateway_success(self):
+		inv = self._open_invoice()
+		attempt = self._captured_attempt(inv)
+		with gateway_status("succeeded") as adapter:
+			out = reconciliation.reconcile_captured_attempt(attempt)
+			reconciliation.reconcile_captured_attempt(attempt)  # idempotent rerun
+			adapter.charge.assert_not_called()  # read-only
+
+		self.assertEqual(out["resolved"], "paid")
+		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Paid")
+		a = frappe.get_doc("Payment Attempt", attempt)
+		self.assertEqual(a.status, "Captured")
+		self.assertEqual(a.resolved_by, "Reconciliation")
+		self.assertTrue(a.completed_at)
+
+	def test_captured_not_confirmed_by_gateway_leaves_invoice_open(self):
+		inv = self._open_invoice()
+		attempt = self._captured_attempt(inv)
+		with gateway_status("requires_action"):
+			out = reconciliation.reconcile_captured_attempt(attempt, now=frappe.utils.now_datetime())
+		self.assertEqual(out["unresolved"], "requires_action")
+		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Open")
+
+	def test_captured_already_paid_invoice_is_skipped(self):
+		inv = self._open_invoice()
+		frappe.db.set_value("Invoice", inv, "status", "Paid")
+		attempt = self._captured_attempt(inv)
+		with gateway_status("succeeded") as adapter:
+			out = reconciliation.reconcile_captured_attempt(attempt)
+			adapter.get_transaction_status.assert_not_called()  # no gateway call once settled
+		self.assertEqual(out["skipped"], "invoice_settled")
+
+	def test_scan_settles_aged_captured_unsettled(self):
+		inv = self._open_invoice()
+		captured = self._captured_attempt(inv, minutes_old=60)
+		with gateway_status("succeeded"):
+			reconciliation.run_reconciliation()
+		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Paid")
+
+	def test_scan_grace_window_excludes_fresh_captured(self):
+		inv = self._open_invoice()
+		fresh = self._captured_attempt(inv, minutes_old=5)  # within 30-min grace
+		with gateway_status("succeeded"):
+			results = reconciliation.run_reconciliation()
+		self.assertNotIn(fresh, [r.get("attempt") for r in results])
+		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Open")
 
 
 class TestScan(ReconTestBase):

--- a/console/src/components/TopupDialog.vue
+++ b/console/src/components/TopupDialog.vue
@@ -16,10 +16,15 @@ const emit = defineEmits<{ done: [res?: unknown] }>()
 const amount = ref<number | null>(null)
 const presets = [1000, 5000, 10000, 25000]
 
-// Payment rail. INR always uses the Razorpay sheet; international currencies pick
-// between a card (Stripe Element) and PayPal (directly settled, ADR 0007).
+// Payment rail. INR always uses the Razorpay sheet; international currencies use a
+// card (Stripe Element). PayPal (directly settled, ADR 0007) is temporarily hidden
+// — its gateway + Buttons plumbing is kept intact (useTopup.mountPayPal) so it can
+// be re-enabled by flipping this flag.
+const PAYPAL_ENABLED = false
 const payMethod = ref<'card' | 'paypal'>('card')
-const showMethodChoice = computed(() => props.currency !== 'INR')
+// With PayPal hidden, foreign currencies have only the Stripe card rail, so there
+// is no rail to choose between.
+const showMethodChoice = computed(() => props.currency !== 'INR' && PAYPAL_ENABLED)
 
 // Second-phase mount targets: Stripe card Element / PayPal Buttons.
 const cardPhase = ref(false)

--- a/console/src/pages/billing/BillingInvoicesPage.vue
+++ b/console/src/pages/billing/BillingInvoicesPage.vue
@@ -64,9 +64,11 @@ watch(
   { immediate: true },
 )
 
-const canPay = computed(
-  () => canManageBilling.value && String(detail.data?.status).toLowerCase() === 'open',
-)
+// A charge already in flight (or captured, awaiting the settlement webhook) means
+// the money is moving — show a "settling" status, never a second Pay button.
+const isOpen = computed(() => String(detail.data?.status).toLowerCase() === 'open')
+const settling = computed(() => isOpen.value && !!detail.data?.payment_in_progress)
+const canPay = computed(() => canManageBilling.value && isOpen.value && !settling.value)
 
 function refresh(): void {
   invoices.reload()
@@ -246,18 +248,26 @@ const dotClass = (theme: string): string => DOTS[theme] || DOTS.gray
             </ol>
           </section>
 
-          <!-- Pinned so the pay action is always reachable. -->
+          <!-- Pinned so the pay action / settling status is always reachable. -->
           <div
-            v-if="canPay"
+            v-if="canPay || settling"
             class="sticky bottom-0 -mx-4 -mb-4 border-t border-outline-gray-1 bg-surface-elevation-1 px-4 py-3"
           >
             <Button
+              v-if="canPay"
               variant="solid"
               :label="`Pay ${money(detail.data.expected_collection, detail.data.currency)}`"
               :loading="payBusy"
               class="w-full"
               @click="pay(detail.data.name)"
             />
+            <div
+              v-else
+              class="flex items-center justify-center gap-2 py-1 text-p-sm text-ink-gray-6"
+            >
+              <span class="lucide-loader-circle size-4 animate-spin" aria-hidden="true" />
+              <span>Waiting for the bank or gateway to confirm your payment…</span>
+            </div>
           </div>
         </div>
       </template>

--- a/console/src/types/billing.ts
+++ b/console/src/types/billing.ts
@@ -137,6 +137,8 @@ export interface InvoiceDetail {
   expected_collection: number
   amount_paid: number
   due_date: string | null
+  /** A charge is in flight (or captured, awaiting the settlement webhook). */
+  payment_in_progress: boolean
   items: BillingLine[]
   activity: InvoiceActivity[]
 }

--- a/console/src/types/billing.ts
+++ b/console/src/types/billing.ts
@@ -27,6 +27,7 @@ export interface BillingLine {
   plan?: string | null
   subscription_resource?: string | null
   days?: number | null
+  hours?: number | null
   quantity?: number
   rate?: number
   unit?: string | null


### PR DESCRIPTION
Four related billing fixes/features, one focused commit each (each builds and
tests on its own). Base: `develop`.

## 1. fix: settle captured-but-unsettled invoices (`661fecf`)
A saved-card off-session charge lands `Captured` **synchronously**, then defers
settlement to the capture webhook. If that webhook is lost, the money is taken
but the invoice is stranded `Open` forever — and reconciliation's ambiguous-state
scan only looked at `Initiated`/`Authorised`, never a terminal `Captured` attempt.

Adds `reconcile_captured_attempt` + a joined scan for `Captured` attempts whose
invoice is still `Open`/`Overdue`: re-confirms success at the gateway (read-only)
and settles through the same idempotent path the webhook uses.

## 2. feat: gate gateway options by customer country — ADR 0005 (`f12f639`)
Saved cards are a Stripe-only rail in every currency.
- **India:** add-payment-method offers the **Card on Stripe** (primary) alongside
  the **Razorpay UPI Autopay** e-mandate — instead of a Razorpay card. Top-ups
  stay Razorpay-only.
- **Foreign:** Stripe-only for both cards and top-ups.
- **PayPal** top-ups hidden behind a reversible flag.

No gateway implementation is removed — all Razorpay/PayPal code is intact for
future use (`_card_gateway` resolves the Stripe card gateway; UPI stays Razorpay).

## 3. feat: hybrid daily/hourly billing for resize churn (`7a9411e`)
Billing stays **daily** by default (a config held ≥24h bills whole days; one day =
one day's rate). **Hourly** billing kicks in only when a machine churns — two
changes <24h apart (resize twice in a day, or a peak-then-drop across midnight).
Any calendar date a churn segment touches is billed by the exact hours each
config ran that date.

A date is billed daily **or** hourly, never both, so the passes partition the
period and the total stays exact — closing the sub-day gaming loophole and billing
short-lived configs fairly, without noising up a normal month. Adds an `hours`
field to Invoice Line Item.

## 4. feat: show settling state while a payment is in flight (`5b3572e`)
An `Open` invoice with an in-flight attempt (`Initiated`/`Authorised`, or
`Captured` awaiting the webhook) is mid-settlement. `get_invoice` now returns
`payment_in_progress`, so the invoice panel replaces the **Pay** button with a
_"Waiting for the bank or gateway to confirm your payment…"_ status — the customer
can't fire a second charge. Dovetails with #1: the invoice sits in this state
until the webhook lands or reconciliation settles it.