### PR TITLE
feat: Consumer service metering

### DIFF
--- a/central/billing/api/admin/services.py
+++ b/central/billing/api/admin/services.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Admin console: a team's team-level metered services (ADR 0013/0015).
+
+Operators see what metered services a team has subscribed to and can subscribe it
+to a new one or switch it onto a different plan in the same family (an upgrade). All
+endpoints are operator-gated and take an explicit `team` — an admin acts across teams,
+unlike the pilot facade which is fixed to its own team.
+"""
+
+import frappe
+
+from central.billing.authz import require_operator
+from central.billing.api.dashboard._shared import _team_currency, require_billing_profile
+
+
+@frappe.whitelist()
+def get_team_services(team: str, cluster: str | None = None) -> dict:
+	"""A team's metered footprint plus the catalog it can subscribe to: the active
+	service subscriptions (subject, plan, modes, allowance, current usage) and the
+	available service plans priced for the team's currency."""
+	require_operator()
+	from central.billing.catalog.services import list_service_plans, team_service_subscriptions
+
+	currency = _team_currency(team)
+	return {
+		"team": team,
+		"currency": currency,
+		"services": team_service_subscriptions(team),
+		"available_plans": list_service_plans(currency, cluster=cluster),
+	}
+
+
+@frappe.whitelist(methods=["POST"])
+def subscribe_team_service(team: str, plan: str, cluster: str | None = None) -> dict:
+	"""Subscribe a team to a team-level service, or switch it onto a different plan in
+	the same family (an upgrade). Idempotent per (team, family, cluster). Requires the
+	team's billing profile to be complete."""
+	require_operator()
+	require_billing_profile(team, "subscribe to a service")
+	from central.billing.catalog.subscriptions import provision_service_subscription
+
+	return provision_service_subscription(team, plan, cluster=cluster)

--- a/central/billing/api/billing_api.py
+++ b/central/billing/api/billing_api.py
@@ -190,48 +190,77 @@ def get_service_subscription() -> dict:
 
 @frappe.whitelist(allow_guest=True, methods=["GET"])
 @pilot_credential_auth
-def check_service_allowance(service_subject: str) -> dict:
-	"""A service subject's allowance state for edge enforcement: `{allowance, used,
-	remaining, blocked, settlement_mode}`. A Prepaid Pack service polls this and degrades
-	when `blocked`; a Postpaid Overage service never blocks. Scoped to the team."""
-	from central.billing.catalog.services import service_allowance
+def check_service_allowance(service: str, cluster: str | None = None) -> dict:
+	"""Allowance state for edge enforcement, by the service the caller *is*: `{allowance,
+	used, remaining, blocked, settlement_mode}`. A Prepaid Pack service polls this and
+	degrades when `blocked`; a Postpaid Overage service never blocks. Central resolves the
+	team's subject from `service` (the metered Resource Type) — the caller handles no
+	subject. `exists: False` when the team isn't subscribed to it."""
+	from central.billing.catalog.services import resolve_service_subject, service_allowance
 
-	return service_allowance(_team(), service_subject)
+	team = _team()
+	subject = resolve_service_subject(team, service, cluster=cluster)
+	if not subject:
+		return {"exists": False}
+	return service_allowance(team, subject)
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
 @pilot_credential_auth
 def report_usage(
-	service_subject: str,
-	resource_type: str,
+	service: str,
 	quantity: float,
-	period_start: str,
-	period_end: str,
-	idempotency_key: str,
-	meter_type: str = "Counter",
+	cluster: str | None = None,
 	sequence: int = 0,
+	period: str | None = None,
 ) -> dict:
-	"""Report metered usage for a team-level service subject. The subject must belong to
-	the credential's team (IDOR defence). Authoritative families send the period's
-	running total (replaced); Incremental families send a delta + a monotonic sequence
-	(accumulated, deduped). Returns the handled idempotency_key, or null if nothing was
-	recorded (e.g. no active segment for the subject)."""
+	"""Report metered usage for a team-level service — the minimal call a consumer service
+	makes. It names the `service` it is (the metered Resource Type) and the `quantity`;
+	Central derives everything else from the credential:
+
+	  - the **team** (from the credential — a caller can only ever report its own team's
+	    usage, so there is no subject to forge),
+	  - the **subject** (resolved from team + service + cluster),
+	  - the billing **period** (the current month unless `period="YYYY-MM"` backfills one),
+	  - the **idempotency key** (subject + service + period).
+
+	Authoritative families send the period's running total (replaced); Incremental families
+	send a delta and bump `sequence` each flush (accumulated, retries/duplicates deduped).
+	Returns `{recorded, service_subject}`; `recorded` is False if the team isn't subscribed
+	to the service or it has no open billing segment."""
+	from central.billing.catalog.services import resolve_service_subject
 	from central.billing.revenue.metering import ingest_rollup
 
-	_assert_owns(frappe.db.get_value("Subscription", {"service_subject": service_subject}, "team"))
+	team = _team()
+	subject = resolve_service_subject(team, service, cluster=cluster)
+	if not subject:
+		frappe.throw(
+			frappe._("Team is not subscribed to service {0}.").format(service), frappe.ValidationError
+		)
+
+	period_start, period_end, tag = _billing_period(period)
 	key = ingest_rollup(
 		{
-			"resource_id": service_subject,
-			"resource_type": resource_type,
-			"meter_type": meter_type,
+			"resource_id": subject,
+			"resource_type": service,
+			"meter_type": "Counter",
 			"quantity": frappe.utils.flt(quantity),
 			"period_start": period_start,
 			"period_end": period_end,
-			"idempotency_key": idempotency_key,
+			"idempotency_key": f"{subject}|{service}|{tag}",
 			"sequence": frappe.utils.cint(sequence),
 		}
 	)
-	return {"recorded": bool(key), "idempotency_key": key}
+	return {"recorded": bool(key), "service_subject": subject}
+
+
+def _billing_period(period: str | None) -> tuple[str, str, str]:
+	"""The (start, end, tag) of a billing month. Defaults to the current month; `period`
+	backfills a past one as `"YYYY-MM"`. The tag keys the rollup so all of a month's
+	reports land on one row."""
+	anchor = f"{period}-01" if period else frappe.utils.nowdate()
+	first = frappe.utils.get_first_day(anchor)
+	return str(first), str(frappe.utils.get_last_day(anchor)), first.strftime("%Y-%m")
 
 
 # ── Credits ──────────────────────────────────────────────────────────────────

--- a/central/billing/api/billing_api.py
+++ b/central/billing/api/billing_api.py
@@ -145,6 +145,84 @@ def change_plan(asset: str, plan: str) -> dict:
 	return resize_server(subscription, plan=plan)
 
 
+# ── Metered services (team-level: AI tokens, email, PDF, …) ──────────────────
+# The in-app flow a consumer service drives (ADR 0013/0015): discover service plans,
+# subscribe (a synthesized subject, no VM), read what the team runs, and report usage.
+# The team is always the credential's — never a parameter — so a pilot reports only its
+# own team's consumption.
+
+
+@frappe.whitelist(allow_guest=True, methods=["GET"])
+@pilot_credential_auth
+def list_service_plans(cluster: str | None = None) -> dict:
+	"""Active team-level service plans (AI tokens, email, PDF, storage), priced for the
+	team's currency on `cluster`. Each entry carries the billing shape, family modes,
+	included allowance, and the resolved rate."""
+	from central.billing.catalog.services import list_service_plans as _list
+
+	team = _team()
+	currency = _team_currency(team)
+	return {"plans": _list(currency, cluster=cluster), "currency": currency}
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+@pilot_credential_auth
+def subscribe_service(plan: str, cluster: str | None = None) -> dict:
+	"""Subscribe the team to a team-level metered service. Mints a synthesized subject
+	(no VM) and opens the price-lock segment inline; idempotent per (team, plan, cluster).
+	Returns the subject + locked handles."""
+	from central.billing.catalog.subscriptions import provision_service_subscription
+
+	team = _team()
+	_require_billing_setup(team)
+	return provision_service_subscription(team, plan, cluster=cluster)
+
+
+@frappe.whitelist(allow_guest=True, methods=["GET"])
+@pilot_credential_auth
+def get_service_subscription() -> dict:
+	"""The team's active team-level service subscriptions: subject, plan, cluster, rate,
+	family modes, included allowance, and the current period's reported usage."""
+	from central.billing.catalog.services import team_service_subscriptions
+
+	return {"services": team_service_subscriptions(_team())}
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+@pilot_credential_auth
+def report_usage(
+	service_subject: str,
+	resource_type: str,
+	quantity: float,
+	period_start: str,
+	period_end: str,
+	idempotency_key: str,
+	meter_type: str = "Counter",
+	sequence: int = 0,
+) -> dict:
+	"""Report metered usage for a team-level service subject. The subject must belong to
+	the credential's team (IDOR defence). Authoritative families send the period's
+	running total (replaced); Incremental families send a delta + a monotonic sequence
+	(accumulated, deduped). Returns the handled idempotency_key, or null if nothing was
+	recorded (e.g. no active segment for the subject)."""
+	from central.billing.revenue.metering import ingest_rollup
+
+	_assert_owns(frappe.db.get_value("Subscription", {"service_subject": service_subject}, "team"))
+	key = ingest_rollup(
+		{
+			"resource_id": service_subject,
+			"resource_type": resource_type,
+			"meter_type": meter_type,
+			"quantity": frappe.utils.flt(quantity),
+			"period_start": period_start,
+			"period_end": period_end,
+			"idempotency_key": idempotency_key,
+			"sequence": frappe.utils.cint(sequence),
+		}
+	)
+	return {"recorded": bool(key), "idempotency_key": key}
+
+
 # ── Credits ──────────────────────────────────────────────────────────────────
 
 

--- a/central/billing/api/billing_api.py
+++ b/central/billing/api/billing_api.py
@@ -188,6 +188,17 @@ def get_service_subscription() -> dict:
 	return {"services": team_service_subscriptions(_team())}
 
 
