### PR TITLE
feat(signup): seed billing currency + welcome credits from IP country

### DIFF
--- a/central/api/auth.py
+++ b/central/api/auth.py
@@ -79,7 +79,24 @@ def verify_signup(email: str, code: str) -> dict:
 	frappe.local.login_manager.login_as(user.name)
 
 	teams = get_user_team_names(user.name)
-	return {"user": user.name, "team": teams[0] if teams else None}
+	team = teams[0] if teams else None
+	if team:
+		_provision_signup_billing(team)
+	return {"user": user.name, "team": team}
+
+
+def _provision_signup_billing(team: str) -> None:
+	"""Seed the new team's billing currency from its signup IP and grant the
+	matching welcome credits. Best-effort: a geolocation or provisioning hiccup is
+	logged, never fatal — the user can still complete their profile from the
+	dashboard, which provisions the same way."""
+	try:
+		from central.billing.payments.provisioning import provision_signup_billing
+		from central.geo import get_country_from_ip
+
+		provision_signup_billing(team, get_country_from_ip())
+	except Exception:
+		frappe.log_error(title="Signup billing provisioning failed")
 
 
 def _otp_key(email: str) -> str:

--- a/central/billing/doctype/billing_profile/billing_profile.py
+++ b/central/billing/doctype/billing_profile/billing_profile.py
@@ -4,9 +4,15 @@
 import re
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from central.billing.india_gst import GST_STATE_CODES, INDIA
+
+# Once a team has been invoiced, these are frozen: invoices are denominated in the
+# currency and taxed by the country in force when they were issued, so changing
+# either would desync documents already sent to the customer.
+_INVOICE_LOCKED_FIELDS = {"country": "country", "currency": "currency"}
 
 # GSTIN: 2-digit state + 10-char PAN + entity digit + 'Z' + checksum char.
 GSTIN_RE = re.compile(r"^[0-9]{2}[A-Z]{5}[0-9]{4}[A-Z]{1}[1-9A-Z]{1}Z[0-9A-Z]{1}$")
@@ -20,6 +26,30 @@ class BillingProfile(Document):
 	def validate(self):
 		self.validate_gstin()
 		self.validate_india_state()
+		self.lock_country_and_currency_after_invoicing()
+
+	def lock_country_and_currency_after_invoicing(self):
+		"""Freeze country and currency once the team has been invoiced.
+
+		A backstop that holds no matter how the profile is saved (dashboard, admin,
+		script); the dashboard also locks currency on any money activity. Legal name,
+		address and GSTIN stay editable — only the two invoice-defining fields lock."""
+		if self.is_new():
+			return
+
+		changed = [label for field, label in _INVOICE_LOCKED_FIELDS.items() if self.has_value_changed(field)]
+		if not changed:
+			return
+
+		if not frappe.db.exists("Invoice", {"team": self.team}):
+			return
+
+		frappe.throw(
+			_("This team has already been invoiced, so its billing {0} can no longer be changed.").format(
+				_(" and ").join(changed)
+			),
+			frappe.ValidationError,
+		)
 
 	def validate_gstin(self):
 		if not self.gstin:

--- a/central/billing/payments/provisioning.py
+++ b/central/billing/payments/provisioning.py
@@ -32,6 +32,34 @@ def provision_billing_profile(team: str) -> None:
 	grant_welcome_credits(team)
 
 
