### PR TITLE
dix: Payment failure granularity

### DIFF
--- a/central/billing/doctype/payment_attempt/payment_attempt.json
+++ b/central/billing/doctype/payment_attempt/payment_attempt.json
@@ -26,7 +26,9 @@
   "completed_at",
   "section_break_failure",
   "failure_code",
-  "failure_reason"
+  "decline_code",
+  "failure_reason",
+  "gateway_response"
  ],
  "fields": [
   {
@@ -129,12 +131,26 @@
   {
    "fieldname": "failure_code",
    "fieldtype": "Data",
-   "label": "Failure Code"
+   "label": "Failure Code",
+   "description": "Gateway top-level error code (Stripe error.code / Razorpay error.reason)"
+  },
+  {
+   "fieldname": "decline_code",
+   "fieldtype": "Data",
+   "label": "Decline Code",
+   "description": "Granular decline reason (Stripe decline_code — insufficient_funds, lost_card, …); why the card_declined family actually failed"
   },
   {
    "fieldname": "failure_reason",
    "fieldtype": "Small Text",
    "label": "Failure Reason"
+  },
+  {
+   "fieldname": "gateway_response",
+   "fieldtype": "Code",
+   "label": "Gateway Response",
+   "options": "JSON",
+   "description": "Raw gateway error/response payload for audit (not shown to customers)"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/central/billing/gateways/base.py
+++ b/central/billing/gateways/base.py
@@ -29,6 +29,7 @@ class PaymentResult:
 	status: str  # captured / authorised / failed
 	gateway_transaction_id: str | None = None
 	failure_code: str | None = None
+	decline_code: str | None = None  # granular decline reason (Stripe decline_code)
 	failure_reason: str | None = None
 	raw: dict = field(default_factory=dict)
 

--- a/central/billing/gateways/razorpay_adapter.py
+++ b/central/billing/gateways/razorpay_adapter.py
@@ -156,11 +156,16 @@ class RazorpayAdapter(GatewayAdapter):
 				}
 			)
 		except razorpay.errors.BadRequestError as e:
+			# The Razorpay SDK collapses the API error to its description string —
+			# it exposes neither the error code nor the granular reason. Those arrive
+			# on the `payment.failed` webhook (see charges.apply_webhook), which is the
+			# authoritative decline record. Capture what the exception carries here.
 			return PaymentResult(
 				success=False,
 				status="Failed",
-				failure_code=getattr(e, "code", None),
+				failure_code=getattr(e, "code", None) or type(e).__name__,
 				failure_reason=str(e),
+				raw={"description": str(e)},
 			)
 		except _TRANSIENT as e:
 			raise GatewayTimeout(str(e)) from e

--- a/central/billing/gateways/stripe_adapter.py
+++ b/central/billing/gateways/stripe_adapter.py
@@ -186,12 +186,16 @@ class StripeAdapter(GatewayAdapter):
 		try:
 			intent = _to_dict(stripe.PaymentIntent.create(**params))
 		except stripe.error.CardError as e:
+			body = getattr(e, "json_body", None) or {}
+			# `code` for a declined card is almost always "card_declined"; the actual
+			# reason (insufficient_funds, lost_card, stolen_card, …) is the decline_code.
 			return PaymentResult(
 				success=False,
 				status="Failed",
 				failure_code=getattr(e, "code", None),
+				decline_code=(body.get("error") or {}).get("decline_code"),
 				failure_reason=getattr(e, "user_message", None) or str(e),
-				raw=getattr(e, "json_body", None) or {},
+				raw=body,
 			)
 		except (stripe.error.APIConnectionError, stripe.error.RateLimitError) as e:
 			raise GatewayTimeout(str(e)) from e

--- a/central/billing/payments/charges.py
+++ b/central/billing/payments/charges.py
@@ -118,8 +118,8 @@ def pay_invoice(invoice: str, payment_method: str | None = None, gateway: str | 
 		attempt.status = "Captured"  # gateway captured; invoice Paid waits on webhook
 	else:
 		attempt.status = "Failed"
-		attempt.failure_code = result.failure_code
-		attempt.failure_reason = result.failure_reason
+		_stamp_failure(attempt, result.failure_code, result.decline_code,
+					   result.failure_reason, result.raw)
 		attempt.completed_at = frappe.utils.now_datetime()
 	attempt.save(ignore_permissions=True)
 
@@ -295,6 +295,12 @@ def apply_webhook(event_name: str) -> dict:
 		inv_status = frappe.db.get_value("Invoice", attempt.invoice, "status")
 		if inv_status != "Paid" and attempt.status not in ("Failed", "Refunded"):
 			attempt.status = "Failed"
+			# Off-session declines surface their real reason here, not on the sync
+			# charge response — pull it off the event so the attempt records why.
+			detail = _extract_failure(adapter_key, payload)
+			if detail:
+				_stamp_failure(attempt, detail.get("failure_code"), detail.get("decline_code"),
+							   detail.get("failure_reason"), detail.get("raw"))
 			attempt.completed_at = frappe.utils.now_datetime()
 			attempt.save(ignore_permissions=True)
 			from central.billing.platform import notifications
@@ -422,6 +428,47 @@ def _extract_transaction_id(adapter_key: str, payload: dict):
 		payment = (((payload.get("payload") or {}).get("payment") or {}).get("entity")) or {}
 		return payment.get("id")
 	return None
+
+
+def _extract_failure(adapter_key: str, payload: dict) -> dict | None:
+	"""Pull the decline detail out of a failure webhook body, normalised to
+	{failure_code, decline_code, failure_reason, raw}. This is where an off-session
+	decline's real reason lives — the sync charge response often can't see it."""
+	if adapter_key == "Stripe":
+		obj = ((payload.get("data") or {}).get("object")) or {}
+		err = obj.get("last_payment_error") or {}
+		if not err:
+			return None
+		return {
+			"failure_code": err.get("code"),
+			"decline_code": err.get("decline_code"),
+			"failure_reason": err.get("message"),
+			"raw": err,
+		}
+	if adapter_key == "Razorpay":
+		entity = (((payload.get("payload") or {}).get("payment") or {}).get("entity")) or {}
+		if not entity.get("error_code") and not entity.get("error_reason"):
+			return None
+		# Razorpay's error_reason is the granular bucket (payment_failed,
+		# insufficient_balance, …) — the decline_code analogue.
+		return {
+			"failure_code": entity.get("error_code"),
+			"decline_code": entity.get("error_reason"),
+			"failure_reason": entity.get("error_description"),
+			"raw": {k: entity.get(k) for k in (
+				"error_code", "error_description", "error_reason", "error_source", "error_step")},
+		}
+	return None
+
+
+def _stamp_failure(attempt, failure_code, decline_code, failure_reason, raw):
+	"""Record the decline detail on a Payment Attempt. `raw` is stored as JSON on
+	the Code field; failure_reason is trimmed to the Small Text column width."""
+	attempt.failure_code = failure_code
+	attempt.decline_code = decline_code
+	attempt.failure_reason = (failure_reason or "")[:140] or None
+	if raw:
+		attempt.gateway_response = frappe.as_json(raw)
 
 
 def _extract_topup(adapter_key: str, payload: dict):

--- a/central/billing/report/failed_payments/failed_payments.js
+++ b/central/billing/report/failed_payments/failed_payments.js
@@ -1,0 +1,36 @@
+// Copyright (c) 2026, Frappe and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["Failed Payments"] = {
+	filters: [
+		{
+			fieldname: "from_date",
+			label: __("From"),
+			fieldtype: "Date",
+			default: frappe.datetime.add_months(frappe.datetime.month_start(), -1),
+		},
+		{
+			fieldname: "to_date",
+			label: __("To"),
+			fieldtype: "Date",
+			default: frappe.datetime.month_end(),
+		},
+		{
+			fieldname: "gateway",
+			label: __("Gateway"),
+			fieldtype: "Link",
+			options: "Payment Gateway",
+		},
+		{
+			fieldname: "team",
+			label: __("Team"),
+			fieldtype: "Link",
+			options: "Team",
+		},
+		{
+			fieldname: "decline_code",
+			label: __("Decline Code"),
+			fieldtype: "Data",
+		},
+	],
+};

--- a/central/billing/report/failed_payments/failed_payments.json
+++ b/central/billing/report/failed_payments/failed_payments.json
@@ -1,0 +1,26 @@
+{
+ "add_total_row": 0,
+ "columns": [],
+ "creation": "2026-07-04 00:00:00.000000",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letterhead": null,
+ "modified": "2026-07-04 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Billing",
+ "name": "Failed Payments",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Payment Attempt",
+ "report_name": "Failed Payments",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "System Manager"
+  }
+ ]
+}