+@frappe.whitelist(allow_guest=True, methods=["GET"])
+@pilot_credential_auth
+def check_service_allowance(service_subject: str) -> dict:
+	"""A service subject's allowance state for edge enforcement: `{allowance, used,
+	remaining, blocked, settlement_mode}`. A Prepaid Pack service polls this and degrades
+	when `blocked`; a Postpaid Overage service never blocks. Scoped to the team."""
+	from central.billing.catalog.services import service_allowance
+
+	return service_allowance(_team(), service_subject)
+
+
 @frappe.whitelist(allow_guest=True, methods=["POST"])
 @pilot_credential_auth
 def report_usage(

--- a/central/billing/api/billing_api.py
+++ b/central/billing/api/billing_api.py
@@ -229,6 +229,7 @@ def report_usage(
 	Returns `{recorded, service_subject}`; `recorded` is False if the team isn't subscribed
 	to the service or it has no open billing segment."""
 	from central.billing.catalog.services import resolve_service_subject
+	from central.billing.catalog.subscriptions import active_segment_for_resource
 	from central.billing.revenue.metering import ingest_rollup
 
 	team = _team()
@@ -238,10 +239,18 @@ def report_usage(
 			frappe._("Team is not subscribed to service {0}.").format(service), frappe.ValidationError
 		)
 
+	# Stamp the subject's authoritative billing context (team + its real cluster +
+	# currency) into the payload. A Live-priced family reads team/cluster/currency
+	# straight from the meter (a grandfathered one re-derives them off the segment), so
+	# without these a Live rollup would land context-less and be missed at invoicing.
+	seg = active_segment_for_resource(subject)
 	period_start, period_end, tag = _billing_period(period)
 	key = ingest_rollup(
 		{
 			"resource_id": subject,
+			"team": seg.team if seg else team,
+			"cluster": seg.cluster if seg else cluster,
+			"currency": seg.currency if seg else None,
 			"resource_type": service,
 			"meter_type": "Counter",
 			"quantity": frappe.utils.flt(quantity),

--- a/central/billing/api/dashboard/__init__.py
+++ b/central/billing/api/dashboard/__init__.py
@@ -61,6 +61,10 @@ from central.billing.api.dashboard.methods import (
 	set_default_payment_method,
 	setup_payment_method_order,
 )
+from central.billing.api.dashboard.services import (
+	get_metered_services,
+	subscribe_metered_service,
+)
 
 __all__ = [
 	"whoami", "get_billing_profile", "get_billing_geo", "save_billing_profile", "get_billing_settings",
@@ -76,4 +80,5 @@ __all__ = [
 	"list_payment_methods", "get_payment_method_options", "initiate_card_setup", "confirm_card",
 	"add_demo_card", "setup_payment_method_order", "confirm_payment_method_order",
 	"remove_payment_method", "set_default_payment_method", "reorder_payment_methods",
+	"get_metered_services", "subscribe_metered_service",
 ]

--- a/central/billing/api/dashboard/services.py
+++ b/central/billing/api/dashboard/services.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Customer dashboard: a team's own team-level metered services (ADR 0013/0015).
+
+Team-scoped via the capability IAM like every dashboard endpoint: the read needs
+`billing:view`, the subscribe mutation `billing:manage`. The team defaults to the
+caller's own and is never silently widened.
+"""
+
+import frappe
+
+from central.billing import authz
+from central.billing.api.dashboard._shared import _resolve_team, _team_currency
+
+
+@frappe.whitelist()
+def get_metered_services(team: str | None = None, cluster: str | None = None) -> dict:
+	"""The team's metered service footprint (subject, plan, modes, allowance, current
+	usage) plus the service catalog it can subscribe to, priced for its currency."""
+	from central.billing.catalog.services import list_service_plans, team_service_subscriptions
+
+	team = _resolve_team(team)
+	currency = _team_currency(team)
+	return {
+		"currency": currency,
+		"services": team_service_subscriptions(team),
+		"available_plans": list_service_plans(currency, cluster=cluster),
+	}
+
+
+@frappe.whitelist(methods=["POST"])
+def subscribe_metered_service(plan: str, cluster: str | None = None, team: str | None = None) -> dict:
+	"""Subscribe the team to a team-level service, or switch it onto a different plan in
+	the same family (an upgrade). Idempotent per (team, family, cluster)."""
+	from central.billing.api.dashboard._shared import require_billing_profile
+	from central.billing.catalog.subscriptions import provision_service_subscription
+
+	team = _resolve_team(team, require=authz.MANAGE)
+	require_billing_profile(team, "subscribe to a service")
+	return provision_service_subscription(team, plan, cluster=cluster)

--- a/central/billing/catalog/services.py
+++ b/central/billing/catalog/services.py
@@ -99,6 +99,42 @@ def team_service_subscriptions(team: str) -> list[dict]:
 	return out
 
 
+def service_allowance(team: str, subject: str) -> dict:
+	"""A service subject's allowance state (ADR 0015), for edge enforcement.
+
+	For a **Prepaid Pack** family the allowance is a purchased balance drawn down by
+	reported usage: `remaining = max(0, allowance - used)`, and the service is `blocked`
+	once it hits zero (the consumer service polls this and degrades, offline-enforcement
+	style). For a **Postpaid Overage** family nothing blocks — usage past the allowance
+	bills as overage — so `blocked` is always False. Returns `exists: False` for an
+	unknown/unsubscribed subject."""
+	from central.billing.catalog.subscriptions import active_segment_for_resource
+
+	seg = active_segment_for_resource(subject)
+	if not seg or seg.team != team:
+		return {"exists": False}
+
+	inc = _includes_by_plan([seg.plan]).get(seg.plan) if seg.plan else None
+	mode = _category_modes_by_plan([seg.plan]).get(seg.plan, frappe._dict()) if seg.plan else frappe._dict()
+	settlement = mode.get("settlement_mode") or "Postpaid Overage"
+	allowance = frappe.utils.flt(inc.quantity) if inc else 0.0
+	used = _current_period_usage(subject)
+	remaining = max(0.0, allowance - used)
+	prepaid = settlement == "Prepaid Pack"
+	return {
+		"exists": True,
+		"service_subject": subject,
+		"plan": seg.plan,
+		"settlement_mode": settlement,
+		"unit": inc.unit if inc else None,
+		"allowance": allowance,
+		"used": used,
+		"remaining": remaining,
+		# A prepaid pack with a real allowance blocks at exhaustion; postpaid never blocks.
+		"blocked": bool(prepaid and allowance and remaining <= 0),
+	}
+
+
 def _includes_by_plan(plan_names: list[str]) -> dict:
 	"""The single include row (resource_type, quantity, unit) per plan, in one query.
 	A team-level service plan is single-resource (ADR 0008), so at most one row matters."""

--- a/central/billing/catalog/services.py
+++ b/central/billing/catalog/services.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Read models for team-level metered services (ADR 0013/0015).
+
+A team-level service (AI tokens, email, common PDF, snapshot storage) is a Plan whose
+family is not provisioned as a whole Server. These readers back both the pilot-facing
+in-app flow (`api/billing_api.py`) and the admin billing console (`api/admin`): what
+services a team can subscribe to, and what it currently runs.
+"""
+
+import frappe
+
+from central.billing.catalog.pricing import get_catalog_rates, resolve_rate
+
+
+def list_service_plans(currency: str, cluster: str | None = None) -> list[dict]:
+	"""Active team-level service plans, priced for `currency` on `cluster`.
+
+	One entry per active Plan under a non-Server family, carrying its billing shape
+	(Fixed bundle vs Metered), the family's settlement + reporting mode, the included
+	allowance, and the resolved rate (a bundle's flat price, or a metered per-unit rate).
+	`rate` is None when the family has no rate for this currency/cluster."""
+	service_categories = {
+		c.name: c
+		for c in frappe.get_all(
+			"Plan Category",
+			filters={"is_active": 1, "provision_target": ["!=", "Server"]},
+			fields=["name", "billing_type", "settlement_mode", "reporting_mode"],
+		)
+	}
+	if not service_categories:
+		return []
+
+	plans = frappe.get_all(
+		"Plan",
+		filters={"category": ["in", list(service_categories)], "is_active": 1},
+		fields=["name", "title", "category"],
+	)
+	includes = _includes_by_plan([p.name for p in plans])
+
+	out = []
+	for p in plans:
+		cat = service_categories[p.category]
+		inc = includes.get(p.name)
+		rate = resolve_rate(get_catalog_rates("Plan", p.name), currency, cluster)
+		out.append(
+			{
+				"plan": p.name,
+				"title": p.title,
+				"category": p.category,
+				"billing_type": cat.billing_type,
+				"settlement_mode": cat.settlement_mode or "Postpaid Overage",
+				"reporting_mode": cat.reporting_mode or "Authoritative",
+				"resource_type": inc.resource_type if inc else None,
+				"unit": inc.unit if inc else None,
+				"allowance": frappe.utils.flt(inc.quantity) if inc else 0.0,
+				"rate": frappe.utils.flt(rate) if rate is not None else None,
+				"currency": currency,
+			}
+		)
+	return out
+
+
+def team_service_subscriptions(team: str) -> list[dict]:
+	"""A team's active team-level service subscriptions (ADR 0013): one per synthesized
+	subject, with its plan, cluster, locked rate, family modes, included allowance, and
+	the current period's reported usage. The console's view of a team's metered footprint."""
+	from central.billing.catalog.subscriptions import team_active_segments
+
+	segs = [s for s in team_active_segments(team) if s.service_subject]
+	if not segs:
+		return []
+
+	includes = _includes_by_plan([s.plan for s in segs if s.plan])
+	modes = _category_modes_by_plan([s.plan for s in segs if s.plan])
+
+	out = []
+	for s in segs:
+		inc = includes.get(s.plan)
+		mode = modes.get(s.plan, {})
+		out.append(
+			{
+				"subscription": s.subscription,
+				"service_subject": s.service_subject,
+				"plan": s.plan,
+				"title": frappe.db.get_value("Plan", s.plan, "title") if s.plan else None,
+				"cluster": s.cluster,
+				"currency": s.currency,
+				"locked_rate": s.locked_rate,
+				"billing_type": mode.get("billing_type"),
+				"settlement_mode": mode.get("settlement_mode") or "Postpaid Overage",
+				"reporting_mode": mode.get("reporting_mode") or "Authoritative",
+				"resource_type": inc.resource_type if inc else None,
+				"unit": inc.unit if inc else None,
+				"allowance": frappe.utils.flt(inc.quantity) if inc else 0.0,
+				"period_usage": _current_period_usage(s.service_subject),
+			}
+		)
+	return out
+
+
+def _includes_by_plan(plan_names: list[str]) -> dict:
+	"""The single include row (resource_type, quantity, unit) per plan, in one query.
+	A team-level service plan is single-resource (ADR 0008), so at most one row matters."""
+	names = [n for n in set(plan_names) if n]
+	if not names:
+		return {}
+	by_plan: dict = {}
+	for row in frappe.get_all(
+		"Plan Includes",
+		filters={"parenttype": "Plan", "parent": ["in", names]},
+		fields=["parent", "resource_type", "quantity", "unit"],
+	):
+		by_plan.setdefault(row.parent, row)  # first (single) row per plan
+	return by_plan
+
+
+def _category_modes_by_plan(plan_names: list[str]) -> dict:
+	"""Plan -> its family's billing_type + settlement/reporting mode, in two queries."""
+	names = [n for n in set(plan_names) if n]
+	if not names:
+		return {}
+	plan_cat = {
+		p.name: p.category
+		for p in frappe.get_all("Plan", filters={"name": ["in", names]}, fields=["name", "category"])
+	}
+	cats = {
+		c.name: c
+		for c in frappe.get_all(
+			"Plan Category",
+			filters={"name": ["in", list(set(plan_cat.values()))]},
+			fields=["name", "billing_type", "settlement_mode", "reporting_mode"],
+		)
+	}
+	return {plan: cats.get(cat, frappe._dict()) for plan, cat in plan_cat.items()}
+
+
+def _current_period_usage(subject: str) -> float:
+	"""The reported usage for a subject in the current billing month (summed across its
+	rollup rows, though there is normally one per meter). A quick read for the console —
+	billing itself measures overage against the locked allowance at invoice time."""
+	month_start = frappe.utils.get_first_day(frappe.utils.nowdate())
+	rows = frappe.get_all(
+		"Usage Rollup",
+		filters={"resource_id": subject, "period_start": [">=", month_start]},
+		pluck="quantity",
+	)
+	return frappe.utils.flt(sum(frappe.utils.flt(q) for q in rows))

--- a/central/billing/catalog/services.py
+++ b/central/billing/catalog/services.py
@@ -99,6 +99,19 @@ def team_service_subscriptions(team: str) -> list[dict]:
 	return out
 
 
+def resolve_service_subject(team: str, service: str, cluster: str | None = None) -> str | None:
+	"""The team's active service subject for `service` on `cluster`, or None if it isn't
+	subscribed (ADR 0015). `service` is the Resource Type the family meters (one active
+	metered plan per resource type, ADR 0008), so a consumer service names the service it
+	*is* and Central resolves the synthesized subject — the caller never handles subjects.
+	A globally-priced service carries no cluster; pass None to match it."""
+	want_cluster = cluster or None
+	for s in team_service_subscriptions(team):
+		if s["resource_type"] == service and (s["cluster"] or None) == want_cluster:
+			return s["service_subject"]
+	return None
+
+
 def service_allowance(team: str, subject: str) -> dict:
 	"""A service subject's allowance state (ADR 0015), for edge enforcement.
 

--- a/central/billing/catalog/services.py
+++ b/central/billing/catalog/services.py
@@ -100,16 +100,25 @@ def team_service_subscriptions(team: str) -> list[dict]:
 
 
 def resolve_service_subject(team: str, service: str, cluster: str | None = None) -> str | None:
-	"""The team's active service subject for `service` on `cluster`, or None if it isn't
-	subscribed (ADR 0015). `service` is the Resource Type the family meters (one active
-	metered plan per resource type, ADR 0008), so a consumer service names the service it
-	*is* and Central resolves the synthesized subject — the caller never handles subjects.
-	A globally-priced service carries no cluster; pass None to match it."""
-	want_cluster = cluster or None
-	for s in team_service_subscriptions(team):
-		if s["resource_type"] == service and (s["cluster"] or None) == want_cluster:
-			return s["service_subject"]
-	return None
+	"""The team's active service subject for `service`, or None if it isn't subscribed
+	(ADR 0015). `service` is the Resource Type the family meters (one active metered plan
+	per resource type, ADR 0008), so a consumer service names the service it *is* and
+	Central resolves the synthesized subject — the caller never handles subjects.
+
+	Many services are globally priced (one team-wide subject, no cluster). So a caller's
+	`cluster` is a hint, not a requirement: a regional subject for that cluster wins, but
+	a **global (unclustered) subject is the fallback** — a caller on any cluster (or one
+	that passes no cluster at all) reports to it. So `cluster` stays genuinely optional."""
+	subs = [s for s in team_service_subscriptions(team) if s["resource_type"] == service]
+	if cluster:
+		exact = next((s for s in subs if s["cluster"] == cluster), None)
+		if exact:
+			return exact["service_subject"]
+	glob = next((s for s in subs if not s["cluster"]), None)
+	if glob:
+		return glob["service_subject"]
+	# No global subject: a caller that named no cluster still resolves a lone regional one.
+	return subs[0]["service_subject"] if len(subs) == 1 else None
 
 
 def service_allowance(team: str, subject: str) -> dict:

--- a/central/billing/catalog/subscriptions.py
+++ b/central/billing/catalog/subscriptions.py
@@ -242,21 +242,28 @@ def provision_service_subscription(
 	price-lock itself, ADR 0010) inline. A service subject is always alive while
 	subscribed; there is no stop/start.
 
-	Idempotent: re-subscribing the same team to the same service on the same cluster
-	returns the existing subscription rather than opening a parallel subject. Returns
-	the subscription + the synthesized subject + the locked handles."""
-	_assert_service_plan(plan)
+	The subject is keyed per (team, service *family*, cluster), not per plan, so
+	upgrading to a different plan in the same family re-locks the SAME subject (a
+	`Plan Changed` segment) and keeps its usage history continuous — never forking into a
+	parallel subject. Re-subscribing the identical plan is idempotent. Returns the
+	subscription + the synthesized subject + the locked handles."""
+	category = _assert_service_plan(plan)
 
-	subject = _service_subject_id(team, plan, cluster)
+	subject = _service_subject_id(team, category, cluster)
 	existing = frappe.db.get_value(
-		"Subscription", {"service_subject": subject, "enabled": 1}, "name"
+		"Subscription", {"service_subject": subject, "enabled": 1}, ["name", "plan"], as_dict=True
 	)
 	if existing:
-		seg = _latest_segment_by_subscription([existing]).get(existing)
+		reused = existing.plan == plan
+		if not reused:
+			# Same family, different plan → an upgrade/downgrade: re-lock in place.
+			change_plan(existing.name, plan, changed_by=changed_by)
+		seg = _latest_segment_by_subscription([existing.name]).get(existing.name)
 		return {
-			"subscription": existing,
+			"subscription": existing.name,
 			"service_subject": subject,
-			"reused": True,
+			"reused": reused,
+			"upgraded": not reused,
 			"locked_rate": frappe.utils.flt(seg.locked_rate) if seg else None,
 			"currency": seg.currency if seg else None,
 		}
@@ -290,15 +297,17 @@ def provision_service_subscription(
 		"subscription": doc.name,
 		"service_subject": subject,
 		"reused": False,
+		"upgraded": False,
 		"locked_rate": opening.locked_rate if opening else None,
 		"currency": opening.currency if opening else None,
 	}
 
 
-def _assert_service_plan(plan: str) -> None:
+def _assert_service_plan(plan: str) -> str:
 	"""A team-level service plan is any active Plan whose family is not provisioned as a
 	whole Server (servers go through the VM create/resize flow, ADR 0007). Metered
-	families (AI Tokens, PDF, storage) and non-Server bundles qualify."""
+	families (AI Tokens, PDF, storage) and non-Server bundles qualify. Returns its
+	Plan Category (the service family)."""
 	category = frappe.db.get_value("Plan", plan, "category")
 	if not category:
 		frappe.throw(frappe._("Unknown plan {0}.").format(plan), frappe.ValidationError)
@@ -307,14 +316,16 @@ def _assert_service_plan(plan: str) -> None:
 			frappe._("Plan {0} provisions a server — subscribe it through the server flow, not as a team-level service.").format(plan),
 			frappe.ValidationError,
 		)
+	return category
 
 
-def _service_subject_id(team: str, plan: str, cluster: str | None) -> str:
-	"""A deterministic, collision-safe virtual subject per (team, service-plan, cluster),
-	so re-subscribing the same service resolves to the same subject (idempotency)."""
+def _service_subject_id(team: str, category: str, cluster: str | None) -> str:
+	"""A deterministic, collision-safe virtual subject per (team, service *family*,
+	cluster). Keyed on the family — not the specific plan — so an upgrade within the
+	family stays on the same subject and its usage history is continuous."""
 	import hashlib
 
-	seed = f"{team}|{plan}|{cluster or ''}"
+	seed = f"{team}|{category}|{cluster or ''}"
 	return "svc-" + hashlib.sha1(seed.encode()).hexdigest()[:16]
 
 

--- a/central/billing/catalog/subscriptions.py
+++ b/central/billing/catalog/subscriptions.py
@@ -224,6 +224,100 @@ def provision_subscription(
 	}
 
 
+def provision_service_subscription(
+	team: str,
+	plan: str,
+	cluster: str | None = None,
+	billing_cycle: str = "Monthly",
+	start_date=None,
+	default_payment_method: str | None = None,
+	gateway: str | None = None,
+	changed_by: str | None = None,
+):
+	"""Subscribe a team to a team-level metered service (ADR 0013/0015).
+
+	Unlike a VM subscription, this mints no Asset and calls no cluster manager: it
+	synthesizes a virtual subject per `(team, plan, cluster)`, records the intent, and
+	opens the authoritative billing segment (the `Created` Subscription Change — the
+	price-lock itself, ADR 0010) inline. A service subject is always alive while
+	subscribed; there is no stop/start.
+
+	Idempotent: re-subscribing the same team to the same service on the same cluster
+	returns the existing subscription rather than opening a parallel subject. Returns
+	the subscription + the synthesized subject + the locked handles."""
+	_assert_service_plan(plan)
+
+	subject = _service_subject_id(team, plan, cluster)
+	existing = frappe.db.get_value(
+		"Subscription", {"service_subject": subject, "enabled": 1}, "name"
+	)
+	if existing:
+		seg = _latest_segment_by_subscription([existing]).get(existing)
+		return {
+			"subscription": existing,
+			"service_subject": subject,
+			"reused": True,
+			"locked_rate": frappe.utils.flt(seg.locked_rate) if seg else None,
+			"currency": seg.currency if seg else None,
+		}
+
+	doc = frappe.get_doc(
+		{
+			"doctype": "Subscription",
+			"team": team,
+			"service_subject": subject,
+			"cluster": cluster,
+			"pricing_mode": "Preset",
+			"plan": plan,
+			"billing_cycle": billing_cycle,
+			"account_standing": "Current",
+			"enabled": 1,
+			"start_date": start_date or frappe.utils.nowdate(),
+			"default_payment_method": default_payment_method,
+			"gateway": gateway,
+		}
+	)
+	doc.flags.changed_by = changed_by
+	doc.insert(ignore_permissions=True)
+
+	opening = frappe.db.get_value(
+		"Subscription Change",
+		{"subscription": doc.name, "change_type": "Created"},
+		["locked_rate", "currency"],
+		as_dict=True,
+	)
+	return {
+		"subscription": doc.name,
+		"service_subject": subject,
+		"reused": False,
+		"locked_rate": opening.locked_rate if opening else None,
+		"currency": opening.currency if opening else None,
+	}
+
+
+def _assert_service_plan(plan: str) -> None:
+	"""A team-level service plan is any active Plan whose family is not provisioned as a
+	whole Server (servers go through the VM create/resize flow, ADR 0007). Metered
+	families (AI Tokens, PDF, storage) and non-Server bundles qualify."""
+	category = frappe.db.get_value("Plan", plan, "category")
+	if not category:
+		frappe.throw(frappe._("Unknown plan {0}.").format(plan), frappe.ValidationError)
+	if frappe.db.get_value("Plan Category", category, "provision_target") == "Server":
+		frappe.throw(
+			frappe._("Plan {0} provisions a server — subscribe it through the server flow, not as a team-level service.").format(plan),
+			frappe.ValidationError,
+		)
+
+
+def _service_subject_id(team: str, plan: str, cluster: str | None) -> str:
+	"""A deterministic, collision-safe virtual subject per (team, service-plan, cluster),
+	so re-subscribing the same service resolves to the same subject (idempotency)."""
+	import hashlib
+
+	seed = f"{team}|{plan}|{cluster or ''}"
+	return "svc-" + hashlib.sha1(seed.encode()).hexdigest()[:16]
+
+
 def change_plan(subscription: str, new_plan: str, changed_by: str | None = None):
 	"""Switch a subscription onto a curated preset (intent). The controller opens the
 	new billing segment on save (the `changed`-event re-lock, ADR 0010) — this just
@@ -594,7 +688,7 @@ def active_segments(filters: dict | None = None) -> list:
 	subs = frappe.get_all(
 		"Subscription",
 		filters=filters or {},
-		fields=["name", "team", "plan", "pricing_mode", "asset_id"],
+		fields=["name", "team", "plan", "pricing_mode", "asset_id", "service_subject", "cluster"],
 	)
 	if not subs:
 		return []
@@ -605,6 +699,10 @@ def active_segments(filters: dict | None = None) -> list:
 		seg = latest.get(s.name)
 		if not seg or seg.change_type == "Cancelled":
 			continue
+		# A VM subscription is subjected by its Asset (cluster off the Asset); a
+		# team-level service subject has no Asset — its id and cluster live on the
+		# Subscription itself (ADR 0013). Either way the resource_id keys metering.
+		resource_id = s.asset_id or s.service_subject
 		out.append(
 			frappe._dict(
 				{
@@ -613,8 +711,9 @@ def active_segments(filters: dict | None = None) -> list:
 					"plan": s.plan,
 					"pricing_mode": s.pricing_mode,
 					"asset_id": s.asset_id,
-					"resource_id": s.asset_id,
-					"cluster": clusters.get(s.asset_id),
+					"service_subject": s.service_subject,
+					"resource_id": resource_id,
+					"cluster": clusters.get(s.asset_id) or s.cluster,
 					"currency": seg.currency,
 					"locked_rate": frappe.utils.flt(seg.locked_rate),
 				}
@@ -629,11 +728,13 @@ def team_active_segments(team: str) -> list:
 
 
 def active_segment_for_resource(resource_id: str):
-	"""The open priced segment for a provisioned resource (its Asset's subscription),
-	or None. `asset_id` names the Asset, whose name is the `resource_id` (autoname
-	field:resource_id), so a resource maps to at most one subscription. Used by
-	metering to grandfather a metered resource's terms off the ledger (#86)."""
+	"""The open priced segment for a metered subject, or None. A VM resource is named
+	by its Asset (`asset_id`); a team-level service subject is named by the synthesized
+	`service_subject` (ADR 0013). Either maps to at most one subscription. Used by
+	metering to grandfather a subject's terms off the ledger (#86)."""
 	segs = active_segments({"asset_id": resource_id})
+	if not segs:
+		segs = active_segments({"service_subject": resource_id})
 	return segs[0] if segs else None
 
 

--- a/central/billing/docs/README.md
+++ b/central/billing/docs/README.md
@@ -1,0 +1,9 @@
+# Billing developer docs
+
+Reference docs for the `central/billing` module. Broader context lives in
+[`../ARCHITECTURE.md`](../ARCHITECTURE.md) and [`../SETUP-AND-DEMO.md`](../SETUP-AND-DEMO.md);
+design decisions live as ADRs in the `billing-specs` repo.
+
+| Doc | What it covers |
+| --- | --- |
+| [metered-services-api.md](metered-services-api.md) | Team-level metered services (ADR 0013/0015): pilot / dashboard / admin endpoints, reporting & settlement modes, request/response examples, and a quick test flow. |

--- a/central/billing/docs/metered-services-api.md
+++ b/central/billing/docs/metered-services-api.md
@@ -1,0 +1,337 @@
+# Team-level metered services — API reference
+
+> Bill a service by its usage — AI tokens, email, PDF rendering, storage — attributed to a
+> **team**, with no server involved. A consumer service subscribes, reports usage, and Central
+> meters it onto the same invoice as everything else. Design decisions live in the `billing-specs`
+> repo: **ADR 0015** (this API contract) and **ADR 0013** (the synthesized subject).
+
+**Source of truth**
+
+| Concern | File |
+| --- | --- |
+| Pilot (consumer-service) facade | `central/billing/api/billing_api.py` |
+| Customer dashboard endpoints | `central/billing/api/dashboard/services.py` |
+| Admin console endpoints | `central/billing/api/admin/services.py` |
+| Read models (plans / subscriptions / allowance / subject resolution) | `central/billing/catalog/services.py` |
+| Provisioning (synthesized subject) | `central/billing/catalog/subscriptions.py` → `provision_service_subscription` |
+| Usage ingestion (dual-mode) | `central/billing/revenue/metering.py` → `ingest_rollup` |
+| Tests | `central/billing/tests/test_service_metering.py` |
+
+---
+
+## Overview
+
+A **team-level metered service** has no customer VM. When a team subscribes, Central mints a
+synthesized *subject* keyed on `(team, service family, cluster)` and opens a price-lock segment —
+the caller never handles that subject. Usage lands as one bounded rollup row per period and bills
+off the same spine as any server.
+
+- **You name the service.** A consumer service calls `report_usage(service, quantity)`. Central
+  derives the team (from the credential), the subject, the billing period, and the idempotency key.
+- **Two service shapes.** A *bundle* (e.g. `$20 → 1M tokens`) carries an included allowance; a
+  *pure meter* (e.g. `$0.0001/PDF`) is per-unit with no allowance.
+- **Cluster is optional.** Most services are globally priced — subscribe once, report from
+  anywhere. `cluster` only matters for the minority that price per region.
+
+---
+
+## Authentication
+
+Three surfaces, three audiences. The team is never widened by a parameter beyond what the caller is
+allowed to touch.
+
+| Surface | Path root | Auth | Team |
+| --- | --- | --- | --- |
+| Consumer service (pilot) | `central.billing.api.billing_api.*` | Header `X-Pilot-Token` | From the credential — a caller only ever touches its own team. |
+| Customer dashboard | `central.billing.api.dashboard.*` | Session cookie `sid` | Caller's team; capability `billing:view` / `billing:manage`. |
+| Admin console | `central.billing.api.admin.services.*` | Session cookie `sid` | Any team (explicit param); operator / System Manager only. |
+
+---
+
+## Conventions
+
+- **URL** — `https://<site>/api/v2/method/<dotted.path>`
+- **Params** — `GET` → query string; `POST` → JSON body with `Content-Type: application/json`.
+- **Success** — HTTP 200, body `{ "message": <payload> }`. Payloads below are the *inner* value.
+
+---
+
+## Reporting & settlement modes
+
+Both are properties of the service **family** (the plan's `Plan Category`) — a consumer service
+doesn't choose them per call, it just honors them.
+
+### Reporting mode — how usage is sent
+
+| Mode | Caller sends | Central does | Typical |
+| --- | --- | --- | --- |
+| `Authoritative` | The period's running total, each report. | Replaces the period quantity. | Token manager, email — services keeping their own ledger. |
+| `Incremental` | A delta, plus a `sequence` that bumps each flush. | Accumulates; a duplicate / stale / out-of-order sequence is a no-op. | Micro-services (PDF) aggregating at the edge. |
+
+> **Dedup.** Central can invent the subject, period and key — but not the dedup token. Only the
+> caller knows a retry from a new increment, so incremental exactly-once needs one bumping integer
+> (`sequence`). Omit it for best-effort (a rare retry may double-count).
+
+### Settlement mode — what a used-up allowance means
+
+| Mode | Behavior | Billing |
+| --- | --- | --- |
+| `Postpaid Overage` | Keep serving past the allowance. | Bills `max(0, qty − allowance) × rate` at period close. |
+| `Prepaid Pack` | Allowance is a purchased balance; `blocked` flips true at zero. | Bills nothing — the pack was paid up front; excess is blocked, not charged. |
+
+---
+
+## Consumer service · pilot
+
+All pilot endpoints require the `X-Pilot-Token` header and take the team from the credential.
+
+### `GET` list_service_plans
+
+Active service plans, priced for the team's currency.
+
+| Name | In | Type | Req | Description |
+| --- | --- | --- | --- | --- |
+| `cluster` | query | string | optional | Region for a regionally-priced family; omit for global. |
+
+```bash
+curl -s '.../central.billing.api.billing_api.list_service_plans' \
+  -H 'X-Pilot-Token: <token>'
+```
+```jsonc
+{ "message": {
+  "currency": "INR",
+  "plans": [{
+    "plan": "meter-tokens", "title": "AI Tokens", "billing_type": "Metered",
+    "settlement_mode": "Postpaid Overage", "reporting_mode": "Authoritative",
+    "resource_type": "Tokens", "unit": "1M tokens", "allowance": 0.0, "rate": 5.0, "currency": "INR"
+  }]
+} }
+```
+
+### `POST` subscribe_service
+
+Subscribe the team to a service — mints the synthesized subject and opens the price-lock segment.
+Idempotent per `(team, family, cluster)`; a different plan in the same family is an in-place
+`upgraded` re-lock.
+
+| Name | In | Type | Req | Description |
+| --- | --- | --- | --- | --- |
+| `plan` | body | string | **required** | Plan name from `list_service_plans`. |
+| `cluster` | body | string | optional | Region; omit for a global subscription. |
+
+```bash
+curl -s -X POST '.../central.billing.api.billing_api.subscribe_service' \
+  -H 'X-Pilot-Token: <token>' -H 'Content-Type: application/json' \
+  -d '{"plan":"meter-tokens"}'
+```
+```jsonc
+{ "message": {
+  "subscription": "a1b2c3", "service_subject": "svc-9f3a1c7e2b4d6a80",
+  "reused": false, "upgraded": false, "locked_rate": 5.0, "currency": "INR"
+} }
+```
+
+### `GET` get_service_subscription
+
+The team's active service subscriptions, each with plan, modes, allowance, and usage reported this
+period. No parameters.
+
+```bash
+curl -s '.../central.billing.api.billing_api.get_service_subscription' \
+  -H 'X-Pilot-Token: <token>'
+```
+```jsonc
+{ "message": {
+  "services": [{
+    "subscription": "a1b2c3", "service_subject": "svc-9f3a…", "plan": "meter-tokens",
+    "title": "AI Tokens", "cluster": null, "currency": "INR", "locked_rate": 5.0,
+    "billing_type": "Metered", "settlement_mode": "Postpaid Overage", "reporting_mode": "Authoritative",
+    "resource_type": "Tokens", "unit": "1M tokens", "allowance": 0.0, "period_usage": 500.0
+  }]
+} }
+```
+
+### `GET` check_service_allowance
+
+Allowance state for edge enforcement, by the service the caller *is*. A prepaid service polls this
+and degrades when `blocked`; a postpaid service never blocks.
+
+| Name | In | Type | Req | Description |
+| --- | --- | --- | --- | --- |
+| `service` | query | string | **required** | The metered Resource Type the family covers (e.g. `Tokens`). |
+| `cluster` | query | string | optional | Region hint; the global subject is the fallback. |
+
+```bash
+curl -s '.../central.billing.api.billing_api.check_service_allowance?service=Tokens' \
+  -H 'X-Pilot-Token: <token>'
+```
+```jsonc
+{ "message": {
+  "exists": true, "service_subject": "svc-9f3a…", "plan": "meter-tokens",
+  "settlement_mode": "Prepaid Pack", "unit": "1M tokens",
+  "allowance": 1000.0, "used": 1000.0, "remaining": 0.0, "blocked": true
+} }
+// not subscribed → { "message": { "exists": false } }
+```
+
+### `POST` report_usage
+
+The core call. Name the `service` you are and the `quantity`; Central derives team, subject, period,
+and idempotency key.
+
+| Name | In | Type | Req | Description |
+| --- | --- | --- | --- | --- |
+| `service` | body | string | **required** | The metered Resource Type (e.g. `PDF Render`). |
+| `quantity` | body | number | **required** | Authoritative: the period running total. Incremental: the delta since last report. |
+| `cluster` | body | string | optional | Regional services only; omit for global. |
+| `sequence` | body | int | optional | Incremental exactly-once: a monotonic counter, bumped each flush. Default `0`. |
+| `period` | body | string | optional | `"YYYY-MM"` to backfill a past month; defaults to the current one. |
+
+```bash
+# incremental micro-service
+curl -s -X POST '.../central.billing.api.billing_api.report_usage' \
+  -H 'X-Pilot-Token: <token>' -H 'Content-Type: application/json' \
+  -d '{"service":"PDF Render","quantity":500,"sequence":7}'
+
+# fire-and-forget: {"service":"PDF Render","quantity":1}
+# authoritative:  {"service":"Tokens","quantity":500}
+```
+```jsonc
+{ "message": { "recorded": true, "service_subject": "svc-9f3a1c7e2b4d6a80" } }
+// recorded=false → no open billing segment yet for the subject (not an error)
+```
+
+---
+
+## Customer dashboard
+
+Session-authed; team defaults to the caller's own.
+
+### `GET` get_metered_services  — `billing:view`
+
+The team's metered footprint plus the catalog it can subscribe to, priced for its currency. Backs
+the console's Metered services card.
+
+| Name | In | Type | Req | Description |
+| --- | --- | --- | --- | --- |
+| `team` | query | string | optional | Defaults to the caller's team. |
+| `cluster` | query | string | optional | Prices the catalog for a region. |
+
+```bash
+curl -s '.../central.billing.api.dashboard.get_metered_services' -b 'sid=<session>'
+```
+```jsonc
+{ "message": {
+  "currency": "INR",
+  "services": [ /* as get_service_subscription */ ],
+  "available_plans": [ /* as list_service_plans */ ]
+} }
+```
+
+### `POST` subscribe_metered_service  — `billing:manage`
+
+Subscribe the team, or upgrade it onto a different plan in the same family. Same result shape as
+`subscribe_service`.
+
+| Name | In | Type | Req | Description |
+| --- | --- | --- | --- | --- |
+| `plan` | body | string | **required** | Plan to subscribe / upgrade to. |
+| `cluster` | body | string | optional | Region; omit for global. |
+| `team` | body | string | optional | Defaults to the caller's team. |
+
+```bash
+curl -s -X POST '.../central.billing.api.dashboard.subscribe_metered_service' \
+  -b 'sid=<session>' -H 'Content-Type: application/json' \
+  -d '{"plan":"meter-tokens"}'
+```
+
+---
+
+## Admin console
+
+Operator / System Manager only; the team is an explicit parameter.
+
+### `GET` get_team_services
+
+Any team's metered footprint plus the catalog it can subscribe to.
+
+| Name | In | Type | Req | Description |
+| --- | --- | --- | --- | --- |
+| `team` | query | string | **required** | The team to inspect. |
+| `cluster` | query | string | optional | Prices the catalog for a region. |
+
+```bash
+curl -s '.../central.billing.api.admin.services.get_team_services?team=acme' -b 'sid=<operator>'
+```
+```jsonc
+{ "message": { "team": "acme", "currency": "INR", "services": [ … ], "available_plans": [ … ] } }
+```
+
+### `POST` subscribe_team_service
+
+Subscribe a team to a service, or upgrade its plan — from the admin console. Same result shape as
+`subscribe_service`.
+
+| Name | In | Type | Req | Description |
+| --- | --- | --- | --- | --- |
+| `team` | body | string | **required** | The team to subscribe. |
+| `plan` | body | string | **required** | Plan to subscribe / upgrade to. |
+| `cluster` | body | string | optional | Region; omit for global. |
+
+```bash
+curl -s -X POST '.../central.billing.api.admin.services.subscribe_team_service' \
+  -b 'sid=<operator>' -H 'Content-Type: application/json' \
+  -d '{"team":"acme","plan":"meter-tokens"}'
+```
+
+---
+
+## Errors
+
+Failures return a non-200 with a Frappe exception payload. The common ones:
+
+| HTTP | Exception | When |
+| --- | --- | --- |
+| 401 | `AuthenticationError` | Missing / invalid / expired `X-Pilot-Token`. |
+| 403 | `PermissionError` | Session lacks `billing:manage`, or a non-operator hits an admin path. |
+| 417 | `ValidationError` | Team not subscribed to the service; billing profile incomplete; a server plan subscribed as a service. |
+
+> `report_usage` returning `{ "recorded": false }` is **not** an error — it means the subject has no
+> open billing segment yet (nothing to bill against), distinct from a 417 for an unsubscribed service.
+
+---
+
+## Quick test flow
+
+Prove the whole path end to end: discover → subscribe → report → verify it bills.
+
+1. `list_service_plans` → pick a `plan` and its `resource_type`.
+2. `subscribe_service(plan)` → note `service_subject`.
+3. `report_usage(service, quantity)` → expect `recorded: true`.
+4. `check_service_allowance(service)` → confirm `used` moved.
+5. Run invoicing for the month → a metered line `(qty − allowance) × rate` appears (postpaid), or
+   none (prepaid).
+
+**Incremental dedup check** — retries and stale batches must be no-ops:
+
+```
+report_usage(service="PDF Render", quantity=100, sequence=1)  → 100
+report_usage(service="PDF Render", quantity=50,  sequence=2)  → 150
+report_usage(service="PDF Render", quantity=50,  sequence=2)  → 150  (duplicate, no-op)
+report_usage(service="PDF Render", quantity=999, sequence=1)  → 150  (stale, no-op)
+```
+
+**Server-side (no auth)** — drive the same code via `bench --site <site> console`:
+
+```python
+import frappe, inspect
+from central.billing.api import billing_api
+frappe.local.pilot_credential = frappe._dict(team="your-team")   # stub the credential
+call = lambda f, **k: inspect.unwrap(getattr(billing_api, f))(**k)
+
+plan = call("list_service_plans")["plans"][0]
+sub  = call("subscribe_service", plan=plan["plan"])
+print(call("report_usage", service=plan["resource_type"], quantity=500))
+print(call("check_service_allowance", service=plan["resource_type"]))
+frappe.db.rollback()   # drop the test data
+```

--- a/central/billing/doctype/plan_category/plan_category.json
+++ b/central/billing/doctype/plan_category/plan_category.json
@@ -19,6 +19,8 @@
   "billing_interval",
   "column_break_billing",
   "pricing_mode",
+  "settlement_mode",
+  "reporting_mode",
   "section_break_resources",
   "allowed_resource_types"
  ],
@@ -100,6 +102,20 @@
    "label": "Pricing Mode",
    "options": "\nGrandfathered\nLive",
    "description": "For a Metered family: Grandfathered bills the rate locked at provision (like bundles); Live reads the current Catalog Rate each period with no allowance, for depreciating storage (ADR 0002). Leave blank for Fixed families."
+  },
+  {
+   "fieldname": "settlement_mode",
+   "fieldtype": "Select",
+   "label": "Settlement Mode",
+   "options": "\nPostpaid Overage\nPrepaid Pack",
+   "description": "What the included allowance means when it runs out (ADR 0015). Postpaid Overage (default): keep serving, bill max(0, qty-allowance) x rate at period close. Prepaid Pack: the allowance is a purchased balance drawn down as usage lands; blocked/degraded at zero until another pack is bought. Blank = Postpaid Overage."
+  },
+  {
+   "fieldname": "reporting_mode",
+   "fieldtype": "Select",
+   "label": "Reporting Mode",
+   "options": "\nAuthoritative\nIncremental",
+   "description": "How a consumer service reports usage (ADR 0015). Authoritative (default): the service sends the period's running total; Central replaces the rollup. Incremental: the service posts deltas as consumed; Central accumulates and dedupes by a monotonic sequence cursor (assumes ordered delivery). Blank = Authoritative."
   },
   {
    "fieldname": "section_break_resources",

--- a/central/billing/doctype/plan_category/plan_category.py
+++ b/central/billing/doctype/plan_category/plan_category.py
@@ -25,12 +25,33 @@ class PlanCategory(Document):
 		is_active: DF.Check
 		pricing_mode: DF.Literal["", "Grandfathered", "Live"]
 		provision_target: DF.Literal["", "Server", "Resource"]
+		reporting_mode: DF.Literal["", "Authoritative", "Incremental"]
+		settlement_mode: DF.Literal["", "Postpaid Overage", "Prepaid Pack"]
 		sub_category_label: DF.Data | None
 	# end: auto-generated types
+
+	def validate(self):
+		# Settlement/reporting mode only govern Metered families; blank them on a Fixed
+		# one so the stored shape stays honest (a bundle has no metered reporting).
+		if self.billing_type != "Metered":
+			self.settlement_mode = None
+			self.reporting_mode = None
 
 	def allowed_types(self) -> set[str]:
 		"""The resource types a member plan's composition may use. Empty = unconstrained."""
 		return {row.resource_type for row in self.allowed_resource_types}
+
+	@property
+	def effective_settlement_mode(self) -> str:
+		"""Settlement of a Metered family's allowance, blank resolving to the built default
+		(ADR 0015). A prepaid pack draws down a purchased balance; postpaid bills overage."""
+		return self.settlement_mode or "Postpaid Overage"
+
+	@property
+	def effective_reporting_mode(self) -> str:
+		"""How this family's usage is reported, blank resolving to the built default
+		(ADR 0015). Authoritative replaces the period total; Incremental accumulates deltas."""
+		return self.reporting_mode or "Authoritative"
 
 	@property
 	def uses_sub_categories(self) -> bool:

--- a/central/billing/doctype/subscription/subscription.json
+++ b/central/billing/doctype/subscription/subscription.json
@@ -10,6 +10,7 @@
   "enabled",
   "team",
   "asset_id",
+  "service_subject",
   "cluster",
   "pricing_mode",
   "plan",
@@ -130,6 +131,13 @@
    "fieldname": "cluster",
    "fieldtype": "Read Only",
    "label": "Cluster"
+  },
+  {
+   "description": "A team-level metered service's synthesized virtual subject (ADR 0013/0015) — keyed per (team, service-plan, cluster), with no customer-owned Asset. Mutually exclusive with asset_id; metering resolves the segment through it just as it does through an Asset.",
+   "fieldname": "service_subject",
+   "fieldtype": "Data",
+   "label": "Service Subject",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,

--- a/central/billing/doctype/subscription/subscription.py
+++ b/central/billing/doctype/subscription/subscription.py
@@ -24,6 +24,7 @@ class Subscription(Document):
 		includes: DF.Table
 		plan: DF.Link | None
 		pricing_mode: DF.Literal["Preset", "Composed"]
+		service_subject: DF.Data | None
 		start_date: DF.Date | None
 		sub_category: DF.Link | None
 		team: DF.Link
@@ -31,6 +32,7 @@ class Subscription(Document):
 
 	def validate(self):
 		self.validate_duplicate_subscription()
+		self.validate_duplicate_service_subject()
 
 	def validate_duplicate_subscription(self):
 		"""Block a second enabled subscription for the same team + asset.
@@ -54,6 +56,29 @@ class Subscription(Document):
 		if duplicate:
 			frappe.throw(
 				f"Team {self.team} already has an active subscription ({duplicate}) for asset {self.asset_id}.",
+				frappe.DuplicateEntryError,
+			)
+
+	def validate_duplicate_service_subject(self):
+		"""One active subscription per synthesized service subject (ADR 0013/0015).
+
+		The subject already encodes (team, service-plan, cluster), so this makes
+		provisioning idempotent: a second subscribe of the same service on the same
+		cluster must reuse the existing subject, not open a parallel one."""
+		if not (self.enabled and self.service_subject):
+			return
+
+		duplicate = frappe.db.exists(
+			"Subscription",
+			{
+				"name": ["!=", self.name],
+				"service_subject": self.service_subject,
+				"enabled": 1,
+			},
+		)
+		if duplicate:
+			frappe.throw(
+				f"Service subject {self.service_subject} already has an active subscription ({duplicate}).",
 				frappe.DuplicateEntryError,
 			)
 
@@ -147,7 +172,11 @@ class Subscription(Document):
 		currency = frappe.db.get_value("Billing Profile", self.team, "currency")
 		if not currency:
 			return None, None
-		cluster = frappe.db.get_value("Asset", self.asset_id, "cluster") if self.asset_id else None
+		# A VM subscription resolves its cluster off the Asset; a team-level service
+		# subject (no Asset) carries its cluster on the Subscription itself (ADR 0013).
+		cluster = (
+			frappe.db.get_value("Asset", self.asset_id, "cluster") if self.asset_id else None
+		) or self.cluster
 
 		if self.pricing_mode == "Composed":
 			from central.billing.catalog.pricing import resolve_config_rate

--- a/central/billing/doctype/usage_rollup/usage_rollup.json
+++ b/central/billing/doctype/usage_rollup/usage_rollup.json
@@ -23,7 +23,8 @@
   "locked_allowance",
   "locked_rate",
   "column_break_key",
-  "idempotency_key"
+  "idempotency_key",
+  "sequence"
  ],
  "fields": [
   {
@@ -114,7 +115,14 @@
    "fieldtype": "Data",
    "label": "Idempotency Key",
    "unique": 1,
-   "description": "(resource_id, meter_type, period) — re-push replaces, never adds"
+   "description": "Period identity (resource_id, meter_type, period) — one row per period. Authoritative re-push replaces the quantity; Incremental batches find the same row and accumulate."
+  },
+  {
+   "default": "0",
+   "fieldname": "sequence",
+   "fieldtype": "Int",
+   "label": "Sequence",
+   "description": "Incremental reporting only (ADR 0015): the last applied batch sequence. A batch is accumulated only if its sequence exceeds this, so a retried/duplicate/out-of-order batch is a no-op. Unused (0) for Authoritative reporting."
   }
  ],
  "index_web_pages_for_search": 1,

--- a/central/billing/revenue/metering.py
+++ b/central/billing/revenue/metering.py
@@ -197,7 +197,15 @@ def ingest_rollup(meter: dict) -> str | None:
 			# the batch), then loop — the re-read FOR UPDATE blocks on the winner and our
 			# figure lands on its row rather than being dropped.
 			frappe.db.rollback(save_point="usage_rollup_insert")
-	return key
+
+	# Every retry lost the race without ever applying or inserting (a winner that kept
+	# rolling back after we saw its lock). Do NOT acknowledge: return None so the caller
+	# doesn't mark the batch synced. The reporter retries and the delta still lands —
+	# the sequence cursor was never advanced, so there is no double-count.
+	frappe.logger("billing").warning(
+		f"Usage rollup {key} could not be applied after {_INGEST_RACE_RETRIES} attempts"
+	)
+	return None
 
 
 # A first-insert race resolves in one retry; a couple more absorb a winner that rolls

--- a/central/billing/revenue/metering.py
+++ b/central/billing/revenue/metering.py
@@ -156,8 +156,14 @@ def ingest_rollup(meter: dict) -> str | None:
 	  after an outage), never adds — the reporter holds the authoritative total.
 	- **Incremental**: each batch carries a `quantity` delta and a monotonic `sequence`.
 	  A batch is ACCUMULATED (`quantity += delta`) only if its sequence exceeds the last
-	  applied, so a retried/duplicate/out-of-order batch is a no-op. The row is locked
-	  for update while it accumulates (concurrent batches serialize).
+	  applied, so a retried/duplicate/out-of-order batch is a no-op.
+
+	Concurrency: an existing row is locked FOR UPDATE while it is applied, so concurrent
+	batches serialize. The FIRST report can't lock a not-yet-existent row, so two
+	first-reports for the same period both miss and race to insert — the loser hits the
+	unique idempotency_key. We roll that failed insert back to a SAVEPOINT (not the whole
+	batch), then loop: the retry re-reads FOR UPDATE (blocking on the winner), so its
+	figure is applied to the winner's row instead of being dropped.
 
 	Returns the idempotency_key once handled (so the reporter can mark it synced)."""
 	key = meter.get("idempotency_key")
@@ -166,29 +172,56 @@ def ingest_rollup(meter: dict) -> str | None:
 
 	mode = _reporting_mode_for(meter.get("resource_type"))
 	qty = frappe.utils.flt(meter.get("quantity"))
+	seq = frappe.utils.cint(meter.get("sequence"))
 
-	existing = frappe.db.get_value(
-		"Usage Rollup", {"idempotency_key": key}, ["name", "quantity", "sequence"],
-		as_dict=True, for_update=True,
-	)
-	if existing:
-		if mode == "Incremental":
-			seq = frappe.utils.cint(meter.get("sequence"))
-			if seq <= frappe.utils.cint(existing.sequence):
-				return key  # duplicate / out-of-order batch — already counted
-			frappe.db.set_value(
-				"Usage Rollup", existing.name,
-				{"quantity": frappe.utils.flt(existing.quantity) + qty, "sequence": seq},
-			)
-		else:
-			# Authoritative: replace the period figure; keep the locked terms stamped first.
-			frappe.db.set_value("Usage Rollup", existing.name, "quantity", qty)
-		return key
+	for _ in range(_INGEST_RACE_RETRIES):
+		existing = frappe.db.get_value(
+			"Usage Rollup", {"idempotency_key": key}, ["name", "quantity", "sequence"],
+			as_dict=True, for_update=True,
+		)
+		if existing:
+			_apply_report(existing, mode, qty, seq)
+			return key
 
-	terms = _resolve_terms(meter)
-	if not terms:
-		return None  # no active lock — nothing to bill this against yet
+		terms = _resolve_terms(meter)
+		if not terms:
+			return None  # no active lock — nothing to bill this against yet
 
+		try:
+			frappe.db.savepoint("usage_rollup_insert")
+			_insert_rollup(meter, terms, qty, seq, key)
+			return key
+		except frappe.DuplicateEntryError:
+			# Lost the first-insert race: a concurrent first report created the row between
+			# our lock-miss and our insert. Undo only our failed insert (keep the rest of
+			# the batch), then loop — the re-read FOR UPDATE blocks on the winner and our
+			# figure lands on its row rather than being dropped.
+			frappe.db.rollback(save_point="usage_rollup_insert")
+	return key
+
+
+# A first-insert race resolves in one retry; a couple more absorb a winner that rolls
+# back after we saw its lock (leaving the row briefly gone again).
+_INGEST_RACE_RETRIES = 3
+
+
+def _apply_report(existing, mode: str, qty: float, seq: int) -> None:
+	"""Apply a report to the already-locked rollup row. Authoritative replaces the period
+	figure; Incremental accumulates only when the sequence advances (else a no-op)."""
+	if mode == "Incremental":
+		if seq <= frappe.utils.cint(existing.sequence):
+			return  # duplicate / out-of-order batch — already counted
+		frappe.db.set_value(
+			"Usage Rollup", existing.name,
+			{"quantity": frappe.utils.flt(existing.quantity) + qty, "sequence": seq},
+		)
+	else:
+		# Authoritative: replace the period figure; the locked terms stay as first stamped.
+		frappe.db.set_value("Usage Rollup", existing.name, "quantity", qty)
+
+
+def _insert_rollup(meter: dict, terms: dict, qty: float, seq: int, key: str) -> None:
+	"""Insert the period's rollup with its billing terms stamped once, at first receipt."""
 	frappe.get_doc(
 		{
 			"doctype": "Usage Rollup",
@@ -205,10 +238,9 @@ def ingest_rollup(meter: dict) -> str | None:
 			"locked_allowance": terms["allowance"],
 			"locked_rate": terms["rate"],
 			"idempotency_key": key,
-			"sequence": frappe.utils.cint(meter.get("sequence")),
+			"sequence": seq,
 		}
 	).insert(ignore_permissions=True)
-	return key
 
 
 def metered_line_items(team: str, cluster: str, period_start, period_end) -> list[dict]:

--- a/central/billing/revenue/metering.py
+++ b/central/billing/revenue/metering.py
@@ -124,23 +124,54 @@ def _locked_terms(resource_id: str, resource_type: str):
 	}
 
 
-def ingest_rollup(meter: dict) -> str | None:
-	"""Idempotently store one Agent meter rollup, keyed by idempotency_key.
+def _reporting_mode_for(resource_type: str) -> str:
+	"""The reporting mode of the family that prices `resource_type` (ADR 0015), blank
+	resolving to Authoritative. A resource type maps to at most one active metered Plan
+	(ADR 0008), whose Plan Category carries the mode — so this is unambiguous."""
+	plan = _metered_plan_for(resource_type)
+	if not plan:
+		return "Authoritative"
+	category = frappe.db.get_value("Plan", plan.name, "category")
+	return frappe.db.get_value("Plan Category", category, "reporting_mode") or "Authoritative"
 
-	A re-push REPLACES the quantity (recompute after an outage), never adds. The
-	locked allowance + rate are stamped once, at first receipt, so the metered
-	terms are grandfathered and a later catalog change cannot move an existing
-	rollup's price. Returns the idempotency_key once handled (so the Agent can
-	mark it synced).
-	"""
+
+def ingest_rollup(meter: dict) -> str | None:
+	"""Idempotently store one meter rollup, keyed by the period-identity idempotency_key.
+	Both reporting modes (ADR 0015) land as one Usage Rollup row per period; the locked
+	allowance + rate are stamped once, at first receipt, so the metered terms are
+	grandfathered and a later catalog change cannot move an existing rollup's price.
+
+	- **Authoritative** (default): a re-push REPLACES the period quantity (recompute
+	  after an outage), never adds — the reporter holds the authoritative total.
+	- **Incremental**: each batch carries a `quantity` delta and a monotonic `sequence`.
+	  A batch is ACCUMULATED (`quantity += delta`) only if its sequence exceeds the last
+	  applied, so a retried/duplicate/out-of-order batch is a no-op. The row is locked
+	  for update while it accumulates (concurrent batches serialize).
+
+	Returns the idempotency_key once handled (so the reporter can mark it synced)."""
 	key = meter.get("idempotency_key")
 	if not key:
 		return None
 
-	existing = frappe.db.get_value("Usage Rollup", {"idempotency_key": key}, "name")
+	mode = _reporting_mode_for(meter.get("resource_type"))
+	qty = frappe.utils.flt(meter.get("quantity"))
+
+	existing = frappe.db.get_value(
+		"Usage Rollup", {"idempotency_key": key}, ["name", "quantity", "sequence"],
+		as_dict=True, for_update=True,
+	)
 	if existing:
-		# Replace the period figure; keep the locked terms stamped at first receipt.
-		frappe.db.set_value("Usage Rollup", existing, "quantity", frappe.utils.flt(meter.get("quantity")))
+		if mode == "Incremental":
+			seq = frappe.utils.cint(meter.get("sequence"))
+			if seq <= frappe.utils.cint(existing.sequence):
+				return key  # duplicate / out-of-order batch — already counted
+			frappe.db.set_value(
+				"Usage Rollup", existing.name,
+				{"quantity": frappe.utils.flt(existing.quantity) + qty, "sequence": seq},
+			)
+		else:
+			# Authoritative: replace the period figure; keep the locked terms stamped first.
+			frappe.db.set_value("Usage Rollup", existing.name, "quantity", qty)
 		return key
 
 	terms = _resolve_terms(meter)
@@ -157,12 +188,13 @@ def ingest_rollup(meter: dict) -> str | None:
 			"meter_type": meter.get("meter_type"),
 			"period_start": meter.get("period_start"),
 			"period_end": meter.get("period_end"),
-			"quantity": frappe.utils.flt(meter.get("quantity")),
+			"quantity": qty,
 			"unit": meter.get("unit"),
 			"currency": terms["currency"],
 			"locked_allowance": terms["allowance"],
 			"locked_rate": terms["rate"],
 			"idempotency_key": key,
+			"sequence": frappe.utils.cint(meter.get("sequence")),
 		}
 	).insert(ignore_permissions=True)
 	return key