+def provision_signup_billing(team: str, country: str | None) -> None:
+	"""Seed a brand-new team's billing at signup from its IP-derived `country`.
+
+	Stamps a minimal Billing Profile with the country and the currency it implies
+	(India → INR, everything else → USD), then runs the standard provisioning so
+	the team gets its entry tier, tax profile, and welcome credits in that currency
+	right away — no waiting for the full address.
+
+	The profile is created with `ignore_mandatory`: at signup we only know the
+	country, and the legal name / address are filled in later from the dashboard.
+	Idempotent — an existing profile (e.g. one already carrying money) is left
+	untouched, and every downstream step is individually guarded."""
+	from central.billing.api.dashboard._shared import currency_for_country
+	from central.billing.india_gst import INDIA
+
+	if not frappe.db.exists("Billing Profile", team):
+		# When the IP can't be geolocated — localhost/127.0.0.1, a private address,
+		# or a failed lookup — fall back to India, our home market. Currency is then
+		# always derived from the country actually stamped on the profile, so the
+		# two can never disagree (India → INR, everywhere else → USD).
+		profile = frappe.get_doc({"doctype": "Billing Profile", "team": team})
+		profile.country = country or INDIA
+		profile.currency = currency_for_country(profile.country)
+		profile.insert(ignore_permissions=True, ignore_mandatory=True)
+
+	provision_billing_profile(team)
+
+
 def assign_entry_tier(team: str) -> None:
 	"""Link the entry Trust Tier Level on the profile if it has none yet.
 

--- a/central/billing/tests/test_billing_profile.py
+++ b/central/billing/tests/test_billing_profile.py
@@ -26,9 +26,19 @@ def _profile(**overrides):
 	return doc
 
 
+def _invoice(team=TEAM, currency="INR"):
+	"""Minimal issued invoice so the team counts as "already invoiced"."""
+	return frappe.get_doc(
+		{"doctype": "Invoice", "team": team, "invoice_type": "Billable", "status": "Open",
+		 "period_start": "2099-01-01", "period_end": "2099-01-31", "currency": currency,
+		 "subtotal": 100, "total": 100, "amount_paid": 0}
+	).insert(ignore_permissions=True)
+
+
 class TestBillingProfile(IntegrationTestCase):
 	def setUp(self):
 		ensure_team(TEAM)
+		frappe.db.delete("Invoice", {"team": TEAM})
 		frappe.db.delete("Billing Profile", {"team": TEAM})
 
 	def test_valid_gstin_matching_state_saves(self):
@@ -65,3 +75,29 @@ class TestBillingProfile(IntegrationTestCase):
 		# Profiles are often created incomplete (just team + currency); that must not throw.
 		doc = _profile(state="", gstin="", legal_name="", address_line1="", city="", pincode="")
 		self.assertEqual(doc.currency, "INR")
+
+	def test_country_and_currency_editable_before_any_invoice(self):
+		_profile(country="India", currency="INR")
+		doc = _profile(country="Germany", currency="USD", state="Hesse", gstin="")
+		self.assertEqual(doc.country, "Germany")
+		self.assertEqual(doc.currency, "USD")
+
+	def test_currency_locked_once_team_is_invoiced(self):
+		_profile(country="India", currency="INR")
+		_invoice()
+		with self.assertRaises(frappe.ValidationError):
+			_profile(currency="USD")
+
+	def test_country_locked_once_team_is_invoiced(self):
+		_profile(country="India", currency="INR")
+		_invoice()
+		with self.assertRaises(frappe.ValidationError):
+			_profile(country="Germany", state="Hesse", gstin="")
+
+	def test_other_fields_still_editable_after_invoicing(self):
+		# Legal name / address / GSTIN can change post-invoice — only the two
+		# invoice-defining fields lock.
+		_profile(country="India", currency="INR")
+		_invoice()
+		doc = _profile(legal_name="Renamed Ltd", address_line1="9 New Road", gstin="27AAPFU0939F1ZV")
+		self.assertEqual(doc.legal_name, "Renamed Ltd")

--- a/central/geo.py
+++ b/central/geo.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Resolve a request's country from its IP.
+
+Ported from press (`press.utils.get_country_info`): we ask ip-api.com to geolocate
+the caller and cache the answer per IP. Used at signup to seed a team's billing
+currency from where the user is signing up from.
+"""
+
+from __future__ import annotations
+
+import frappe
+import requests
+
+
+def get_country_from_ip(ip: str | None = None) -> str | None:
+	"""Country name (e.g. "India") for `ip`, or None when it can't be determined.
+
+	Falls back to the current request's IP. Returns None on any miss — no IP, a
+	private/localhost address, a lookup failure, or during tests — so every caller
+	must tolerate None (we default the currency in that case). Never raises."""
+	if frappe.flags.in_test:
+		return None
+
+	ip = ip or getattr(frappe.local, "request_ip", None)
+	if not ip:
+		return None
+
+	info = frappe.cache().hget("ip_country_map", ip, generator=lambda: _lookup_ip(ip))
+	return (info or {}).get("country")
+
+
+def _lookup_ip(ip: str) -> dict:
+	"""Hit ip-api.com for `ip`. Uses the paid `pro` endpoint when an `ip-api-key`
+	is configured, otherwise the free endpoint. A failure (network, rate limit, a
+	private-range IP) returns {} — the caller treats that as "country unknown"."""
+	key = frappe.conf.get("ip-api-key")
+	if key:
+		url = f"https://pro.ip-api.com/json/{ip}?key={key}&fields=status,country,countryCode"
+	else:
+		url = f"http://ip-api.com/json/{ip}?fields=status,country,countryCode"
+
+	try:
+		data = requests.get(url, timeout=5).json()
+		if data.get("status") != "fail":
+			return data
+	except Exception:
+		frappe.log_error(title="IP country lookup failed")
+	return {}

