### PR TITLE
refactor(billing): update role capabilities and documentation

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -95,8 +95,8 @@ all teams. Teams may also define custom roles scoped to themselves.
 | `team:edit` | ✓ | ✓ | | | |
 | `team:manage_members` | ✓ | ✓ | | | |
 | `team:delete` | ✓ | | | | |
-| `billing:view` | ✓ | | | | ✓ |
-| `billing:manage` | ✓ | | | | ✓ |
+| `billing:view` | ✓ | ✓ | | | ✓ |
+| `billing:manage` | ✓ | ✓ | | | ✓ |
 | `cluster:view` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `server:view` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `server:create` | ✓ | ✓ | ✓ | | |
@@ -106,13 +106,13 @@ all teams. Teams may also define custom roles scoped to themselves.
 | `server:terminate` | ✓ | ✓ | ✓ | | |
 | `server:open` | ✓ | ✓ | ✓ | | |
 
-Totals: Owner 13, Admin 10, Developer 8, Viewer 2, Billing 4.
+Totals: Owner 13, Admin 12, Developer 8, Viewer 2, Billing 4.
 
 The ladder reads top to bottom: **Viewer** (look) → **Billing** (look + pay) →
 **Developer** (operate servers) → **Admin** (Developer + run the team) → **Owner**
-(Admin + billing + delete the team). A team has exactly one Owner, transferable via
-Transfer Ownership. Need a different mix (e.g. administration *and* billing)? Create
-a custom role.
+(Admin + delete the team). A team has exactly one Owner, transferable via Transfer
+Ownership. Need a different mix (e.g. server operations without billing)? Create a
+custom role.
 
 ## Changing the taxonomy
 

--- a/central/billing/authz.py
+++ b/central/billing/authz.py
@@ -7,7 +7,7 @@ Billing defines no roles of its own. It reuses Central's capability IAM
 (`billing:view`), every **mutation** through `require_billing_manage`
 (`billing:manage`), and the cross-team admin console through `require_operator`
 (System Manager). Those capabilities ship in Central's fixtures, carried by the
-system `Owner` and `Billing` team roles.
+system `Owner`, `Admin`, and `Billing` team roles.
 
 A System Manager (operator) bypasses team scoping — they see/act across every
 team. The cluster Agent API key holds no billing capability and is not a System

--- a/central/billing/tests/test_dashboard.py
+++ b/central/billing/tests/test_dashboard.py
@@ -187,17 +187,23 @@ class TestTeamScoping(CustomerDataBase):
 					frappe.set_user("Administrator")
 
 	def test_billing_capable_roles_can_read_and_manage(self):
-		"""The system roles that carry both capabilities — Owner and Billing — can
-		read and run a manage mutation on their own team. (Owner is the team's
-		sole owner_user; Billing is a separate member.)"""
+		"""The system roles that carry both capabilities can read and run a manage
+		mutation on their own team. Owner is the team's sole owner_user; Admin and
+		Billing are separate members."""
 		user = make_user()
 		owner_team = frappe.get_doc(
 			{"doctype": "Team", "team_name": f"Owned {frappe.generate_hash(5)}", "owner_user": user}
 		).insert(ignore_permissions=True)  # user becomes the sole active Owner member
+		admin_user = make_user()
+		admin_team = make_billing_team(admin_user, role="Admin")
 		billing_user = make_user()
 		billing_team = make_billing_team(billing_user, role="Billing")
 
-		cases = {"Owner": (user, owner_team.name), "Billing": (billing_user, billing_team.name)}
+		cases = {
+			"Owner": (user, owner_team.name),
+			"Admin": (admin_user, admin_team.name),
+			"Billing": (billing_user, billing_team.name),
+		}
 		for role, (member, team_name) in cases.items():
 			with self.subTest(role=role):
 				frappe.set_user(member)