--- a/central/billing/revenue/metering.py
+++ b/central/billing/revenue/metering.py
@@ -135,6 +135,17 @@ def _reporting_mode_for(resource_type: str) -> str:
 	return frappe.db.get_value("Plan Category", category, "reporting_mode") or "Authoritative"
 
 
+def _settlement_mode_for(resource_type: str) -> str:
+	"""The settlement mode of the family that prices `resource_type` (ADR 0015), blank
+	resolving to Postpaid Overage. Prepaid Pack usage is not billed as overage — the
+	pack was paid up front and excess is blocked at the edge, not charged."""
+	plan = _metered_plan_for(resource_type)
+	if not plan:
+		return "Postpaid Overage"
+	category = frappe.db.get_value("Plan", plan.name, "category")
+	return frappe.db.get_value("Plan Category", category, "settlement_mode") or "Postpaid Overage"
+
+
 def ingest_rollup(meter: dict) -> str | None:
 	"""Idempotently store one meter rollup, keyed by the period-identity idempotency_key.
 	Both reporting modes (ADR 0015) land as one Usage Rollup row per period; the locked
@@ -223,6 +234,11 @@ def metered_line_items(team: str, cluster: str, period_start, period_end) -> lis
 	unpriced = []  # (resource_type, reason) — collected so every problem surfaces at once
 	for r in rollups:
 		if r.period_start and not (period_start <= frappe.utils.getdate(r.period_start) <= period_end):
+			continue
+
+		# A prepaid-pack family bills nothing here: the pack was paid up front and usage
+		# beyond it is blocked at the edge, not charged as overage (ADR 0015).
+		if _settlement_mode_for(r.resource_type) == "Prepaid Pack":
 			continue
 
 		# A live metered plan (e.g. snapshot) reads the CURRENT catalog rate and has no

--- a/central/billing/tests/test_service_metering.py
+++ b/central/billing/tests/test_service_metering.py
@@ -20,6 +20,41 @@ def _ensure_resource_type(name: str) -> str:
 	return name
 
 
+def _make_metered_family(category, resource_type, plan, reporting_mode="Authoritative", rate=0.5):
+	"""A metered single-resource Plan under a dedicated Plan Category carrying an explicit
+	reporting_mode — so a test can exercise incremental accumulation without mutating a
+	shared category. Returns the plan name."""
+	from central.billing.catalog.pricing import set_catalog_rates
+	from central.billing.tests.utils import _ensure_rate_instances
+
+	_ensure_resource_type(resource_type)
+	for old in frappe.get_all("Plan", {"category": category}, pluck="name"):
+		frappe.delete_doc("Plan", old, force=True)
+	if frappe.db.exists("Plan Category", category):
+		frappe.delete_doc("Plan Category", category, force=True)
+	frappe.get_doc(
+		{
+			"doctype": "Plan Category", "category_name": category, "billing_type": "Metered",
+			"pricing_mode": "Grandfathered", "reporting_mode": reporting_mode,
+		}
+	).insert(ignore_permissions=True)
+
+	doc = frappe.get_doc(
+		{
+			"doctype": "Plan", "title": plan, "category": category, "billing_cycle": "Monthly",
+			"is_active": 1,
+			"includes": [{"resource_type": resource_type, "quantity": 0, "unit": "unit"}],
+		}
+	)
+	doc.name = plan
+	doc.flags.name_set = True
+	doc.insert(ignore_permissions=True)
+	rates = [{"cluster": "", "currency": "INR", "rate": rate}]
+	_ensure_rate_instances(rates)
+	set_catalog_rates("Plan", doc.name, rates)
+	return doc.name
+
+
 class TestPlanCategoryModes(IntegrationTestCase):
 	"""settlement_mode / reporting_mode are per-family properties, blank resolving to
 	the built default; both are meaningless on a Fixed family (ADR 0015)."""
@@ -119,3 +154,72 @@ class TestServiceSubjectProvisioning(IntegrationTestCase):
 		)
 		with self.assertRaises(frappe.ValidationError):
 			subscriptions.provision_service_subscription(self.TEAM, server_plan, cluster="mumbai")
+
+
+class TestDualModeIngestion(IntegrationTestCase):
+	"""Usage lands as one rollup row per period in both reporting modes (ADR 0015):
+	Authoritative replaces the period total; Incremental accumulates deltas, deduped by
+	a monotonic sequence cursor."""
+
+	TEAM = "svc-team-ingest"
+
+	def setUp(self):
+		from central.billing.revenue import metering
+
+		self.metering = metering
+		ensure_team(self.TEAM)
+		complete_billing_profile(self.TEAM, currency="INR")
+		frappe.db.delete("Subscription", {"team": self.TEAM})
+		frappe.db.delete("Usage Rollup", {"team": self.TEAM})
+
+	def _subject(self, resource_type, plan):
+		res = subscriptions.provision_service_subscription(self.TEAM, plan, cluster="mumbai")
+		return res["service_subject"]
+
+	def _meter(self, subject, resource_type, key, qty, sequence=0):
+		return {
+			"resource_id": subject, "resource_type": resource_type, "meter_type": "Counter",
+			"period_start": "2026-07-01 00:00:00", "period_end": "2026-07-31 23:59:59",
+			"quantity": qty, "unit": "unit", "idempotency_key": key, "sequence": sequence,
+		}
+
+	def _qty(self, subject):
+		return frappe.utils.flt(frappe.db.get_value("Usage Rollup", {"resource_id": subject}, "quantity"))
+
+	def test_authoritative_repush_replaces(self):
+		plan = _make_metered_family("SM Auth Family", "PDF Auth", "SM PDF Auth Plan")
+		subject = self._subject("PDF Auth", plan)
+		key = f"{subject}|Counter|2026-07"
+		self.metering.ingest_rollup(self._meter(subject, "PDF Auth", key, 100))
+		self.metering.ingest_rollup(self._meter(subject, "PDF Auth", key, 250))
+		self.assertEqual(self._qty(subject), 250)  # replaced, not summed
+
+	def test_incremental_accumulates_and_dedupes(self):
+		plan = _make_metered_family(
+			"SM Incr Family", "PDF Incr", "SM PDF Incr Plan", reporting_mode="Incremental"
+		)
+		subject = self._subject("PDF Incr", plan)
+		key = f"{subject}|Counter|2026-07"
+		self.metering.ingest_rollup(self._meter(subject, "PDF Incr", key, 100, sequence=1))
+		self.metering.ingest_rollup(self._meter(subject, "PDF Incr", key, 50, sequence=2))
+		self.assertEqual(self._qty(subject), 150)
+
+		# A retried batch (same sequence) and an out-of-order older batch are no-ops.
+		self.metering.ingest_rollup(self._meter(subject, "PDF Incr", key, 50, sequence=2))
+		self.metering.ingest_rollup(self._meter(subject, "PDF Incr", key, 999, sequence=1))
+		self.assertEqual(self._qty(subject), 150)
+
+		# A new higher sequence accumulates again.
+		self.metering.ingest_rollup(self._meter(subject, "PDF Incr", key, 25, sequence=3))
+		self.assertEqual(self._qty(subject), 175)
+
+	def test_incremental_stays_one_row_per_period(self):
+		plan = _make_metered_family(
+			"SM Incr Family", "PDF Incr", "SM PDF Incr Plan", reporting_mode="Incremental"
+		)
+		subject = self._subject("PDF Incr", plan)
+		key = f"{subject}|Counter|2026-07"
+		for seq in range(1, 21):
+			self.metering.ingest_rollup(self._meter(subject, "PDF Incr", key, 1, sequence=seq))
+		self.assertEqual(frappe.db.count("Usage Rollup", {"resource_id": subject}), 1)
+		self.assertEqual(self._qty(subject), 20)

--- a/central/billing/tests/test_service_metering.py
+++ b/central/billing/tests/test_service_metering.py
@@ -7,6 +7,18 @@ pilot-authenticated service API."""
 import frappe
 from frappe.tests import IntegrationTestCase
 