--- a/central/geo.py
+++ b/central/geo.py
@@ -9,6 +9,8 @@ currency from where the user is signing up from.
 
 from __future__ import annotations
 
+import ipaddress
+
 import frappe
 import requests
 
@@ -22,12 +24,46 @@ def get_country_from_ip(ip: str | None = None) -> str | None:
 	if frappe.flags.in_test:
 		return None
 
-	ip = ip or getattr(frappe.local, "request_ip", None)
+	ip = _clean_public_ip(ip or getattr(frappe.local, "request_ip", None))
 	if not ip:
 		return None
 
 	info = frappe.cache().hget("ip_country_map", ip, generator=lambda: _lookup_ip(ip))
 	return (info or {}).get("country")
+
+
+def _clean_public_ip(raw: str | None) -> str | None:
+	"""Canonical, globally-routable IP for `raw`, or None.
+
+	`request_ip` can be derived from a client-supplied `X-Forwarded-For` header, so
+	it is untrusted: validate it as a real IP address before it ever reaches the
+	outbound lookup URL or the cache key. This shuts the door on a spoofed or
+	malformed value injecting into the request, and drops private/loopback/reserved
+	addresses that can't be geolocated anyway (they fall back to India/INR at the
+	caller). Returns the library's canonical string form, which by construction
+	contains no URL-significant characters.
+
+	(Trusting X-Forwarded-For at all is a deployment concern — the edge proxy must
+	overwrite, not append, the client's header. This function only guarantees the
+	value is well-formed, not that it's honest.)"""
+	if not raw:
+		return None
+	# An X-Forwarded-For chain is "client, proxy1, proxy2"; the client is first.
+	candidate = str(raw).split(",")[0].strip()
+	try:
+		addr = ipaddress.ip_address(candidate)
+	except ValueError:
+		return None
+	if (
+		addr.is_private
+		or addr.is_loopback
+		or addr.is_reserved
+		or addr.is_link_local
+		or addr.is_multicast
+		or addr.is_unspecified
+	):
+		return None
+	return addr.compressed
 
 
 def _lookup_ip(ip: str) -> dict:

--- a/central/tests/test_auth.py
+++ b/central/tests/test_auth.py
@@ -42,6 +42,60 @@ class TestAuth(IntegrationTestCase):
 		self.assertTrue(result["team"])
 		self.assertIsNone(frappe.cache.get_value(_otp_key(email)))
 