--- a/central/fixtures/team_role.json
+++ b/central/fixtures/team_role.json
@@ -27,6 +27,8 @@
   "capabilities": [
    {"capability": "team:edit"},
    {"capability": "team:manage_members"},
+   {"capability": "billing:view"},
+   {"capability": "billing:manage"},
    {"capability": "cluster:view"},
    {"capability": "server:view"},
    {"capability": "server:create"},

--- a/central/tests/test_iam.py
+++ b/central/tests/test_iam.py
@@ -74,11 +74,11 @@ class TestCentralIAM(IntegrationTestCase):
 		self.assertNotIn("team:manage_members", developer_caps)
 		self.assertIn("team:delete", owner_caps)
 		self.assertNotIn("team:delete", admin_caps)
-		# Billing lives with Owner and Billing only.
+		# Billing is day-to-day team administration, so Owner/Admin/Billing carry it.
 		for cap in ("billing:view", "billing:manage"):
 			self.assertIn(cap, owner_caps)
+			self.assertIn(cap, admin_caps)
 			self.assertIn(cap, billing_caps)
-			self.assertNotIn(cap, admin_caps)
 			self.assertNotIn(cap, developer_caps)
 		# Viewer is a pure inventory auditor; Billing adds billing to that read view.
 		self.assertEqual(viewer_caps, {"cluster:view", "server:view"})

--- a/dashboard/src/components/GroupGate.vue
+++ b/dashboard/src/components/GroupGate.vue
@@ -11,7 +11,7 @@ import { useCapabilities } from '@/composables/useCapabilities'
 const props = defineProps({
   capability: { type: String, default: '' },
   requireMember: { type: Boolean, default: false },
-  roles: { type: String, default: 'Owner or Billing' },
+  roles: { type: String, default: 'Owner, Admin, or Billing' },
 })
 
 const { caps, has, isMember } = useCapabilities()

--- a/dashboard/src/components/NoAccess.vue
+++ b/dashboard/src/components/NoAccess.vue
@@ -4,7 +4,7 @@
 defineProps({
   title: { type: String, default: "You don't have access" },
   message: { type: String, default: '' },
-  roles: { type: String, default: 'Owner or Billing' },
+  roles: { type: String, default: 'Owner, Admin, or Billing' },
 })
 </script>
 

--- a/dashboard/src/router/index.js
+++ b/dashboard/src/router/index.js
@@ -20,7 +20,7 @@ const routes = [
       {
         path: 'billing',
         component: GroupGate,
-        props: { capability: 'billing:view', roles: 'Owner or Billing' },
+        props: { capability: 'billing:view', roles: 'Owner, Admin, or Billing' },
         children: [
           { path: '', name: 'Overview', component: () => import('@/pages/billing/Overview.vue') },
           { path: 'invoices', name: 'Invoices', component: () => import('@/pages/billing/Invoices.vue') },
@@ -32,7 +32,7 @@ const routes = [
       {
         path: 'settings',
         component: GroupGate,
-        props: { capability: 'billing:view', roles: 'Owner or Billing' },
+        props: { capability: 'billing:view', roles: 'Owner, Admin, or Billing' },
         children: [
           { path: '', redirect: '/settings/address' },
           { path: 'address', name: 'Address', component: () => import('@/pages/billing/Settings.vue') },

--- a/spec/IAM.md
+++ b/spec/IAM.md
@@ -48,7 +48,7 @@ There are no per-user capability overrides. A Team owner is an active
 | Role | Intended access |
 | --- | --- |
 | Owner | All Team capabilities |
-| Admin | Team management and server operations, excluding billing and team deletion |
+| Admin | Day-to-day team, server, and billing operations, excluding team deletion and ownership transfer |
 | Developer | Full server operations |
 | Viewer | Read-only server access |
 | Billing | Billing and read-only server access |


### PR DESCRIPTION
- Updated the billing capabilities for the Admin role to include both `billing:view` and `billing:manage`.
- Adjusted related documentation to reflect the inclusion of Admin in billing operations.
- Modified tests to ensure that Admin roles can read and manage billing for their teams.
- Updated UI components to display the correct roles required for billing access.
- Clarified the IAM documentation regarding the responsibilities of the Admin role in team management and billing operations.