+from central.billing.catalog import subscriptions
+from central.billing.tests.utils import complete_billing_profile, ensure_team, make_metered_plan
+
+
+def _ensure_resource_type(name: str) -> str:
+	"""A metered Plan's include links a Resource Type; ensure one exists for the test."""
+	if not frappe.db.exists("Resource Type", name):
+		frappe.get_doc({"doctype": "Resource Type", "resource_type_name": name}).insert(
+			ignore_permissions=True
+		)
+	return name
+
 
 class TestPlanCategoryModes(IntegrationTestCase):
 	"""settlement_mode / reporting_mode are per-family properties, blank resolving to
@@ -47,3 +59,63 @@ class TestPlanCategoryModes(IntegrationTestCase):
 		self.assertFalse(cat.reporting_mode)
 		self.assertEqual(cat.effective_settlement_mode, "Postpaid Overage")
 		self.assertEqual(cat.effective_reporting_mode, "Authoritative")
+
+
+class TestServiceSubjectProvisioning(IntegrationTestCase):
+	"""A team-level service is subscribed with a synthesized subject and no Asset
+	(ADR 0013): the segment opens inline and metering resolves it like any resource."""
+
+	TEAM = "svc-team-a"
+
+	def setUp(self):
+		ensure_team(self.TEAM)
+		complete_billing_profile(self.TEAM, currency="INR")
+		frappe.db.delete("Subscription", {"team": self.TEAM})
+		_ensure_resource_type("PDF Render")
+		self.plan = make_metered_plan("Svc PDF Render", resource_type="PDF Render", unit="doc")
+
+	def test_provision_synthesizes_subject_and_opens_segment(self):
+		res = subscriptions.provision_service_subscription(self.TEAM, self.plan, cluster="mumbai")
+
+		self.assertTrue(res["service_subject"].startswith("svc-"))
+		self.assertFalse(res["reused"])
+		self.assertEqual(res["currency"], "INR")
+
+		sub = frappe.get_doc("Subscription", res["subscription"])
+		self.assertEqual(sub.service_subject, res["service_subject"])
+		self.assertFalse(sub.asset_id)  # no VM Asset for a team-level service
+		self.assertEqual(sub.cluster, "mumbai")
+
+		# Metering resolves the subject off the ledger, just like a VM resource.
+		seg = subscriptions.active_segment_for_resource(res["service_subject"])
+		self.assertIsNotNone(seg)
+		self.assertEqual(seg.team, self.TEAM)
+		self.assertEqual(seg.cluster, "mumbai")
+		self.assertEqual(seg.currency, "INR")
+
+	def test_reprovision_same_service_is_idempotent(self):
+		first = subscriptions.provision_service_subscription(self.TEAM, self.plan, cluster="mumbai")
+		second = subscriptions.provision_service_subscription(self.TEAM, self.plan, cluster="mumbai")
+
+		self.assertEqual(first["service_subject"], second["service_subject"])
+		self.assertEqual(first["subscription"], second["subscription"])
+		self.assertTrue(second["reused"])
+		self.assertEqual(
+			frappe.db.count("Subscription", {"service_subject": first["service_subject"]}), 1
+		)
+
+	def test_different_cluster_is_a_distinct_subject(self):
+		mumbai = subscriptions.provision_service_subscription(self.TEAM, self.plan, cluster="mumbai")
+		blr = subscriptions.provision_service_subscription(self.TEAM, self.plan, cluster="blr")
+		self.assertNotEqual(mumbai["service_subject"], blr["service_subject"])
+
+	def test_server_plan_rejected_as_service(self):
+		from central.billing.tests.utils import make_plan
+
+		server_plan = make_plan("Svc Server Plan", rates=[{"cluster": "", "currency": "INR", "rate": 500}])
+		frappe.db.set_value(
+			"Plan Category", frappe.db.get_value("Plan", server_plan, "category"),
+			"provision_target", "Server",
+		)
+		with self.assertRaises(frappe.ValidationError):
+			subscriptions.provision_service_subscription(self.TEAM, server_plan, cluster="mumbai")

--- a/central/billing/tests/test_service_metering.py
+++ b/central/billing/tests/test_service_metering.py
@@ -383,3 +383,34 @@ class TestPrepaidSettlement(IntegrationTestCase):
 			self.TEAM, "mumbai", "2026-07-01", "2026-07-31"
 		)
 		self.assertEqual(lines, [])
+
+
+class TestAdminServices(IntegrationTestCase):
+	"""The operator console view of a team's metered services + subscribe/upgrade
+	(ADR 0015). Operator-gated, team explicit (an admin acts across teams)."""
+
+	TEAM = "svc-team-admin"
+
+	def setUp(self):
+		from central.billing.api.admin import services as admin_services
+
+		self.admin = admin_services
+		frappe.set_user("Administrator")
+		ensure_team(self.TEAM)
+		complete_billing_profile(self.TEAM, currency="INR")
+		frappe.db.delete("Subscription", {"team": self.TEAM})
+		self.plan = _make_metered_family("SM Admin Family", "PDF Admin", "SM PDF Admin Plan")
+
+	def test_get_team_services_lists_footprint_and_catalog(self):
+		self.admin.subscribe_team_service(self.TEAM, self.plan, cluster="mumbai")
+		out = self.admin.get_team_services(self.TEAM, cluster="mumbai")
+		self.assertEqual(out["currency"], "INR")
+		self.assertIn(self.plan, [s["plan"] for s in out["services"]])
+		self.assertIn(self.plan, [p["plan"] for p in out["available_plans"]])
+
+	def test_subscribe_team_service_provisions_subject(self):
+		res = self.admin.subscribe_team_service(self.TEAM, self.plan, cluster="mumbai")
+		self.assertTrue(res["service_subject"].startswith("svc-"))
+		self.assertEqual(
+			frappe.db.get_value("Subscription", res["subscription"], "team"), self.TEAM
+		)

--- a/central/billing/tests/test_service_metering.py
+++ b/central/billing/tests/test_service_metering.py
@@ -317,6 +317,20 @@ class TestServiceAPI(IntegrationTestCase):
 			500,
 		)
 
+	def test_global_service_reports_from_any_cluster(self):
+		# A globally-priced service is subscribed once with no cluster; a caller on any
+		# cluster (or none) reports to that one team-wide subject.
+		globally = self.subscribe_service(self.plan, cluster=None)["service_subject"]
+
+		from_mumbai = self.report_usage(service="PDF API", quantity=30, cluster="mumbai")
+		from_nowhere = self.report_usage(service="PDF API", quantity=70)  # authoritative replace
+		self.assertEqual(from_mumbai["service_subject"], globally)
+		self.assertEqual(from_nowhere["service_subject"], globally)
+		self.assertEqual(
+			frappe.utils.flt(frappe.db.get_value("Usage Rollup", {"resource_id": globally}, "quantity")),
+			70,
+		)
+
 	def test_report_usage_for_unsubscribed_service_is_rejected(self):
 		# A caller can only report for a service ITS OWN team is subscribed to — there is
 		# no subject to name, so another team's usage cannot be forged.

--- a/central/billing/tests/test_service_metering.py
+++ b/central/billing/tests/test_service_metering.py
@@ -223,3 +223,68 @@ class TestDualModeIngestion(IntegrationTestCase):
 			self.metering.ingest_rollup(self._meter(subject, "PDF Incr", key, 1, sequence=seq))
 		self.assertEqual(frappe.db.count("Usage Rollup", {"resource_id": subject}), 1)
 		self.assertEqual(self._qty(subject), 20)
+
+
+class TestServiceAPI(IntegrationTestCase):
+	"""The pilot-authenticated service facade (ADR 0015): list/subscribe/get/report,
+	with the team fixed from the credential so a pilot only touches its own team."""
+
+	TEAM = "svc-team-api"
+	OTHER = "svc-team-other"
+
+	def setUp(self):
+		import inspect
+
+		from central.billing.api import billing_api
+
+		# Fully unwrap the whitelist + pilot-auth decorators to reach the facade body,
+		# then exercise it with a stubbed credential (there is no request in tests).
+		self.list_service_plans = inspect.unwrap(billing_api.list_service_plans)
+		self.subscribe_service = inspect.unwrap(billing_api.subscribe_service)
+		self.get_service_subscription = inspect.unwrap(billing_api.get_service_subscription)
+		self.report_usage = inspect.unwrap(billing_api.report_usage)
+		for t in (self.TEAM, self.OTHER):
+			ensure_team(t)
+			complete_billing_profile(t, currency="INR")
+			frappe.db.delete("Subscription", {"team": t})
+		frappe.db.delete("Usage Rollup", {"team": self.TEAM})
+		self.plan = _make_metered_family("SM API Family", "PDF API", "SM PDF API Plan")
+		self._act_as(self.TEAM)
+
+	def _act_as(self, team):
+		frappe.local.pilot_credential = frappe._dict(team=team)
+
+	def test_list_service_plans_priced_for_team_currency(self):
+		out = self.list_service_plans(cluster="mumbai")
+		self.assertEqual(out["currency"], "INR")
+		self.assertIn(self.plan, [p["plan"] for p in out["plans"]])
+
+	def test_subscribe_then_get_and_report(self):
+		sub = self.subscribe_service(self.plan, cluster="mumbai")
+		subject = sub["service_subject"]
+
+		services = self.get_service_subscription()["services"]
+		self.assertIn(subject, [s["service_subject"] for s in services])
+
+		res = self.report_usage(
+			service_subject=subject, resource_type="PDF API", quantity=500,
+			period_start="2026-07-01 00:00:00", period_end="2026-07-31 23:59:59",
+			idempotency_key=f"{subject}|Counter|2026-07",
+		)
+		self.assertTrue(res["recorded"])
+		self.assertEqual(
+			frappe.utils.flt(frappe.db.get_value("Usage Rollup", {"resource_id": subject}, "quantity")),
+			500,
+		)
+
+	def test_report_usage_for_foreign_subject_is_rejected(self):
+		# A subject owned by another team must not be reportable by this credential.
+		self._act_as(self.OTHER)
+		foreign = self.subscribe_service(self.plan, cluster="mumbai")["service_subject"]
+		self._act_as(self.TEAM)
+		with self.assertRaises(frappe.PermissionError):
+			self.report_usage(
+				service_subject=foreign, resource_type="PDF API", quantity=10,
+				period_start="2026-07-01 00:00:00", period_end="2026-07-31 23:59:59",
+				idempotency_key=f"{foreign}|Counter|2026-07",
+			)

--- a/central/billing/tests/test_service_metering.py
+++ b/central/billing/tests/test_service_metering.py
@@ -22,7 +22,7 @@ def _ensure_resource_type(name: str) -> str:
 
 def _make_metered_family(
 	category, resource_type, plan, reporting_mode="Authoritative",
-	settlement_mode="Postpaid Overage", allowance=0, rate=0.5,
+	settlement_mode="Postpaid Overage", allowance=0, rate=0.5, pricing_mode="Grandfathered",
 ):
 	"""A metered single-resource Plan under a dedicated Plan Category carrying explicit
 	reporting + settlement modes and an included allowance — so a test can exercise