--- a/central/billing/report/failed_payments/failed_payments.py
+++ b/central/billing/report/failed_payments/failed_payments.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Failed payments — a glance view of every declined charge and why.
+
+One row per failed Payment Attempt, newest first, with the granular decline
+reason (Stripe `decline_code` / Razorpay `error_reason`) beside the top-level
+code so an operator can see at a glance *why* collection is failing — not just
+that it did. The chart buckets failures by reason so the dominant cause (e.g.
+insufficient_funds) stands out. Pair it with Gateway Payment Success Ratio,
+which gives the aggregate rate; this one names the individual failures.
+"""
+
+import frappe
+from frappe import _
+from frappe.utils import flt
+
+
+def execute(filters: dict | None = None):
+	filters = filters or {}
+	rows = _failed_attempts(filters)
+	columns = _columns()
+	chart = _reason_chart(rows)
+	summary = _summary(rows)
+	return columns, rows, None, chart, summary
+
+
+def _failed_attempts(filters: dict) -> list[dict]:
+	conditions = {"status": "Failed"}
+	for field in ("gateway", "team", "decline_code"):
+		if filters.get(field):
+			conditions[field] = filters[field]
+	if filters.get("from_date") and filters.get("to_date"):
+		conditions["initiated_at"] = ["between", [filters["from_date"], filters["to_date"]]]
+	elif filters.get("from_date"):
+		conditions["initiated_at"] = [">=", filters["from_date"]]
+	elif filters.get("to_date"):
+		conditions["initiated_at"] = ["<=", filters["to_date"]]
+	return frappe.get_all(
+		"Payment Attempt",
+		filters=conditions,
+		fields=[
+			"name", "initiated_at", "team", "invoice", "gateway", "payment_method",
+			"amount", "currency", "retry_number",
+			"failure_code", "decline_code", "failure_reason",
+		],
+		order_by="initiated_at desc",
+	)
+
+
+def _columns() -> list[dict]:
+	return [
+		{"label": _("Attempt"), "fieldname": "name", "fieldtype": "Link", "options": "Payment Attempt", "width": 150},
+		{"label": _("Failed At"), "fieldname": "initiated_at", "fieldtype": "Datetime", "width": 165},
+		{"label": _("Team"), "fieldname": "team", "fieldtype": "Link", "options": "Team", "width": 140},
+		{"label": _("Invoice"), "fieldname": "invoice", "fieldtype": "Link", "options": "Invoice", "width": 150},
+		{"label": _("Gateway"), "fieldname": "gateway", "fieldtype": "Link", "options": "Payment Gateway", "width": 120},
+		{"label": _("Amount"), "fieldname": "amount", "fieldtype": "Float", "width": 100},
+		{"label": _("Currency"), "fieldname": "currency", "fieldtype": "Data", "width": 80},
+		{"label": _("Retry"), "fieldname": "retry_number", "fieldtype": "Int", "width": 70},
+		{"label": _("Failure Code"), "fieldname": "failure_code", "fieldtype": "Data", "width": 150},
+		{"label": _("Decline Code"), "fieldname": "decline_code", "fieldtype": "Data", "width": 160},
+		{"label": _("Reason"), "fieldname": "failure_reason", "fieldtype": "Data", "width": 300},
+	]
+
+
+def _reason(row: dict) -> str:
+	"""The most specific label available for a failure: the granular decline code,
+	then the top-level code, then a catch-all."""
+	return row.get("decline_code") or row.get("failure_code") or _("(unknown)")
+
+
+def _reason_chart(rows: list[dict]) -> dict | None:
+	if not rows:
+		return None
+	counts: dict[str, int] = {}
+	for r in rows:
+		counts[_reason(r)] = counts.get(_reason(r), 0) + 1
+	top = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:10]
+	return {
+		"data": {"labels": [k for k, _c in top],
+				 "datasets": [{"name": _("Failures"), "values": [c for _k, c in top]}]},
+		"type": "bar",
+	}
+
+
+def _summary(rows: list[dict]) -> list[dict]:
+	if not rows:
+		return [{"label": _("Failed Payments"), "value": 0, "datatype": "Int", "indicator": "green"}]
+	amount = flt(sum(flt(r.get("amount")) for r in rows), 2)
+	teams = len({r.get("team") for r in rows if r.get("team")})
+	counts: dict[str, int] = {}
+	for r in rows:
+		counts[_reason(r)] = counts.get(_reason(r), 0) + 1
+	top_reason, top_count = max(counts.items(), key=lambda kv: kv[1])
+	return [
+		{"label": _("Failed Payments"), "value": len(rows), "datatype": "Int", "indicator": "red"},
+		{"label": _("Amount Not Collected"), "value": amount, "datatype": "Float", "indicator": "red"},
+		{"label": _("Teams Affected"), "value": teams, "datatype": "Int", "indicator": "orange"},
+		{"label": _("Top Reason"), "value": f"{top_reason} ({top_count})", "datatype": "Data"},
+	]

--- a/central/billing/tests/test_charges.py
+++ b/central/billing/tests/test_charges.py
@@ -363,3 +363,75 @@ class TestLogRetention(ChargeTestBase):
 		with patch.dict(frappe.conf, {"payment_log_retention_days": 365}):
 			charges.cleanup_payment_logs()
 		self.assertTrue(frappe.db.exists("Payment Attempt", captured))
+
+
+class TestDeclineDetail(ChargeTestBase):
+	"""An off-session decline surfaces its real reason on the webhook, not the
+	sync charge response — apply_webhook must stamp it on the attempt."""
+
+	def _initiated_attempt(self, invoice, txn_id):
+		return frappe.get_doc({
+			"doctype": "Payment Attempt", "invoice": invoice, "team": TEAM,
+			"gateway": GATEWAY, "amount": 1000, "currency": "INR", "status": "Initiated",
+			"gateway_transaction_id": txn_id, "initiated_at": frappe.utils.now_datetime(),
+		}).insert(ignore_permissions=True).name
+
+	def _stripe_failed_event(self, gateway_event_id, txn_id, error):
+		payload = {"id": gateway_event_id, "type": "payment_intent.payment_failed",
+				   "data": {"object": {"id": txn_id, "last_payment_error": error}}}
+		return frappe.get_doc({
+			"doctype": "Webhook Event", "gateway": GATEWAY, "gateway_event_id": gateway_event_id,
+			"event_type": "payment_intent.payment_failed", "raw_payload": json.dumps(payload),
+			"status": "Received",
+		}).insert(ignore_permissions=True).name
+
+	def test_stripe_failure_webhook_records_decline_code(self):
+		inv = self._open_invoice(1000)
+		attempt = self._initiated_attempt(inv, "pi_decl")
+		event = self._stripe_failed_event("evt_decl", "pi_decl", {
+			"code": "card_declined", "decline_code": "insufficient_funds",
+			"message": "Your card has insufficient funds.",
+		})
+		# The failure branch also kicks off method fallback (#28); stub it so this
+		# test stays about decline-detail capture, not a live re-charge.
+		with patch("central.billing.payments.collection.collect_invoice", return_value=None):
+			charges.apply_webhook(event)
+		a = frappe.get_doc("Payment Attempt", attempt)
+		self.assertEqual(a.status, "Failed")
+		self.assertEqual(a.failure_code, "card_declined")
+		self.assertEqual(a.decline_code, "insufficient_funds")
+		self.assertIn("insufficient funds", a.failure_reason)
+		self.assertTrue(a.gateway_response)  # raw error persisted for audit
+
+
+class TestFailedPaymentsReport(ChargeTestBase):
+	def _failed(self, decline_code, reason, amount=1000):
+		return frappe.get_doc({
+			"doctype": "Payment Attempt", "invoice": self._open_invoice(amount), "team": TEAM,
+			"gateway": GATEWAY, "amount": amount, "currency": "INR", "status": "Failed",
+			"failure_code": "card_declined", "decline_code": decline_code,
+			"failure_reason": reason, "initiated_at": frappe.utils.now_datetime(),
+		}).insert(ignore_permissions=True).name
+
+	def test_lists_failures_with_reason_and_summary(self):
+		from central.billing.report.failed_payments import failed_payments
+
+		self._failed("insufficient_funds", "no funds")
+		self._failed("insufficient_funds", "no funds")
+		self._failed("lost_card", "reported lost")
+		# A captured attempt must never appear.
+		frappe.get_doc({
+			"doctype": "Payment Attempt", "invoice": self._open_invoice(1000), "team": TEAM,
+			"gateway": GATEWAY, "amount": 1000, "currency": "INR", "status": "Captured",
+			"initiated_at": frappe.utils.now_datetime(),
+		}).insert(ignore_permissions=True)
+
+		columns, rows, _msg, chart, summary = failed_payments.execute({"team": TEAM})
+		self.assertEqual(len(rows), 3)
+		self.assertTrue(all(r["decline_code"] for r in rows))
+		# Summary: 3 failures, top reason is insufficient_funds (2).
+		by_label = {s["label"]: s["value"] for s in summary}
+		self.assertEqual(by_label["Failed Payments"], 3)
+		self.assertIn("insufficient_funds", by_label["Top Reason"])
+		# Chart buckets by reason.
+		self.assertIn("insufficient_funds", chart["data"]["labels"])


### PR DESCRIPTION
### fix(billing): capture granular decline reason
- Payment Attempt gains decline_code (granular reason) + gateway_response (raw JSON for audit).
- PaymentResult carries decline_code; the Stripe adapter now pulls it from json_body.error.decline_code, so the whole card_declined family (insufficient_funds, lost_card, stolen_card, fraudulent, …) is now distinguishable instead of collapsing to one code.
- The async webhook decline path (apply_webhook) previously recorded nothing — it now extracts last_payment_error (Stripe) / error_code+error_reason (Razorpay) and stamps the attempt. This matters because off-session declines surface their real reason on the webhook, not the sync response.
- Razorpay reality check: its SDK throws away the API code/reason on the sync path (raises BadRequestError(description) only) — I documented that and made the webhook the authoritative decline record for Razorpay.

### feat(billing): Failed Payments report
- New Script Report "Failed Payments": one row per declined charge (newest first) — attempt, time, team, invoice, gateway, amount, retry, failure code, decline code, reason.
- Summary tiles: failures count, amount not collected, teams affected, top reason. Chart buckets failures by reason so the dominant cause stands out.
- Filters: date range, gateway, team, decline code. Complements the existing Gateway Payment Success Ratio (aggregate rate) by naming individual failures.
- Tests cover the webhook decline capture and the report's row/summary/chart output.