+	@IntegrationTestCase.change_settings("Website Settings", disable_signup=1)
+	def test_signup_seeds_billing_profile_currency_from_ip_country(self):
+		frappe.set_user("Guest")
+		email = "central-signup-geo-test@example.test"
+		self.addCleanup(frappe.cache.delete_value, _otp_key(email))
+
+		sign_up(email, "Geo Signup Test")
+		code = frappe.cache.get_value(_otp_key(email))["code"]
+
+		with (
+			patch("frappe.local.login_manager", create=True) as login_manager,
+			patch("central.geo.get_country_from_ip", return_value="India"),
+		):
+			login_manager.login_as.side_effect = frappe.set_user
+			result = verify_signup(email, code)
+
+		team = result["team"]
+		# India → INR profile, stamped despite no legal name / address (ignore_mandatory).
+		self.assertEqual(frappe.db.get_value("Billing Profile", team, "country"), "India")
+		self.assertEqual(frappe.db.get_value("Billing Profile", team, "currency"), "INR")
+		# Welcome credits are granted in that currency.
+		self.assertTrue(
+			frappe.db.exists(
+				"Credit Ledger Entry", {"team": team, "reference_type": "Promotion", "currency": "INR"}
+			)
+		)
+
+	@IntegrationTestCase.change_settings("Website Settings", disable_signup=1)
+	def test_signup_falls_back_to_india_inr_when_ip_country_is_unknown(self):
+		frappe.set_user("Guest")
+		email = "central-signup-nogeo-test@example.test"
+		self.addCleanup(frappe.cache.delete_value, _otp_key(email))
+
+		sign_up(email, "No Geo Signup Test")
+		code = frappe.cache.get_value(_otp_key(email))["code"]
+
+		# get_country_from_ip returns None for localhost/private IPs (and in tests).
+		with (
+			patch("frappe.local.login_manager", create=True) as login_manager,
+			patch("central.geo.get_country_from_ip", return_value=None),
+		):
+			login_manager.login_as.side_effect = frappe.set_user
+			result = verify_signup(email, code)
+
+		team = result["team"]
+		# Unknown country → default to India / INR, and the two must agree.
+		self.assertEqual(frappe.db.get_value("Billing Profile", team, "country"), "India")
+		self.assertEqual(frappe.db.get_value("Billing Profile", team, "currency"), "INR")
+		self.assertTrue(
+			frappe.db.exists(
+				"Credit Ledger Entry", {"team": team, "reference_type": "Promotion", "currency": "INR"}
+			)
+		)
+
 	def test_developer_otp_bypass_still_requires_a_pending_signup(self):
 		frappe.set_user("Guest")
 		email = "central-missing-signup-test@example.test"

--- a/central/tests/test_geo.py
+++ b/central/tests/test_geo.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""The IP sanitizer that guards the country lookup against spoofed/malformed
+X-Forwarded-For input."""
+
+from frappe.tests import IntegrationTestCase
+
+from central.geo import _clean_public_ip
+
+
+class TestCleanPublicIP(IntegrationTestCase):
+	def test_valid_public_ipv4_passes_through_canonicalised(self):
+		self.assertEqual(_clean_public_ip("49.207.0.1"), "49.207.0.1")
+
+	def test_valid_public_ipv6_is_canonicalised(self):
+		# Upper case + zero-groups collapse to the library's canonical form
+		# (Google public DNS, a genuinely global address).
+		self.assertEqual(_clean_public_ip("2001:4860:4860:0000:0000:0000:0000:8888"), "2001:4860:4860::8888")
+
+	def test_xforwarded_for_chain_takes_the_client_hop(self):
+		self.assertEqual(_clean_public_ip("49.207.0.1, 10.0.0.5, 172.16.0.1"), "49.207.0.1")
+
+	def test_url_injection_payload_is_rejected(self):
+		# A value that would otherwise land inside the outbound lookup URL.
+		for payload in ("49.207.0.1/../admin", "1.2.3.4?x=y", "1.2.3.4 8.8.8.8", "evil.example.com", ""):
+			with self.subTest(payload=payload):
+				self.assertIsNone(_clean_public_ip(payload))
+
+	def test_private_and_loopback_are_dropped(self):
+		for ip in ("127.0.0.1", "10.0.0.1", "192.168.1.1", "::1", "169.254.0.1", "0.0.0.0"):
+			with self.subTest(ip=ip):
+				self.assertIsNone(_clean_public_ip(ip))
+
+	def test_none_and_blank_return_none(self):
+		self.assertIsNone(_clean_public_ip(None))
+		self.assertIsNone(_clean_public_ip("   "))


### PR DESCRIPTION
At OTP verification, resolve the signup's country from its IP (ported from press get_country_info: ip-api.com, per-IP cache, pro endpoint when an ip-api-key is configured else free) and provision the team's billing early: a minimal Billing Profile stamped with country + derived currency (India -> INR, else USD) inserted with ignore_mandatory, then the standard idempotent provision_billing_profile for entry tier, tax profile and welcome credits.

An unknown IP (localhost/private/failed lookup) falls back to India/INR. Currency is always derived from the country actually stamped on the profile, so the Billing Profile's country doctype default ("India") can't leave the two disagreeing. Best-effort and try/excepted so it never blocks signup.