@@ -39,7 +39,7 @@ def _make_metered_family(
 	frappe.get_doc(
 		{
 			"doctype": "Plan Category", "category_name": category, "billing_type": "Metered",
-			"pricing_mode": "Grandfathered", "reporting_mode": reporting_mode,
+			"pricing_mode": pricing_mode, "reporting_mode": reporting_mode,
 			"settlement_mode": settlement_mode,
 		}
 	).insert(ignore_permissions=True)
@@ -329,6 +329,36 @@ class TestServiceAPI(IntegrationTestCase):
 		self.assertEqual(
 			frappe.utils.flt(frappe.db.get_value("Usage Rollup", {"resource_id": globally}, "quantity")),
 			70,
+		)
+
+	def test_live_priced_service_reports_with_billing_context(self):
+		# A Live-priced family reads team/cluster/currency from the meter payload; the
+		# subject's segment must supply them, or the rollup lands context-less and is
+		# missed at invoicing.
+		from central.billing.revenue.metering import metered_line_items
+
+		live = _make_metered_family(
+			"SM Live Family", "PDF Live", "SM PDF Live Plan", pricing_mode="Live", rate=2.0
+		)
+		res_sub = self.subscribe_service(live, cluster=None)  # global Live service
+		res = self.report_usage(service="PDF Live", quantity=300)
+		subject = res_sub["service_subject"]
+		self.assertTrue(res["recorded"])
+
+		row = frappe.db.get_value(
+			"Usage Rollup", {"resource_id": subject}, ["team", "cluster", "currency"], as_dict=True
+		)
+		self.assertEqual(row.team, self.TEAM)     # was null before the context fix
+		self.assertEqual(row.currency, "INR")     # Live reads currency off the payload
+
+		# It bills: Live reads the current catalog rate at invoice time (300 x 2.0).
+		lines = metered_line_items(
+			self.TEAM, row.cluster,
+			frappe.utils.get_first_day(frappe.utils.nowdate()),
+			frappe.utils.get_last_day(frappe.utils.nowdate()),
+		)
+		self.assertTrue(
+			any(l["subscription_resource"] == subject and l["amount"] == 600.0 for l in lines)
 		)
 
 	def test_report_usage_for_unsubscribed_service_is_rejected(self):

--- a/central/billing/tests/test_service_metering.py
+++ b/central/billing/tests/test_service_metering.py
@@ -254,6 +254,43 @@ class TestDualModeIngestion(IntegrationTestCase):
 		self.metering.ingest_rollup(self._meter(subject, "PDF Incr", key, 25, sequence=3))
 		self.assertEqual(self._qty(subject), 175)
 
+	def test_first_insert_race_reapplies_lost_delta(self):
+		# Two concurrent FIRST reports both miss the not-yet-existent row and race to
+		# insert; the loser hits the unique idempotency_key. Simulate that (lock-miss +
+		# duplicate insert) and assert the loser's delta is re-applied to the winner's
+		# row, not dropped.
+		from unittest.mock import patch
+
+		plan = _make_metered_family(
+			"SM Race Family", "PDF Race", "SM PDF Race Plan", reporting_mode="Incremental"
+		)
+		subject = self._subject("PDF Race", plan)
+		key = f"{subject}|Counter|2026-07"
+		self.metering.ingest_rollup(self._meter(subject, "PDF Race", key, 100, sequence=1))  # winner
+
+		orig_gv, orig_ins = frappe.db.get_value, self.metering._insert_rollup
+		state = {"missed": False, "raised": False}
+
+		def gv(doctype, filters=None, *a, **k):
+			if (not state["missed"] and doctype == "Usage Rollup"
+					and isinstance(filters, dict) and filters.get("idempotency_key") == key):
+				state["missed"] = True
+				return None  # our first-report lock-miss
+			return orig_gv(doctype, filters, *a, **k)
+
+		def ins(*a, **k):
+			if not state["raised"]:
+				state["raised"] = True
+				raise frappe.DuplicateEntryError  # we lose the unique-key race
+			return orig_ins(*a, **k)
+
+		with patch.object(frappe.db, "get_value", side_effect=gv), \
+				patch.object(self.metering, "_insert_rollup", side_effect=ins):
+			self.metering.ingest_rollup(self._meter(subject, "PDF Race", key, 50, sequence=2))
+
+		self.assertEqual(self._qty(subject), 150)  # 100 + 50 — the racing delta survived
+		self.assertEqual(frappe.db.count("Usage Rollup", {"resource_id": subject}), 1)
+
 	def test_incremental_stays_one_row_per_period(self):
 		plan = _make_metered_family(
 			"SM Incr Family", "PDF Incr", "SM PDF Incr Plan", reporting_mode="Incremental"

--- a/central/billing/tests/test_service_metering.py
+++ b/central/billing/tests/test_service_metering.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Consumer-service metered billing (ADR 0015): per-family settlement + reporting
+mode, synthesized team-level subjects, dual-mode usage ingestion, and the
+pilot-authenticated service API."""
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+
+class TestPlanCategoryModes(IntegrationTestCase):
+	"""settlement_mode / reporting_mode are per-family properties, blank resolving to
+	the built default; both are meaningless on a Fixed family (ADR 0015)."""
+
+	def _category(self, name, billing_type="Metered", **kwargs):
+		if frappe.db.exists("Plan Category", name):
+			frappe.delete_doc("Plan Category", name, force=True)
+		doc = frappe.get_doc(
+			{"doctype": "Plan Category", "category_name": name, "billing_type": billing_type, **kwargs}
+		)
+		doc.insert(ignore_permissions=True)
+		return doc
+
+	def test_blank_modes_resolve_to_built_defaults(self):
+		cat = self._category("SM Metered Blank")
+		self.assertEqual(cat.effective_settlement_mode, "Postpaid Overage")
+		self.assertEqual(cat.effective_reporting_mode, "Authoritative")
+
+	def test_explicit_modes_are_honoured(self):
+		cat = self._category(
+			"SM Prepaid Incremental",
+			settlement_mode="Prepaid Pack",
+			reporting_mode="Incremental",
+		)
+		self.assertEqual(cat.effective_settlement_mode, "Prepaid Pack")
+		self.assertEqual(cat.effective_reporting_mode, "Incremental")
+
+	def test_modes_cleared_on_fixed_family(self):
+		cat = self._category(
+			"SM Fixed Bundle",
+			billing_type="Fixed",
+			settlement_mode="Prepaid Pack",
+			reporting_mode="Incremental",
+		)
+		# A bundle has no metered reporting — the controller blanks both on validate.
+		self.assertFalse(cat.settlement_mode)
+		self.assertFalse(cat.reporting_mode)
+		self.assertEqual(cat.effective_settlement_mode, "Postpaid Overage")
+		self.assertEqual(cat.effective_reporting_mode, "Authoritative")

--- a/central/billing/tests/test_service_metering.py
+++ b/central/billing/tests/test_service_metering.py
@@ -307,28 +307,22 @@ class TestServiceAPI(IntegrationTestCase):
 		services = self.get_service_subscription()["services"]
 		self.assertIn(subject, [s["service_subject"] for s in services])
 
-		res = self.report_usage(
-			service_subject=subject, resource_type="PDF API", quantity=500,
-			period_start="2026-07-01 00:00:00", period_end="2026-07-31 23:59:59",
-			idempotency_key=f"{subject}|Counter|2026-07",
-		)
+		# The consumer service names only the service it is + the quantity; Central
+		# derives the subject, period and idempotency key from the credential.
+		res = self.report_usage(service="PDF API", quantity=500, cluster="mumbai")
 		self.assertTrue(res["recorded"])
+		self.assertEqual(res["service_subject"], subject)
 		self.assertEqual(
 			frappe.utils.flt(frappe.db.get_value("Usage Rollup", {"resource_id": subject}, "quantity")),
 			500,
 		)
 
-	def test_report_usage_for_foreign_subject_is_rejected(self):
-		# A subject owned by another team must not be reportable by this credential.
-		self._act_as(self.OTHER)
-		foreign = self.subscribe_service(self.plan, cluster="mumbai")["service_subject"]
-		self._act_as(self.TEAM)
-		with self.assertRaises(frappe.PermissionError):
-			self.report_usage(
-				service_subject=foreign, resource_type="PDF API", quantity=10,
-				period_start="2026-07-01 00:00:00", period_end="2026-07-31 23:59:59",
-				idempotency_key=f"{foreign}|Counter|2026-07",
-			)
+	def test_report_usage_for_unsubscribed_service_is_rejected(self):
+		# A caller can only report for a service ITS OWN team is subscribed to — there is
+		# no subject to name, so another team's usage cannot be forged.
+		self._act_as(self.OTHER)  # OTHER never subscribed to PDF API
+		with self.assertRaises(frappe.ValidationError):
+			self.report_usage(service="PDF API", quantity=10, cluster="mumbai")
 
 
 class TestPrepaidSettlement(IntegrationTestCase):

--- a/central/billing/tests/test_service_metering.py
+++ b/central/billing/tests/test_service_metering.py
@@ -149,6 +149,42 @@ class TestServiceSubjectProvisioning(IntegrationTestCase):
 		blr = subscriptions.provision_service_subscription(self.TEAM, self.plan, cluster="blr")
 		self.assertNotEqual(mumbai["service_subject"], blr["service_subject"])
 
+	def test_upgrade_within_family_keeps_subject_and_relocks(self):
+		# Subject is keyed on the family, so switching a team onto a newer plan in the
+		# same family (a catalog swap — only one metered plan per resource type may be
+		# active, ADR 0008) is an upgrade that stays on the same subject and re-locks.
+		from central.billing.catalog.pricing import set_catalog_rates
+		from central.billing.tests.utils import _ensure_rate_instances
+
+		cat = "SM Upgrade Family"
+		small = _make_metered_family(cat, "Tokens Up", "SM Tokens Small", rate=0.01, allowance=1000)
+		first = subscriptions.provision_service_subscription(self.TEAM, small, cluster="mumbai")
+
+		# Retire the small plan and publish a bigger one in the same family.
+		frappe.db.set_value("Plan", small, "is_active", 0)
+		big = frappe.get_doc(
+			{
+				"doctype": "Plan", "title": "SM Tokens Big", "category": cat,
+				"billing_cycle": "Monthly", "is_active": 1,
+				"includes": [{"resource_type": "Tokens Up", "quantity": 5000, "unit": "unit"}],
+			}
+		)
+		big.name = "SM Tokens Big"
+		big.flags.name_set = True
+		big.insert(ignore_permissions=True)
+		rates = [{"cluster": "", "currency": "INR", "rate": 0.008}]
+		_ensure_rate_instances(rates)
+		set_catalog_rates("Plan", big.name, rates)
+
+		upgrade = subscriptions.provision_service_subscription(self.TEAM, "SM Tokens Big", cluster="mumbai")
+
+		self.assertEqual(first["service_subject"], upgrade["service_subject"])
+		self.assertEqual(first["subscription"], upgrade["subscription"])
+		self.assertTrue(upgrade["upgraded"])
+		self.assertEqual(
+			frappe.db.get_value("Subscription", upgrade["subscription"], "plan"), "SM Tokens Big"
+		)
+
 	def test_server_plan_rejected_as_service(self):
 		from central.billing.tests.utils import make_plan
 

--- a/central/billing/tests/test_service_metering.py
+++ b/central/billing/tests/test_service_metering.py
@@ -291,6 +291,33 @@ class TestDualModeIngestion(IntegrationTestCase):
 		self.assertEqual(self._qty(subject), 150)  # 100 + 50 — the racing delta survived
 		self.assertEqual(frappe.db.count("Usage Rollup", {"resource_id": subject}), 1)
 
+	def test_exhausted_insert_race_does_not_acknowledge(self):
+		# If every retry loses the race without ever persisting, ingest must return None
+		# (not the key) so the reporter does not mark the batch synced over missing usage.
+		from unittest.mock import patch
+
+		plan = _make_metered_family(
+			"SM Exhaust Family", "PDF Exh", "SM PDF Exh Plan", reporting_mode="Incremental"
+		)
+		subject = self._subject("PDF Exh", plan)
+		key = f"{subject}|Counter|2026-07"
+		orig_gv = frappe.db.get_value
+
+		def gv(doctype, filters=None, *a, **k):
+			if doctype == "Usage Rollup" and isinstance(filters, dict) and filters.get("idempotency_key") == key:
+				return None  # every read misses
+			return orig_gv(doctype, filters, *a, **k)
+
+		def ins(*a, **k):
+			raise frappe.DuplicateEntryError  # every insert loses
+
+		with patch.object(frappe.db, "get_value", side_effect=gv), \
+				patch.object(self.metering, "_insert_rollup", side_effect=ins):
+			result = self.metering.ingest_rollup(self._meter(subject, "PDF Exh", key, 50, sequence=1))
+
+		self.assertIsNone(result)  # not acknowledged
+		self.assertEqual(frappe.db.count("Usage Rollup", {"resource_id": subject}), 0)
+
 	def test_incremental_stays_one_row_per_period(self):
 		plan = _make_metered_family(
 			"SM Incr Family", "PDF Incr", "SM PDF Incr Plan", reporting_mode="Incremental"

--- a/central/billing/tests/test_service_metering.py
+++ b/central/billing/tests/test_service_metering.py
@@ -20,10 +20,14 @@ def _ensure_resource_type(name: str) -> str:
 	return name
 
 
-def _make_metered_family(category, resource_type, plan, reporting_mode="Authoritative", rate=0.5):
-	"""A metered single-resource Plan under a dedicated Plan Category carrying an explicit
-	reporting_mode — so a test can exercise incremental accumulation without mutating a
-	shared category. Returns the plan name."""
+def _make_metered_family(
+	category, resource_type, plan, reporting_mode="Authoritative",
+	settlement_mode="Postpaid Overage", allowance=0, rate=0.5,
+):
+	"""A metered single-resource Plan under a dedicated Plan Category carrying explicit
+	reporting + settlement modes and an included allowance — so a test can exercise
+	incremental accumulation / prepaid draw-down without mutating a shared category.
+	Returns the plan name."""
 	from central.billing.catalog.pricing import set_catalog_rates
 	from central.billing.tests.utils import _ensure_rate_instances
 
@@ -36,6 +40,7 @@ def _make_metered_family(category, resource_type, plan, reporting_mode="Authorit
 		{
 			"doctype": "Plan Category", "category_name": category, "billing_type": "Metered",
 			"pricing_mode": "Grandfathered", "reporting_mode": reporting_mode,
+			"settlement_mode": settlement_mode,
 		}
 	).insert(ignore_permissions=True)
 
@@ -43,7 +48,7 @@ def _make_metered_family(category, resource_type, plan, reporting_mode="Authorit
 		{
 			"doctype": "Plan", "title": plan, "category": category, "billing_cycle": "Monthly",
 			"is_active": 1,
-			"includes": [{"resource_type": resource_type, "quantity": 0, "unit": "unit"}],
+			"includes": [{"resource_type": resource_type, "quantity": allowance, "unit": "unit"}],
 		}
 	)
 	doc.name = plan
@@ -288,3 +293,57 @@ class TestServiceAPI(IntegrationTestCase):
 				period_start="2026-07-01 00:00:00", period_end="2026-07-31 23:59:59",
 				idempotency_key=f"{foreign}|Counter|2026-07",
 			)
+
+
+class TestPrepaidSettlement(IntegrationTestCase):
+	"""A Prepaid Pack family draws its allowance down as usage lands, blocks at zero,
+	and bills no overage — the pack is paid up front (ADR 0015)."""
+
+	TEAM = "svc-team-prepaid"
+
+	def setUp(self):
+		from central.billing.revenue import metering
+
+		self.metering = metering
+		ensure_team(self.TEAM)
+		complete_billing_profile(self.TEAM, currency="INR")
+		frappe.db.delete("Subscription", {"team": self.TEAM})
+		frappe.db.delete("Usage Rollup", {"team": self.TEAM})
+		self.plan = _make_metered_family(
+			"SM Prepaid Family", "Tokens Pre", "SM Tokens Pack",
+			settlement_mode="Prepaid Pack", allowance=1000, rate=0.01,
+		)
+		res = subscriptions.provision_service_subscription(self.TEAM, self.plan, cluster="mumbai")
+		self.subject = res["service_subject"]
+
+	def _report(self, qty):
+		self.metering.ingest_rollup({
+			"resource_id": self.subject, "resource_type": "Tokens Pre", "meter_type": "Counter",
+			"period_start": "2026-07-01 00:00:00", "period_end": "2026-07-31 23:59:59",
+			"quantity": qty, "unit": "unit", "idempotency_key": f"{self.subject}|Counter|2026-07",
+		})
+
+	def test_within_allowance_not_blocked(self):
+		from central.billing.catalog.services import service_allowance
+
+		self._report(400)
+		state = service_allowance(self.TEAM, self.subject)
+		self.assertEqual(state["remaining"], 600)
+		self.assertFalse(state["blocked"])
+
+	def test_exhausted_allowance_blocks(self):
+		from central.billing.catalog.services import service_allowance
+
+		self._report(1000)
+		state = service_allowance(self.TEAM, self.subject)
+		self.assertEqual(state["remaining"], 0)
+		self.assertTrue(state["blocked"])
+
+	def test_prepaid_usage_bills_no_overage(self):
+		# 1500 used against a 1000 pack — a postpaid family would bill 500 of overage; a
+		# prepaid one bills nothing (excess is blocked, not charged).
+		self._report(1500)
+		lines = self.metering.metered_line_items(
+			self.TEAM, "mumbai", "2026-07-01", "2026-07-31"
+		)
+		self.assertEqual(lines, [])

--- a/central/www/dashboard.html
+++ b/central/www/dashboard.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Central Console</title>
-    <script type="module" crossorigin src="/assets/central/dashboard/assets/index-C2Cah0Do.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/central/dashboard/assets/index-CvVpVqms.css">
+    <script type="module" crossorigin src="/assets/central/dashboard/assets/index-BT7cbKqG.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/central/dashboard/assets/index-CvfeGc75.css">
   </head>
   <body>
     <div id="app"></div>

--- a/console/src/api/methods.ts
+++ b/console/src/api/methods.ts
@@ -76,6 +76,7 @@ export const API = {
   paymentMethods: 'central.billing.api.dashboard.list_payment_methods',
   paymentMethodOptions: 'central.billing.api.dashboard.get_payment_method_options',
   subscriptions: 'central.billing.api.dashboard.list_subscriptions',
+  meteredServices: 'central.billing.api.dashboard.get_metered_services',
   billingProfile: 'central.billing.api.dashboard.get_billing_profile',
   billingGeo: 'central.billing.api.dashboard.get_billing_geo',
   billingSettings: 'central.billing.api.dashboard.get_billing_settings',
@@ -103,4 +104,5 @@ export const API = {
   saveNotificationPreferences: 'central.billing.api.dashboard.save_notification_preferences',
   pauseSubscription: 'central.billing.api.dashboard.pause_subscription',
   resumeSubscription: 'central.billing.api.dashboard.resume_subscription',
+  subscribeMeteredService: 'central.billing.api.dashboard.subscribe_metered_service',
 } as const

--- a/console/src/components/billing/MeteredServicesCard.vue
+++ b/console/src/components/billing/MeteredServicesCard.vue
@@ -1,0 +1,154 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { Badge, Button, useCall } from 'frappe-ui'
+import BillingCard from '@/components/billing/BillingCard.vue'
+import EmptyState from '@/components/common/EmptyState.vue'
+import SubscribeServiceDialog from '@/components/billing/SubscribeServiceDialog.vue'
+import type { ServicePlanOption } from '@/components/billing/SubscribeServiceDialog.vue'
+import { API, method } from '@/api/methods'
+import { useSession } from '@/composables/useSession'
+import { whenTeamReady } from '@/composables/useTeamScope'
+import { useCapabilities } from '@/composables/useCapabilities'
+
+// Metered services (ADR 0015) — the team-level services it has subscribed to (AI
+// tokens, email, PDF, storage), each with its allowance draw-down / usage this
+// period, plus a subscribe/upgrade action. A metered service has no VM: it is a
+// synthesized subject billed off the same rollup + price-lock spine as a server.
+interface ServiceRow {
+  service_subject: string
+  plan: string
+  title: string | null
+  cluster: string | null
+  currency: string
+  unit: string | null
+  billing_type: string | null
+  settlement_mode: string
+  reporting_mode: string
+  allowance: number
+  period_usage: number
+}
+interface MeteredServices {
+  currency: string
+  services: ServiceRow[]
+  available_plans: ServicePlanOption[]
+}
+
+const { canManageBilling } = useCapabilities()
+const { activeTeam } = useSession()
+
+const data = useCall<MeteredServices, { team: string }>({
+  url: method(API.meteredServices),
+  params: () => ({ team: activeTeam.value! }),
+  immediate: false,
+  refetch: true,
+})
+whenTeamReady(() => data.reload())
+
+const loading = computed(() => data.loading && !data.data)
+const rows = computed(() => data.data?.services ?? [])
+const plans = computed(() => data.data?.available_plans ?? [])
+const currency = computed(() => data.data?.currency ?? 'INR')
+
+const dialogOpen = ref(false)
+
+function subtitle(row: ServiceRow): string {
+  const parts: string[] = []
+  if (row.title) parts.push(row.title)
+  if (row.cluster) parts.push(row.cluster)
+  return parts.join(' · ') || row.service_subject
+}
+
+// A prepaid pack shows remaining allowance; a postpaid meter shows usage this period.
+function usageLabel(row: ServiceRow): string {
+  const unit = row.unit || 'units'
+  if (row.settlement_mode === 'Prepaid Pack' && row.allowance) {
+    const remaining = Math.max(0, row.allowance - row.period_usage)
+    return `${remaining.toLocaleString()} / ${row.allowance.toLocaleString()} ${unit} left`
+  }
+  const included = row.allowance ? ` of ${row.allowance.toLocaleString()} incl.` : ''
+  return `${row.period_usage.toLocaleString()} ${unit}${included} this period`
+}
+
+function exhausted(row: ServiceRow): boolean {
+  return (
+    row.settlement_mode === 'Prepaid Pack' &&
+    row.allowance > 0 &&
+    row.period_usage >= row.allowance
+  )
+}
+</script>
+
+<template>
+  <BillingCard
+    title="Metered services"
+    title-info="Team-level services billed by usage (AI tokens, email, PDF, storage) — no server required."
+  >
+    <template v-if="canManageBilling && plans.length" #action>
+      <Button label="Add service" @click="dialogOpen = true">
+        <template #prefix>
+          <span class="lucide-plus size-4" aria-hidden="true" />
+        </template>
+      </Button>
+    </template>
+
+    <div v-if="loading" class="space-y-3 py-1">
+      <div v-for="i in 2" :key="i" class="flex items-center gap-3">
+        <span class="size-4 shrink-0 animate-pulse rounded bg-surface-gray-2" />
+        <div class="flex-1 space-y-1.5">
+          <span class="block h-3.5 w-40 animate-pulse rounded bg-surface-gray-2" />
+          <span class="block h-3 w-28 animate-pulse rounded bg-surface-gray-2" />
+        </div>
+      </div>
+    </div>
+
+    <div v-else-if="rows.length" class="divide-y divide-outline-gray-1">
+      <div
+        v-for="row in rows"
+        :key="row.service_subject"
+        class="flex items-center justify-between gap-3 py-3"
+      >
+        <div class="flex min-w-0 items-start gap-2.5">
+          <span
+            class="lucide-gauge mt-0.5 size-4 shrink-0 text-ink-gray-5"
+            aria-hidden="true"
+          />
+          <div class="min-w-0">
+            <div class="flex items-center gap-2">
+              <span class="truncate text-sm font-medium text-ink-gray-9">
+                {{ row.title || row.plan }}
+              </span>
+              <Badge v-if="exhausted(row)" theme="orange" label="Exhausted" />
+              <Badge
+                v-else-if="row.settlement_mode === 'Prepaid Pack'"
+                theme="blue"
+                label="Prepaid"
+              />
+            </div>
+            <div class="truncate text-p-sm text-ink-gray-5">{{ subtitle(row) }}</div>
+          </div>
+        </div>
+        <span class="shrink-0 text-sm font-medium tabular-nums text-ink-gray-9">
+          {{ usageLabel(row) }}
+        </span>
+      </div>
+    </div>
+
+    <EmptyState
+      v-else
+      icon="lucide-gauge"
+      title="No metered services"
+      description="Subscribe to a usage-billed service like AI tokens, email, or PDF rendering."
+    >
+      <template v-if="canManageBilling && plans.length" #action>
+        <Button variant="solid" theme="gray" label="Add service" @click="dialogOpen = true" />
+      </template>
+    </EmptyState>
+
+    <SubscribeServiceDialog
+      v-model:open="dialogOpen"
+      :plans="plans"
+      :currency="currency"
+      @subscribed="data.reload()"
+    />
+  </BillingCard>
+</template>

--- a/console/src/components/billing/SubscribeServiceDialog.vue
+++ b/console/src/components/billing/SubscribeServiceDialog.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { Dialog, FormControl, useCall } from 'frappe-ui'
+import { API, method } from '@/api/methods'
+import { useSession } from '@/composables/useSession'
+import { money } from '@/lib/format'
+import { successToast, errorToast } from '@/lib/toast'
+
+// Subscribe the team to a team-level metered service, or switch it onto a different
+// plan in the same family (an upgrade). Controlled by the page via v-model:open; the
+// available plans + currency come from the parent's already-loaded read, so the
+// dialog stays a thin form over `subscribeMeteredService`.
+export interface ServicePlanOption {
+  plan: string
+  title: string
+  billing_type: string
+  settlement_mode: string
+  unit: string | null
+  allowance: number
+  rate: number | null
+}
+
+const props = defineProps<{
+  open: boolean
+  plans: ServicePlanOption[]
+  currency: string
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  subscribed: []
+}>()
+
+const open = computed({
+  get: () => props.open,
+  set: (v: boolean) => emit('update:open', v),
+})
+
+const plan = ref('')
+const cluster = ref('')
+
+// Reset the selection each time the dialog opens, defaulting to the first plan.
+watch(open, (isOpen) => {
+  if (isOpen) {
+    plan.value = props.plans[0]?.plan ?? ''
+    cluster.value = ''
+  }
+})
+
+const options = computed(() =>
+  props.plans.map((p) => ({ label: planLabel(p), value: p.plan })),
+)
+
+function planLabel(p: ServicePlanOption): string {
+  const price =
+    p.rate == null
+      ? 'unpriced'
+      : `${money(p.rate, props.currency, { trimTrailingZeros: true })}/${p.unit || 'unit'}`
+  const included = p.allowance ? `, ${p.allowance.toLocaleString()} ${p.unit || 'unit'} included` : ''
+  return `${p.title} — ${price}${included}`
+}
+
+const { activeTeam } = useSession()
+
+const subscribe = useCall<
+  { service_subject: string; upgraded: boolean },
+  { team: string | null; plan: string; cluster: string | undefined }
+>({
+  url: method(API.subscribeMeteredService),
+  method: 'POST',
+  immediate: false,
+})
+
+async function onSubmit(): Promise<void> {
+  if (!plan.value) return
+  try {
+    await subscribe.submit({
+      team: activeTeam.value,
+      plan: plan.value,
+      cluster: cluster.value || undefined,
+    })
+    successToast(subscribe.data?.upgraded ? 'Service plan updated.' : 'Service subscribed.')
+    emit('subscribed')
+    open.value = false
+  } catch (e) {
+    errorToast(e)
+  }
+}
+
+const actions = computed(() => [
+  {
+    label: 'Subscribe',
+    variant: 'solid' as const,
+    loading: subscribe.loading,
+    disabled: !plan.value,
+    onClick: onSubmit,
+  },
+])
+</script>
+
+<template>
+  <Dialog v-model="open" title="Subscribe to a service" :actions="actions">
+    <template #body-content>
+      <div class="space-y-4">
+        <FormControl
+          type="select"
+          v-model="plan"
+          :options="options"
+          label="Service plan"
+          description="Metered services bill per unit of usage; a bundle includes an allowance."
+        />
+        <FormControl
+          v-model="cluster"
+          label="Cluster"
+          description="Optional — leave blank for a globally-priced service."
+          placeholder="e.g. mumbai"
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>

--- a/console/src/pages/billing/BillingOverviewPage.vue
+++ b/console/src/pages/billing/BillingOverviewPage.vue
@@ -9,6 +9,7 @@ import WalletHistoryPanel from '@/components/billing/WalletHistoryPanel.vue'
 import PaymentMethodsCard from '@/components/billing/PaymentMethodsCard.vue'
 import BillingContactTaxCard from '@/components/billing/BillingContactTaxCard.vue'
 import SubscriptionsCard from '@/components/billing/SubscriptionsCard.vue'
+import MeteredServicesCard from '@/components/billing/MeteredServicesCard.vue'
 import StopBillingCard from '@/components/billing/StopBillingCard.vue'
 import EditBillingProfileDialog from '@/components/billing/EditBillingProfileDialog.vue'
 import { useBillingSetup } from '@/composables/useBillingSetup'
@@ -61,6 +62,7 @@ const showWalletHistory = ref(false)
           <PaymentMethodsCard />
           <BillingContactTaxCard @edit="setupDialogOpen = true" />
           <SubscriptionsCard />
+          <MeteredServicesCard />
           <StopBillingCard />
         </div>
       </div>


### PR DESCRIPTION
Problem

Central bills metered usage only for VM-bound resources — every metered subject is reached through a Subscription's asset_id, and usage is metered from the cluster manager, pull-style (record_meter_rollups is deliberately internal: "any caller could forge usage").

That leaves a whole class of offerings with no billing path:

- Bundled services — AI tokens ($20 → 1M), email ($5 → 10k): a price + an included allowance, no server.
- Per-unit micro-services — a shared PDF renderer ($0.0001/doc), streaming S3 backup, snapshot maintenance: pure count × rate, no server.

These run on a cluster but attribute to a team, not to a customer-owned VM, and the consumer services need to discover plans, subscribe in-app, read their subscription, and push usage over an authenticated API. ADR 0013 settled the subject model but explicitly deferred the API/reporting/settlement contract.

Solution

A team-level service is a metered Plan over a synthesized (team, family, cluster) subject — no Asset — billed off the existing rollup + price-lock + invoicing spine. New behaviour is confined to subject synthesis, two per-family modes, a dual-mode ingest branch, and the API surface. Full contract in ADR 0015.

- Synthesized subject (Subscription.service_subject, cluster on the Subscription). VM-oriented sweeps (server list, backfill, Atlas gone-reconciliation) key on Asset and ignore it. Keyed on family, so an upgrade re-locks the same subject and keeps usage continuous.
- Reporting mode (per Plan Category): Authoritative re-push replaces the period total (unchanged behaviour); Incremental accumulates deltas, deduped by a monotonic sequence cursor — one rollup row per period either way, so tables stay bounded.
- Settlement mode (per Plan Category): Postpaid Overage bills max(0, qty−allowance) × rate; Prepaid Pack draws the allowance down and blocks at zero (edge-enforced), billing no overage.
- Auth: reuses the pilot credential — the team is taken from the credential, never a parameter, so a pilot reports only its own team's usage (IDOR defence).
- Console: a team-scoped Metered services card on the billing overview with usage/allowance draw-down and a subscribe/upgrade dialog; plus operator and customer-dashboard endpoints.

Everything is auditable end-to-end: report → Usage Rollup (bounded, idempotent) → Invoice Line Item → Invoice.

API endpoints to consume

Consumer service → Central (central.billing.api.billing_api, header X-Pilot-Token, team from the credential):
| Method | HTTP | Params | Returns |
| --- | --- | --- | --- |
| `list_service_plans` | GET | `cluster?` | `{ plans[], currency }` — priced for the team's currency |
| `subscribe_service` | POST | `plan`, `cluster?` | `{ subscription, service_subject, reused, upgraded, locked_rate, currency }` |
| `get_service_subscription` | GET | — | `{ services[] }` (subject, plan, modes, allowance, `period_usage`) |
| `check_service_allowance` | GET | `service_subject` | `{ exists, allowance, used, remaining, blocked, settlement_mode }` |
| `report_usage` | POST | `service_subject`, `resource_type`, `quantity`, `period_start`, `period_end`, `idempotency_key`, `meter_type?="Counter"`, `sequence?=0` | `{ recorded, idempotency_key }` |

report_usage contract by family reporting mode:
- Authoritative (token manager, email): send the period's running total; idempotency_key = period identity → replaced.
- Incremental (PDF micro-service): send a delta + a monotonic sequence; batches accumulate and dedupe.

POST /api/v2/method/central.billing.api.billing_api.report_usage
X-Pilot-Token: <token>
{ "service_subject":"svc-…", "resource_type":"PDF Render", "quantity":500,
  "period_start":"2026-07-01 00:00:00", "period_end":"2026-07-31 23:59:59",
  "idempotency_key":"svc-…|Counter|2026-07", "sequence":7 }

Customer dashboard (central.billing.api.dashboard, session user, capability-gated):
- get_metered_services(team?, cluster?) — GET, billing:view → { currency, services[], available_plans[] }
- subscribe_metered_service(plan, cluster?, team?) — POST, billing:manage

Admin console (central.billing.api.admin.services, operator, team explicit):
- get_team_services(team, cluster?) — GET
- subscribe_team_service(team, plan, cluster?) — POST