### PR TITLE
fix: Set login URLs on Asset and Site

### DIFF
--- a/central/api/sites.py
+++ b/central/api/sites.py
@@ -58,8 +58,11 @@ def get_site(name: str) -> dict:
 	"""Current state of a site for the onboarding poll. Gated on team membership.
 
 	Reads the mirror; while the site is still provisioning we pull Atlas's get_site
-	as the self-heal (in case an event delivery was missed) and re-mirror. The admin
-	password + URL are only surfaced once Running — the tenant handoff."""
+	as the self-heal (in case an event delivery was missed) and re-mirror. The
+	one-click login URL + live URL are only surfaced once Running — the tenant
+	handoff. The login URL is short-lived (a 24h session), so if the stored one has
+	expired by the time the tenant lands here we regenerate a fresh one on read, so
+	the link they click always works."""
 	user = frappe.session.user
 	mirror = frappe.db.get_value(
 		"Site", name, ["team", "cluster", "status"], as_dict=True
@@ -83,8 +86,45 @@ def get_site(name: str) -> dict:
 		"name": doc.name,
 		"status": doc.status,
 		"url": doc.url if running else None,
-		"admin_password": doc.get_password("admin_password") if running else None,
+		"login_url": _fresh_site_login_url(doc) if running else None,
 	}
+
+
+def _fresh_site_login_url(doc) -> str | None:
+	"""The site's usable one-click login URL: the stored one if it hasn't expired,
+	else a freshly-regenerated one. The URL is a short-lived (24h) session, so a
+	tenant who lands on a stale mirror row would otherwise get a dead link — we
+	re-mint on read instead. Best-effort: if the regenerate call fails (Atlas
+	unreachable), fall back to the stored URL rather than blocking the handoff."""
+	if doc.login_url and not _login_url_expired(doc.login_url_expires_at):
+		return doc.login_url
+	try:
+		return _regenerate_site_login(doc.name, doc.cluster).get("login_url") or doc.login_url
+	except Exception:
+		frappe.log_error(title=f"Regenerate login failed for site {doc.name}")
+		return doc.login_url or None
+
+
+def _login_url_expired(expires_at) -> bool:
+	"""True if a stored login URL is at/past its expiry (or carries no expiry — treat
+	an unstamped URL as unusable and force a regenerate). A small skew guard trims the
+	tail so we don't hand out a URL that dies mid-click."""
+	if not expires_at:
+		return True
+	skew = frappe.utils.add_to_date(frappe.utils.now_datetime(), seconds=30)
+	return frappe.utils.get_datetime(expires_at) <= skew
+
+
+def _regenerate_site_login(name: str, cluster: str) -> dict:
+	"""Ask Atlas to re-mint the site's login URL, re-mirror the fresh handoff, and
+	return it. The Atlas Site controller re-signs the session in the guest and returns
+	the Site-mirror shape; we upsert it so the stored URL + expiry stay in lockstep."""
+	from central.central.doctype.site.site import Site
+
+	instance = frappe.get_doc("Atlas Instance", cluster)
+	fresh = AtlasClient(instance).regenerate_site_login(name)
+	Site.mirror_site(cluster, fresh, synced_at=frappe.utils.now_datetime())
+	return fresh
 
 
 @frappe.whitelist(methods=["GET"])

--- a/central/api/sso.py
+++ b/central/api/sso.py
@@ -7,10 +7,11 @@ from central.integrations.atlas import AtlasClient
 from central.sso import _bench_sso_url, mint_bench_assertion
 
 # Open-in-bench: hand the signed-in user a one-click link into their bench VM. For a
-# real VM (asset) that link is the login URL Atlas minted in the guest — a scoped,
-# short-lived admin session; expired ones are regenerated on the click so the link
-# always works. The legacy SSO-assertion path (central.sso) survives only for the
-# gateway_url dev shortcut, until RS256 signing (#21) makes it prod-safe.
+# real VM (asset) that link is a login URL Atlas mints in the guest — a scoped,
+# single-use admin SID (a 5-minute JWT). Because it's single-use, we re-mint on every
+# Open rather than reuse a stored URL, so the click always carries a live, unused SID.
+# The legacy SSO-assertion path (central.sso) survives only for the gateway_url dev
+# shortcut, until RS256 signing (#21) makes it prod-safe.
 
 
 @frappe.whitelist(methods=["GET"])
@@ -45,10 +46,9 @@ def _asset_login_link(asset: str, team: str | None, user: str) -> dict:
 
 	get_doc enforces the team-scoped Asset read perm, so a user who can't see the VM
 	can't probe it here either. The VM must be Running and live on an Active cluster.
-	The login URL comes from the mirror when it's present and unexpired; otherwise
-	Atlas re-mints it (the admin session is short-lived, and the push that carries a
-	fresh URL can lag the mirror by a reconcile cycle) and the mirror is refreshed
-	before we return."""
+	The login URL is always re-minted via Atlas (the admin SID is single-use, so the
+	stored mirror value is worthless on Open) and the mirror is refreshed before we
+	return; if the re-mint can't reach Atlas we hand back nothing and refuse below."""
 	doc = frappe.get_doc("Asset", asset)
 	if team and team != doc.team:
 		frappe.throw("That VM isn't in this team.", frappe.PermissionError)
@@ -60,36 +60,37 @@ def _asset_login_link(asset: str, team: str | None, user: str) -> dict:
 		frappe.throw("That cluster is not active.", frappe.ValidationError)
 	url = _fresh_asset_login_url(doc)
 	if not url:
-		# Running + Active but still no URL: the mirror never carried one and the
-		# re-mint couldn't reach Atlas. Surface it rather than hand back a dead link.
+		# Running + Active but the re-mint couldn't reach Atlas. Surface it rather than
+		# hand back the stored (single-use, likely already-spent) SID as a dead link.
 		frappe.throw("Couldn't get a login URL for this VM. Try again shortly.", frappe.ValidationError)
 	return {"url": url}
 
 
 def _fresh_asset_login_url(doc) -> str:
-	"""The VM's usable login URL: the stored one if it's still good, else a freshly
-	regenerated one.
+	"""The VM's usable login URL: always a freshly regenerated one.
 
-	Re-mint whenever the mirror can't hand back a live URL — the stored one is empty
-	or expired. Empty is the common case just after a VM goes Running: the login mint
-	on the guest lands on Atlas, but the status push that carries it can miss (the
-	Running flip is a db_set that doesn't fire the push), so the mirror only catches
-	up on the next reconcile. Asking Atlas directly closes that window instead of
-	failing Open.
+	Unlike a site session (a reusable 24h browser session), a bench Asset's login URL
+	is a **single-use** admin SID — a 5-minute JWT that `bench generate-admin-session`
+	invalidates the moment it's redeemed. So the stored mirror URL is worthless on
+	Open: even inside its 5-minute clock it may already be spent (the tenant clicked
+	once), and a spent SID is a dead login. We re-mint on every Open so the click
+	always carries a live, unused SID — the timestamp is not a usability signal here.
 
-	Best-effort on the regenerate — if Atlas is unreachable, fall back to the stored
-	URL. That may be empty, but a dead/absent link is no worse than blocking Open, and
-	the caller has already confirmed the VM is Running on an Active cluster."""
-	from central.api.sites import _login_url_expired
+	Re-minting also closes the just-went-Running window where the mirror carries no
+	URL at all: the guest mint lands on Atlas but the status push that carries it can
+	miss (the Running flip is a db_set that doesn't fire the push), so the mirror only
+	catches up on the next reconcile. Asking Atlas directly covers both cases.
 
-	if doc.login_url and not _login_url_expired(doc.login_url_expires_at):
-		return doc.login_url
+	NOT best-effort: if the re-mint can't reach Atlas we return empty (the caller then
+	refuses Open) rather than falling back to the stored URL. For a single-use SID the
+	stored value is almost certainly already consumed, so handing it back would open a
+	dead session — a clean "try again shortly" is better than a broken login."""
 	try:
 		fresh = AtlasClient(frappe.get_doc("Atlas Instance", doc.cluster)).regenerate_vm_login(doc.resource_id)
 		from central.central.doctype.asset.asset import Asset
 
 		Asset.mirror_vm(doc.cluster, fresh, synced_at=frappe.utils.now_datetime())
-		return fresh.get("login_url") or doc.login_url
+		return fresh.get("login_url") or ""
 	except Exception:
 		frappe.log_error(title=f"Regenerate login failed for VM {doc.resource_id}")
-		return doc.login_url
+		return ""

--- a/central/api/sso.py
+++ b/central/api/sso.py
@@ -3,25 +3,34 @@ from __future__ import annotations
 import frappe
 
 from central.iam import can, resolve_team
+from central.integrations.atlas import AtlasClient
 from central.sso import _bench_sso_url, mint_bench_assertion
 
-# Open-in-bench: mint a short-lived SSO assertion for the signed-in user and hand
-# back the bench URL to redirect to. The signing/minting lives in central.sso.
+# Open-in-bench: hand the signed-in user a one-click link into their bench VM. For a
+# real VM (asset) that link is the login URL Atlas minted in the guest — a scoped,
+# short-lived admin session; expired ones are regenerated on the click so the link
+# always works. The legacy SSO-assertion path (central.sso) survives only for the
+# gateway_url dev shortcut, until RS256 signing (#21) makes it prod-safe.
 
 
 @frappe.whitelist(methods=["GET"])
 def get_bench_link(asset: str | None = None, team: str | None = None, gateway_url: str | None = None) -> dict:
-	"""Mint a scoped SSO assertion and return the bench URL to redirect to.
+	"""Return the URL to open a bench VM at.
 
-	Pass `asset` (a server resource_id) to open that server — its team and gateway
-	are resolved and validated (Running, has a gateway, Active cluster). `server:open`
-	on the team is the gate (distinct from `server:view`, which only lists it).
-	`gateway_url` is the dev path used until the registry "Open" wires `asset` in."""
+	Pass `asset` (a server resource_id) to open that server: `server:open` on its
+	team is the gate (distinct from `server:view`, which only lists it), and the VM
+	must be Running with a bench front door on an Active cluster. The URL handed back
+	is Atlas's one-click login URL — a scoped admin session minted in the guest. It is
+	short-lived (an admin JWT lasts minutes), so a stored URL past its expiry is
+	regenerated here before it's returned, keeping the click live.
+
+	`gateway_url` (no asset) is the dev shortcut: mint a shared-secret SSO assertion
+	against an explicit gateway, used only until the registry "Open" wires `asset` in."""
 	user = frappe.session.user
 	if not user or user == "Guest":
 		frappe.throw("Sign in first.", frappe.PermissionError)
 	if asset:
-		team, gateway_url = _resolve_asset_target(asset, team)
+		return _asset_login_link(asset, team, user)
 	team = resolve_team(user, team)
 	if not can(user, team, "server:open"):
 		frappe.throw("You can't open servers for this team.", frappe.PermissionError)
@@ -31,17 +40,56 @@ def get_bench_link(asset: str | None = None, team: str | None = None, gateway_ur
 	return {"url": f"{target}?assertion={mint_bench_assertion(user, team)}"}
 
 
-def _resolve_asset_target(asset: str, team: str | None) -> tuple[str, str]:
-	"""Resolve a VM Asset to (team, gateway_url), refusing anything not openable.
-	get_doc enforces the team-scoped Asset read perm, so a user who can't see the
-	VM can't probe it here either."""
+def _asset_login_link(asset: str, team: str | None, user: str) -> dict:
+	"""Resolve a VM Asset to its usable one-click login URL, gated on `server:open`.
+
+	get_doc enforces the team-scoped Asset read perm, so a user who can't see the VM
+	can't probe it here either. The VM must be Running and live on an Active cluster.
+	The login URL comes from the mirror when it's present and unexpired; otherwise
+	Atlas re-mints it (the admin session is short-lived, and the push that carries a
+	fresh URL can lag the mirror by a reconcile cycle) and the mirror is refreshed
+	before we return."""
 	doc = frappe.get_doc("Asset", asset)
 	if team and team != doc.team:
 		frappe.throw("That VM isn't in this team.", frappe.PermissionError)
+	if not can(user, doc.team, "server:open"):
+		frappe.throw("You can't open servers for this team.", frappe.PermissionError)
 	if doc.status != "Running":
 		frappe.throw(f"VM is {doc.status.lower()}, not running.", frappe.ValidationError)
-	if not doc.gateway_url:
-		frappe.throw("VM has no gateway yet.", frappe.ValidationError)
 	if frappe.db.get_value("Atlas Instance", doc.cluster, "status") != "Active":
 		frappe.throw("That cluster is not active.", frappe.ValidationError)
-	return doc.team, doc.gateway_url
+	url = _fresh_asset_login_url(doc)
+	if not url:
+		# Running + Active but still no URL: the mirror never carried one and the
+		# re-mint couldn't reach Atlas. Surface it rather than hand back a dead link.
+		frappe.throw("Couldn't get a login URL for this VM. Try again shortly.", frappe.ValidationError)
+	return {"url": url}
+
+
+def _fresh_asset_login_url(doc) -> str:
+	"""The VM's usable login URL: the stored one if it's still good, else a freshly
+	regenerated one.
+
+	Re-mint whenever the mirror can't hand back a live URL — the stored one is empty
+	or expired. Empty is the common case just after a VM goes Running: the login mint
+	on the guest lands on Atlas, but the status push that carries it can miss (the
+	Running flip is a db_set that doesn't fire the push), so the mirror only catches
+	up on the next reconcile. Asking Atlas directly closes that window instead of
+	failing Open.
+
+	Best-effort on the regenerate — if Atlas is unreachable, fall back to the stored
+	URL. That may be empty, but a dead/absent link is no worse than blocking Open, and
+	the caller has already confirmed the VM is Running on an Active cluster."""
+	from central.api.sites import _login_url_expired
+
+	if doc.login_url and not _login_url_expired(doc.login_url_expires_at):
+		return doc.login_url
+	try:
+		fresh = AtlasClient(frappe.get_doc("Atlas Instance", doc.cluster)).regenerate_vm_login(doc.resource_id)
+		from central.central.doctype.asset.asset import Asset
+
+		Asset.mirror_vm(doc.cluster, fresh, synced_at=frappe.utils.now_datetime())
+		return fresh.get("login_url") or doc.login_url
+	except Exception:
+		frappe.log_error(title=f"Regenerate login failed for VM {doc.resource_id}")
+		return doc.login_url

--- a/central/central/doctype/asset/asset.json
+++ b/central/central/doctype/asset/asset.json
@@ -18,6 +18,8 @@
   "ipv6_address",
   "public_ipv4",
   "gateway_url",
+  "login_url",
+  "login_url_expires_at",
   "resize_in_progress",
   "last_synced_at",
   "last_event_at"
@@ -109,11 +111,27 @@
    "read_only": 1
   },
   {
-   "description": "The bench gateway Central deep-links into (VM leaf). Reserved — empty until the bench-gateway layer reports it.",
+   "description": "The URL a bench VM is fronted at (https://<title>.<region domain>), reported by Atlas. The console deep-links into it and it backs the login URL. Empty for a non-bench VM.",
    "fieldname": "gateway_url",
    "fieldtype": "Data",
    "label": "Gateway URL",
    "options": "URL"
+  },
+  {
+   "description": "The one-click admin sign-in URL Atlas minted after the bench booted. Short-lived and single-use (see login_url_expires_at); Central regenerates it if the tenant clicks after it expires. Only set once the VM is Running; empty for a non-bench VM.",
+   "fieldname": "login_url",
+   "fieldtype": "Small Text",
+   "label": "Login URL",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "description": "When login_url stops working (Atlas's mint time + the token TTL). Central compares against this to decide 'use it' vs 'regenerate'.",
+   "fieldname": "login_url_expires_at",
+   "fieldtype": "Datetime",
+   "label": "Login URL Expires At",
+   "no_copy": 1,
+   "read_only": 1
   },
   {
    "default": "0",

--- a/central/central/doctype/asset/asset.py
+++ b/central/central/doctype/asset/asset.py
@@ -19,6 +19,8 @@ class Asset(Document):
 		ipv6_address: DF.Data | None
 		last_event_at: DF.Datetime | None
 		last_synced_at: DF.Datetime | None
+		login_url: DF.SmallText | None
+		login_url_expires_at: DF.Datetime | None
 		memory_megabytes: DF.Int
 		plan: DF.Link | None
 		public_ipv4: DF.Data | None
@@ -138,6 +140,12 @@ class Asset(Document):
 		doc.ipv6_address = vm.get("ipv6_address")
 		doc.public_ipv4 = vm.get("public_ipv4")
 		doc.gateway_url = vm.get("gateway_url") or None
+		# Write-once: the bench login URL + its expiry only arrive once the VM is
+		# Running (Atlas gates them on status), so never blank a handoff we've already
+		# stored on a later status-only event. Same rule as Site's login_url.
+		if vm.get("login_url"):
+			doc.login_url = vm["login_url"]
+			doc.login_url_expires_at = vm.get("login_url_expires_at")
 		if occurred_at:
 			doc.last_event_at = occurred_at
 		if synced_at:

--- a/central/central/doctype/site/site.json
+++ b/central/central/doctype/site/site.json
@@ -13,7 +13,8 @@
   "region",
   "status",
   "url",
-  "admin_password",
+  "login_url",
+  "login_url_expires_at",
   "last_synced_at",
   "last_event_at"
  ],
@@ -80,10 +81,19 @@
    "read_only": 1
   },
   {
-   "description": "The baked Administrator password (the tenant handoff). Written once, when the site reaches Running.",
-   "fieldname": "admin_password",
-   "fieldtype": "Password",
-   "label": "Admin Password",
+   "description": "The one-click Administrator sign-in URL Atlas minted after the site went live (the tenant handoff, replacing the shared password). Short-lived (a 24h session); Central regenerates it if the tenant clicks after it expires. Written once, when the site reaches Running; empty before that.",
+   "fieldname": "login_url",
+   "fieldtype": "Small Text",
+   "label": "Login URL",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "description": "When login_url stops working (Atlas's mint time + the session's 24h TTL). Central compares against this to decide 'use it' vs 'regenerate'.",
+   "fieldname": "login_url_expires_at",
+   "fieldtype": "Datetime",
+   "label": "Login URL Expires At",
+   "no_copy": 1,
    "read_only": 1
   },
   {

--- a/central/central/doctype/site/site.py
+++ b/central/central/doctype/site/site.py
@@ -13,10 +13,11 @@ class Site(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		admin_password: DF.Password | None
 		cluster: DF.Link
 		last_event_at: DF.Datetime | None
 		last_synced_at: DF.Datetime | None
+		login_url: DF.SmallText | None
+		login_url_expires_at: DF.Datetime | None
 		region: DF.Data | None
 		site_name: DF.Data
 		status: DF.Literal["Pending", "Provisioning", "Deploying", "Running", "Failed", "Terminated"]
@@ -76,10 +77,12 @@ class Site(Document):
 		doc.region = site.get("region")
 		doc.status = site.get("status") or "Pending"
 		doc.url = site.get("url") or None
-		# Write-once: the handoff password only arrives once Running; never blank a
-		# password we've already stored on a later (e.g. status-only) event.
-		if site.get("admin_password"):
-			doc.admin_password = site["admin_password"]
+		# Write-once: the one-click login URL + its expiry only arrive once Running
+		# (Atlas gates them on status), so never blank a handoff we've already stored on
+		# a later (e.g. status-only) event. Same rule as Asset's login_url.
+		if site.get("login_url"):
+			doc.login_url = site["login_url"]
+			doc.login_url_expires_at = site.get("login_url_expires_at")
 		if occurred_at:
 			doc.last_event_at = occurred_at
 		if synced_at:

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -119,7 +119,12 @@ class AtlasClient:
 		cpu_max_cores: float | None = None,
 	) -> dict:
 		"""Provision a VM on this Atlas for a Central team (the operator write).
-		Returns the new VM in the Asset-mirror shape so the caller can upsert it."""
+		Returns the new VM in the Asset-mirror shape so the caller can upsert it.
+
+		For a bench VM, `title` doubles as the subdomain — Atlas fronts it at
+		`title.<region domain>` and reports that back as gateway_url. The one-click
+		login URL is minted after boot, so it (and its expiry) arrive later on the
+		vm.status_changed event, not in this reply."""
 		params: dict = {
 			"team": team,
 			"title": title,
@@ -177,7 +182,8 @@ class AtlasClient:
 
 	def central_vms(self, team: str | None = None) -> list[dict]:
 		"""Tenant-tagged VMs on this Atlas for the mirror reconcile (optionally one
-		team). One dict per VM: name, team, status, gateway_url."""
+		team). One dict per VM in the Asset-mirror shape — including the bench login
+		handoff (gateway_url + login_url/expiry, the latter only once Running)."""
 		params = {"team": team} if team else None
 		return self.client().get_api("atlas.atlas.api.inventory.tenant_vms", params)
 
@@ -294,10 +300,36 @@ class AtlasClient:
 	def get_site(self, name: str) -> dict:
 		"""
 		Poll one site's current state — the self-heal fallback to the site.* events.
-		Returns the mirror shape, with url + admin_password once the site is Running.
+		Returns the mirror shape, with url + the one-click login_url (and its expiry)
+		once the site is Running.
 		"""
 
 		return self.client().post_api("atlas.atlas.api.site.get_site", params={"name": name})
+
+	def regenerate_site_login(self, name: str) -> dict:
+		"""Re-mint a serving site's one-click login URL and return the fresh Site-mirror
+		shape (url + login_url + login_url_expires_at). Central calls this when a tenant
+		clicks their login link after the stored URL's 24h session has expired — the URL
+		is short-lived by design, so it is re-signed on demand. The Atlas Site controller
+		re-mints in the guest, re-stamps, and returns the mirror."""
+		return self.client().post_api(
+			"run_doc_method",
+			params={"dt": "Site", "dn": name, "method": "regenerate_login_url"},
+		)
+
+	def regenerate_vm_login(self, name: str) -> dict:
+		"""Re-mint a bench VM's one-click login URL and return the fresh Asset-mirror
+		shape (gateway_url + login_url + login_url_expires_at). Central calls this on
+		Open when the Asset's stored URL has expired (the admin JWT lasts 5 minutes, so
+		this is the common path).
+
+		A bench VM's login URL lives on the Pilot that owns the VM, not the pure-microVM
+		Virtual Machine, so this goes through Atlas's provision endpoint, which resolves
+		the VM to its Pilot and re-mints in the guest before returning the payload."""
+		return self.client().post_api(
+			"atlas.atlas.api.provision.regenerate_vm_login",
+			params={"name": name},
+		)
 
 	def check_subdomain(self, subdomain: str, region: str | None = None) -> dict:
 		"""Best-effort availability pre-check: {available, reason, fqdn, domain}."""

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -122,6 +122,134 @@ class TestAtlasMirror(IntegrationTestCase):
 		asset = frappe.get_doc("Asset", "vm-r")
 		self.assertEqual((asset.vcpus, asset.memory_megabytes, asset.disk_gigabytes), (4, 16384, 80))
 
+	def test_bench_login_handoff_mirrors_and_is_write_once(self):
+		# A bench VM reports its front door immediately, but the login URL + expiry only
+		# arrive once Running (Atlas gates them on status).
+		self._push(
+			"vm.created",
+			{"name": "vm-b", "team": self.team.name, "status": "Pending",
+			 "gateway_url": "https://acme.blr1.frappe.dev"},
+			"2026-06-18 10:00:00",
+		)
+		asset = frappe.get_doc("Asset", "vm-b")
+		self.assertEqual(asset.gateway_url, "https://acme.blr1.frappe.dev")
+		self.assertIsNone(asset.login_url)
+
+		# The Running event carries the minted handoff — it lands on the mirror.
+		self._push(
+			"vm.status_changed",
+			{"name": "vm-b", "team": self.team.name, "status": "Running",
+			 "gateway_url": "https://acme.blr1.frappe.dev",
+			 "login_url": "https://acme.blr1.frappe.dev/app?sid=abc",
+			 "login_url_expires_at": "2026-06-18 10:05:00"},
+			"2026-06-18 10:01:00",
+		)
+		asset.reload()
+		self.assertEqual(asset.login_url, "https://acme.blr1.frappe.dev/app?sid=abc")
+		self.assertEqual(str(asset.login_url_expires_at), "2026-06-18 10:05:00")
+
+		# Write-once: a later status-only event (no login_url in the payload — e.g. the
+		# reconcile shape before another Running) must not blank the stored handoff.
+		self._push(
+			"vm.status_changed",
+			{"name": "vm-b", "team": self.team.name, "status": "Stopped",
+			 "gateway_url": "https://acme.blr1.frappe.dev"},
+			"2026-06-18 10:10:00",
+		)
+		asset.reload()
+		self.assertEqual(asset.login_url, "https://acme.blr1.frappe.dev/app?sid=abc")
+
+	def test_site_login_handoff_mirrors_and_is_write_once(self):
+		# A self-serve Site's one-click login URL + expiry only arrive once Running
+		# (Atlas gates them on status), same contract as the bench VM's.
+		fqdn = "handoff.blr1.frappe.dev"
+		self._push(
+			"site.created",
+			{"name": fqdn, "team": self.team.name, "subdomain": "handoff", "status": "Provisioning"},
+			"2026-06-18 10:00:00",
+		)
+		site = frappe.get_doc("Site", fqdn)
+		self.assertIsNone(site.login_url)
+
+		# The Running event carries the minted handoff — it lands on the mirror.
+		self._push(
+			"site.status_changed",
+			{"name": fqdn, "team": self.team.name, "subdomain": "handoff",
+			 "status": "Running", "url": f"https://{fqdn}",
+			 "login_url": f"https://{fqdn}/app?sid=xyz",
+			 "login_url_expires_at": "2026-06-19 10:00:00"},
+			"2026-06-18 10:05:00",
+		)
+		site.reload()
+		self.assertEqual(site.url, f"https://{fqdn}")
+		self.assertEqual(site.login_url, f"https://{fqdn}/app?sid=xyz")
+		self.assertEqual(str(site.login_url_expires_at), "2026-06-19 10:00:00")
+
+		# Write-once: a later status-only event without a login_url must not blank it.
+		self._push(
+			"site.status_changed",
+			{"name": fqdn, "team": self.team.name, "subdomain": "handoff", "status": "Running"},
+			"2026-06-18 10:10:00",
+		)
+		site.reload()
+		self.assertEqual(site.login_url, f"https://{fqdn}/app?sid=xyz")
+
+	def test_get_site_returns_stored_login_url_when_fresh(self):
+		# A Running site with a not-yet-expired login URL: get_site returns it verbatim,
+		# no regenerate round-trip to Atlas.
+		from central.api import sites
+
+		fqdn = "fresh.blr1.frappe.dev"
+		self._push(
+			"site.status_changed",
+			{"name": fqdn, "team": self.team.name, "subdomain": "fresh",
+			 "status": "Running", "url": f"https://{fqdn}",
+			 "login_url": f"https://{fqdn}/app?sid=fresh",
+			 "login_url_expires_at": "2099-01-01 00:00:00"},
+			"2026-06-18 10:05:00",
+		)
+		frappe.set_user(self.owner)
+		try:
+			with patch(
+				"central.integrations.atlas.AtlasClient.regenerate_site_login"
+			) as regen:
+				got = sites.get_site(fqdn)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(got["login_url"], f"https://{fqdn}/app?sid=fresh")
+		regen.assert_not_called()
+
+	def test_get_site_regenerates_expired_login_url(self):
+		# A Running site whose stored login URL has expired: get_site re-mints it via
+		# Atlas, re-mirrors, and returns the fresh URL.
+		from central.api import sites
+
+		fqdn = "stale.blr1.frappe.dev"
+		self._push(
+			"site.status_changed",
+			{"name": fqdn, "team": self.team.name, "subdomain": "stale",
+			 "status": "Running", "url": f"https://{fqdn}",
+			 "login_url": f"https://{fqdn}/app?sid=stale",
+			 "login_url_expires_at": "2000-01-01 00:00:00"},
+			"2026-06-18 10:05:00",
+		)
+		fresh = {
+			"name": fqdn, "team": self.team.name, "subdomain": "stale",
+			"status": "Running", "url": f"https://{fqdn}",
+			"login_url": f"https://{fqdn}/app?sid=fresh",
+			"login_url_expires_at": "2099-01-01 00:00:00",
+		}
+		frappe.set_user(self.owner)
+		try:
+			with patch(
+				"central.integrations.atlas.AtlasClient.regenerate_site_login", return_value=fresh
+			) as regen:
+				got = sites.get_site(fqdn)
+		finally:
+			frappe.set_user("Administrator")
+		regen.assert_called_once_with(fqdn)
+		self.assertEqual(got["login_url"], f"https://{fqdn}/app?sid=fresh")
+
 	def test_resize_vm_posts_run_doc_method_with_args(self):
 		import json
 

--- a/central/tests/test_open_bench.py
+++ b/central/tests/test_open_bench.py
@@ -7,10 +7,12 @@ from central.api.sso import get_bench_link
 from central.tests.test_iam import ensure_user
 
 # Open-in-bench for a real VM (asset) now hands back Atlas's one-click login URL —
-# the scoped admin session minted in the guest — not a Central-signed SSO assertion.
-# A stored URL that's still good is returned verbatim (no Atlas round-trip); an
-# expired one is regenerated on the click. The legacy SSO-assertion path survives
-# only for the explicit `gateway_url` dev shortcut (covered by test_sso.py).
+# the scoped admin SID minted in the guest — not a Central-signed SSO assertion.
+# The SID is single-use (a 5-minute JWT `bench generate-admin-session` invalidates on
+# redeem), so Open ALWAYS re-mints via Atlas — even a stored, unexpired URL is spent
+# once clicked. If the re-mint can't reach Atlas, Open is refused (the stored SID is
+# no fallback — it's dead). The legacy SSO-assertion path survives only for the
+# explicit `gateway_url` dev shortcut (covered by test_sso.py).
 
 FUTURE = "2099-01-01 00:00:00"
 PAST = "2000-01-01 00:00:00"
@@ -86,12 +88,26 @@ class TestOpenBench(IntegrationTestCase):
 		finally:
 			frappe.set_user("Administrator")
 
-	def test_open_running_vm_returns_its_login_url(self):
-		"""A still-valid stored login URL is handed back verbatim — no Atlas round-trip."""
-		with patch("central.integrations.atlas.AtlasClient.regenerate_vm_login") as regen:
+	def test_open_running_vm_always_regenerates_sid(self):
+		"""Even a stored, unexpired login URL is re-minted on Open — the bench SID is
+		single-use, so the stored value may already be spent. The fresh URL is returned
+		(and mirrored back), never the stored one."""
+		fresh_url = "https://vm-open-1.blr1.frappe.dev/app?sid=fresh"
+		fresh_payload = {
+			"name": "vm-open-1",
+			"team": self.team.name,
+			"status": "Running",
+			"gateway_url": "https://vm-open-1.blr1.frappe.dev",
+			"login_url": fresh_url,
+			"login_url_expires_at": FUTURE,
+		}
+		with patch(
+			"central.integrations.atlas.AtlasClient.regenerate_vm_login", return_value=fresh_payload
+		) as regen:
 			link = self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
-		self.assertEqual(link["url"], STORED_URL)
-		regen.assert_not_called()
+		regen.assert_called_once_with("vm-open-1")
+		self.assertEqual(link["url"], fresh_url)
+		self.assertEqual(frappe.db.get_value("Asset", "vm-open-1", "login_url"), fresh_url)
 
 	def test_expired_login_url_is_regenerated(self):
 		"""An expired stored URL triggers a re-mint via Atlas, and the fresh URL is
@@ -114,15 +130,16 @@ class TestOpenBench(IntegrationTestCase):
 		self.assertEqual(link["url"], fresh_url)
 		self.assertEqual(frappe.db.get_value("Asset", "vm-open-1", "login_url"), fresh_url)
 
-	def test_regenerate_failure_falls_back_to_stored_url(self):
-		"""If Atlas is unreachable when regenerating, Open falls back to the stored URL
-		rather than blocking — a possibly-dead link is no worse than no link."""
-		self._asset("vm-open-1", "Running", login_url=STORED_URL, expires_at=PAST)
+	def test_regenerate_failure_refuses_rather_than_serving_stored_url(self):
+		"""If Atlas is unreachable when regenerating, Open is refused — the stored SID is
+		single-use and almost certainly spent, so handing it back would open a dead
+		session. A clean 'try again shortly' beats a broken login."""
+		self._asset("vm-open-1", "Running", login_url=STORED_URL, expires_at=FUTURE)
 		with patch(
 			"central.integrations.atlas.AtlasClient.regenerate_vm_login", side_effect=Exception("down")
 		):
-			link = self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
-		self.assertEqual(link["url"], STORED_URL)
+			with self.assertRaises(frappe.ValidationError):
+				self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
 
 	def test_viewer_without_vm_open_is_blocked(self):
 		with self.assertRaises(frappe.PermissionError):

--- a/central/tests/test_open_bench.py
+++ b/central/tests/test_open_bench.py
@@ -1,26 +1,33 @@
+from unittest.mock import patch
+
 import frappe
-import jwt
 from frappe.tests import IntegrationTestCase
 
 from central.api.sso import get_bench_link
-from central.sso import _central_url, _ensure_oauth_client
 from central.tests.test_iam import ensure_user
+
+# Open-in-bench for a real VM (asset) now hands back Atlas's one-click login URL —
+# the scoped admin session minted in the guest — not a Central-signed SSO assertion.
+# A stored URL that's still good is returned verbatim (no Atlas round-trip); an
+# expired one is regenerated on the click. The legacy SSO-assertion path survives
+# only for the explicit `gateway_url` dev shortcut (covered by test_sso.py).
+
+FUTURE = "2099-01-01 00:00:00"
+PAST = "2000-01-01 00:00:00"
+STORED_URL = "https://vm-open-1.blr1.frappe.dev/app?sid=stored"
 
 
 class TestOpenBench(IntegrationTestCase):
 	def setUp(self):
 		frappe.set_user("Administrator")
-		self._orig = frappe.conf.get("sso_allow_insecure_hs256")
-		frappe.conf.sso_allow_insecure_hs256 = 1
 		self.owner = ensure_user("open.owner@example.test")
 		self.dev = ensure_user("open.dev@example.test")
 		self.viewer = ensure_user("open.viewer@example.test")
 		self.team = self._team()
 		self.cluster = self._cluster("blr-open")
-		self.asset = self._asset("vm-open-1", "Running", "http://localhost:3030")
+		self.asset = self._asset("vm-open-1", "Running", login_url=STORED_URL, expires_at=FUTURE)
 
 	def tearDown(self):
-		frappe.conf.sso_allow_insecure_hs256 = self._orig
 		frappe.set_user("Administrator")
 
 	def _team(self):
@@ -56,7 +63,7 @@ class TestOpenBench(IntegrationTestCase):
 		).insert()
 		return region
 
-	def _asset(self, rid, status, gateway):
+	def _asset(self, rid, status, *, login_url="", expires_at=None, gateway="https://vm-open-1.blr1.frappe.dev"):
 		if frappe.db.exists("Asset", rid):
 			frappe.delete_doc("Asset", rid, force=True, ignore_permissions=True)
 		return frappe.get_doc(
@@ -67,19 +74,10 @@ class TestOpenBench(IntegrationTestCase):
 				"cluster": self.cluster,
 				"status": status,
 				"gateway_url": gateway or None,
+				"login_url": login_url or None,
+				"login_url_expires_at": expires_at,
 			}
 		).insert(ignore_permissions=True)
-
-	def _verify(self, token):
-		client = _ensure_oauth_client()
-		return jwt.decode(
-			token,
-			client.client_secret,
-			algorithms=["HS256"],
-			audience=client.client_id,
-			issuer=_central_url(),
-			options={"require": ["exp", "aud", "iss", "sub"]},
-		)
 
 	def _as(self, user, fn):
 		frappe.set_user(user)
@@ -88,26 +86,83 @@ class TestOpenBench(IntegrationTestCase):
 		finally:
 			frappe.set_user("Administrator")
 
-	def test_open_running_vm_mints_for_its_gateway(self):
-		link = self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
-		self.assertTrue(link["url"].startswith("http://localhost:3030/sso?assertion="))
-		claims = self._verify(link["url"].split("assertion=", 1)[1])
-		self.assertEqual(claims["sub"], self.dev)
-		self.assertEqual(claims["team"], self.team.name)
+	def test_open_running_vm_returns_its_login_url(self):
+		"""A still-valid stored login URL is handed back verbatim — no Atlas round-trip."""
+		with patch("central.integrations.atlas.AtlasClient.regenerate_vm_login") as regen:
+			link = self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
+		self.assertEqual(link["url"], STORED_URL)
+		regen.assert_not_called()
+
+	def test_expired_login_url_is_regenerated(self):
+		"""An expired stored URL triggers a re-mint via Atlas, and the fresh URL is
+		returned (and mirrored back onto the Asset)."""
+		self._asset("vm-open-1", "Running", login_url=STORED_URL, expires_at=PAST)
+		fresh_url = "https://vm-open-1.blr1.frappe.dev/app?sid=fresh"
+		fresh_payload = {
+			"name": "vm-open-1",
+			"team": self.team.name,
+			"status": "Running",
+			"gateway_url": "https://vm-open-1.blr1.frappe.dev",
+			"login_url": fresh_url,
+			"login_url_expires_at": FUTURE,
+		}
+		with patch(
+			"central.integrations.atlas.AtlasClient.regenerate_vm_login", return_value=fresh_payload
+		) as regen:
+			link = self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
+		regen.assert_called_once_with("vm-open-1")
+		self.assertEqual(link["url"], fresh_url)
+		self.assertEqual(frappe.db.get_value("Asset", "vm-open-1", "login_url"), fresh_url)
+
+	def test_regenerate_failure_falls_back_to_stored_url(self):
+		"""If Atlas is unreachable when regenerating, Open falls back to the stored URL
+		rather than blocking — a possibly-dead link is no worse than no link."""
+		self._asset("vm-open-1", "Running", login_url=STORED_URL, expires_at=PAST)
+		with patch(
+			"central.integrations.atlas.AtlasClient.regenerate_vm_login", side_effect=Exception("down")
+		):
+			link = self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
+		self.assertEqual(link["url"], STORED_URL)
 
 	def test_viewer_without_vm_open_is_blocked(self):
 		with self.assertRaises(frappe.PermissionError):
 			self._as(self.viewer, lambda: get_bench_link(asset="vm-open-1"))
 
 	def test_stopped_vm_refused(self):
-		self._asset("vm-open-1", "Stopped", "http://localhost:3030")
+		self._asset("vm-open-1", "Stopped", login_url=STORED_URL, expires_at=FUTURE)
 		with self.assertRaises(frappe.ValidationError):
 			self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
 
-	def test_missing_gateway_refused(self):
-		self._asset("vm-open-1", "Running", "")
-		with self.assertRaises(frappe.ValidationError):
-			self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
+	def test_missing_login_url_is_regenerated(self):
+		"""An empty mirror login_url (the push that carries it lagged behind the reconcile)
+		is re-minted via Atlas rather than refused — Open shouldn't block on mirror lag."""
+		self._asset("vm-open-1", "Running", login_url="", expires_at=None)
+		fresh_url = "https://vm-open-1.blr1.frappe.dev/app?sid=minted"
+		fresh_payload = {
+			"name": "vm-open-1",
+			"team": self.team.name,
+			"status": "Running",
+			"gateway_url": "https://vm-open-1.blr1.frappe.dev",
+			"login_url": fresh_url,
+			"login_url_expires_at": FUTURE,
+		}
+		with patch(
+			"central.integrations.atlas.AtlasClient.regenerate_vm_login", return_value=fresh_payload
+		) as regen:
+			link = self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
+		regen.assert_called_once_with("vm-open-1")
+		self.assertEqual(link["url"], fresh_url)
+		self.assertEqual(frappe.db.get_value("Asset", "vm-open-1", "login_url"), fresh_url)
+
+	def test_missing_login_url_and_atlas_down_refused(self):
+		"""Empty mirror URL AND Atlas unreachable: there's no live link to hand back, so
+		Open is refused with a clear message rather than opening a dead/empty URL."""
+		self._asset("vm-open-1", "Running", login_url="", expires_at=None)
+		with patch(
+			"central.integrations.atlas.AtlasClient.regenerate_vm_login", side_effect=Exception("down")
+		):
+			with self.assertRaises(frappe.ValidationError):
+				self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
 
 	def test_disabled_cluster_refused(self):
 		frappe.db.set_value("Atlas Instance", self.cluster, "status", "Disabled")

--- a/console/src/pages/onboarding/SiteReadyPage.vue
+++ b/console/src/pages/onboarding/SiteReadyPage.vue
@@ -6,16 +6,15 @@ import AuthShell from '@/components/auth/AuthShell.vue'
 import { API } from '@/api/methods'
 import { frappeErrorMessage, getFrappe, methodUrl } from '@/lib/auth'
 
-type SiteState = { name: string; status: string; url: string | null; admin_password: string | null }
+type SiteState = { name: string; status: string; url: string | null; login_url: string | null }
 
-const POLL_MS = 3000
+const POLL_MS = 1000
 
 const route = useRoute()
 const name = String(route.params.name ?? '')
 
 const site = ref<SiteState | null>(null)
 const error = ref('')
-const copied = ref(false)
 let timer: ReturnType<typeof setTimeout> | undefined
 
 const isReady = computed(() => site.value?.status === 'Running')
@@ -25,7 +24,8 @@ async function poll() {
   try {
     const result = await getFrappe<SiteState>(methodUrl(API.getSite), { name })
     site.value = result
-    if (result.status === 'Running' || result.status === 'Failed') return
+    if (result.status === 'Running') return signIn()
+    if (result.status === 'Failed') return
   } catch (exception) {
     error.value = frappeErrorMessage(exception, 'Lost track of your site. Refresh to retry.')
     return
@@ -33,11 +33,14 @@ async function poll() {
   timer = setTimeout(poll, POLL_MS)
 }
 
-async function copyPassword() {
-  if (!site.value?.admin_password) return
-  await navigator.clipboard.writeText(site.value.admin_password)
-  copied.value = true
-  setTimeout(() => (copied.value = false), 2000)
+// The site is ready: log the tenant straight in by navigating this tab to the
+// one-click login URL. No button, no password — the poll landing on Running IS
+// the handoff. If the site somehow reported Running without a login URL, fall
+// through to the manual state so the tenant isn't stranded.
+function signIn() {
+  const url = site.value?.login_url
+  if (!url) return
+  window.location.assign(url)
 }
 
 onMounted(poll)
@@ -52,34 +55,14 @@ onUnmounted(() => clearTimeout(timer))
       </div>
       <h1 class="text-2xl font-semibold text-ink-gray-9">Your site is ready</h1>
       <p class="mt-2 text-base text-ink-gray-5">
-        Sign in as <span class="font-medium text-ink-gray-8">Administrator</span> with the password below.
+        Signing you in to <span class="font-medium text-ink-gray-8">{{ site.url }}</span> as
+        <span class="font-medium text-ink-gray-8">Administrator</span>…
       </p>
 
-      <div class="mt-8 space-y-3">
-        <div>
-          <span class="text-sm font-medium text-ink-gray-8">Site address</span>
-          <p class="mt-1 break-all text-base text-ink-gray-9">{{ site.url }}</p>
-        </div>
-        <div>
-          <span class="text-sm font-medium text-ink-gray-8">Administrator password</span>
-          <div class="mt-1 flex items-center gap-2">
-            <code class="flex-1 break-all rounded bg-surface-gray-2 px-3 py-2 text-base text-ink-gray-9">
-              {{ site.admin_password }}
-            </code>
-            <Button
-              variant="outline"
-              size="md"
-              :label="copied ? 'Copied' : 'Copy'"
-              :icon="copied ? 'lucide-check' : 'lucide-copy'"
-              @click="copyPassword"
-            />
-          </div>
-        </div>
+      <div class="mt-8 flex items-center gap-3 text-ink-gray-5">
+        <span class="lucide-loader-circle size-5 animate-spin" aria-hidden="true" />
+        <span class="text-base">Taking you to your site…</span>
       </div>
-
-      <a :href="site.url ?? '#'" target="_blank" rel="noopener" class="mt-8 block">
-        <Button variant="solid" size="md" class="w-full">Go to site</Button>
-      </a>
     </template>
 
     <template v-else-if="isFailed">


### PR DESCRIPTION
**Replace admin-password handoff with a one-click login URL**

Sites and bench VMs now hand tenants a short-lived one-click login URL (a scoped admin session minted by Atlas in the guest) instead of a baked Administrator password.

- Mirror `login_url` + `login_url_expires_at` on Asset and Site (write-once, only once Running).
- Regenerate the URL on read when the stored one is expired or missing — `get_site` (onboarding poll) and open-in-bench both re-mint via Atlas rather than hand back a dead link. Best-effort: falls back to the stored URL if Atlas is unreachable.
- Open-in-bench returns Atlas's login URL for real VMs; the legacy SSO-assertion path survives only for the `gateway_url` dev shortcut.
- Onboarding now signs the tenant straight in when the site goes Running — no password to copy.