### PR TITLE
chore(console): UI polish pass across servers, billing, and notifications

### DIFF
--- a/console/src/components/billing/BillingCard.vue
+++ b/console/src/components/billing/BillingCard.vue
@@ -10,7 +10,7 @@ defineProps<{ title: string; description?: string; titleInfo?: string }>()
 
 <template>
   <section class="rounded-xl border border-outline-gray-2 bg-surface-elevation-1">
-    <header class="flex items-start justify-between gap-3 px-5 pt-4">
+    <header class="flex items-center justify-between gap-3 px-5 pt-4">
       <div class="min-w-0">
         <div class="flex items-center gap-1.5">
           <h2 class="truncate text-base font-semibold text-ink-gray-8">{{ title }}</h2>
@@ -24,7 +24,7 @@ defineProps<{ title: string; description?: string; titleInfo?: string }>()
         <slot name="action" />
       </div>
     </header>
-    <div class="px-5 pb-5 pt-2">
+    <div class="px-5 pb-5 pt-4">
       <slot />
     </div>
   </section>

--- a/console/src/components/billing/BillingContactTaxCard.vue
+++ b/console/src/components/billing/BillingContactTaxCard.vue
@@ -32,6 +32,7 @@ const isIndia = computed(() => country.value === 'India')
       <Button
         v-if="canManageBilling"
         variant="ghost"
+        size="xs"
         icon="lucide-pencil"
         aria-label="Edit billing contact & tax"
         @click="$emit('edit')"

--- a/console/src/components/billing/CollectionActionBanner.vue
+++ b/console/src/components/billing/CollectionActionBanner.vue
@@ -5,6 +5,7 @@
 // is an invitation to decide. Backend feed: get_collection_status.
 import { computed, ref } from 'vue'
 import { useCall, Dialog, Button } from 'frappe-ui'
+import Alert from '@/components/common/Alert.vue'
 import { API, method } from '@/api/methods'
 import { useSession } from '@/composables/useSession'
 import { whenTeamReady } from '@/composables/useTeamScope'
@@ -70,39 +71,20 @@ const options = [
 </script>
 
 <template>
-  <div
+  <Alert
     v-if="show && s"
-    class="flex flex-col gap-3 rounded-lg border border-outline-amber-2 bg-surface-amber-1 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
-    role="status"
-    aria-live="polite"
+    theme="yellow"
+    title="Action required — choose how to keep paying"
+    :action="canManageBilling ? { label: 'Choose how to pay', onClick: () => (choosing = true) } : null"
   >
-    <div class="flex items-start gap-3">
-      <span
-        class="lucide-triangle-alert mt-0.5 size-5 shrink-0 text-ink-amber-7"
-        aria-hidden="true"
-      />
-      <div class="space-y-0.5">
-        <p class="text-base font-medium text-ink-gray-9">
-          Action required — choose how to keep paying
-        </p>
-        <p class="text-p-sm text-ink-gray-7">
-          Your usage is trending to
-          <span class="font-medium">{{ money(s.projected_total, currency) }}</span>
-          this month, above the
-          <span class="font-medium">{{ money(s.threshold, currency) }}</span>
-          limit for automatic payments. Your services keep running.
-        </p>
-      </div>
-    </div>
-    <Button
-      v-if="canManageBilling"
-      variant="solid"
-      theme="gray"
-      label="Choose how to pay"
-      class="shrink-0"
-      @click="choosing = true"
-    />
-  </div>
+    <template #description>
+      Your usage is trending to
+      <span class="font-medium">{{ money(s.projected_total, currency) }}</span>
+      this month, above the
+      <span class="font-medium">{{ money(s.threshold, currency) }}</span>
+      limit for automatic payments. Your services keep running.
+    </template>
+  </Alert>
 
   <Dialog
     v-model:open="choosing"

--- a/console/src/components/billing/EstimatedCard.vue
+++ b/console/src/components/billing/EstimatedCard.vue
@@ -105,17 +105,18 @@ async function submitAlert(): Promise<void> {
         <template v-if="daysRemaining != null"> · {{ daysRemaining }} days left</template>
       </p>
 
-      <Button
-        v-if="canManageBilling"
-        variant="ghost"
-        size="sm"
-        class="mt-auto -ml-2 self-start"
-        :class="alertTint"
-        :label="alertLabel"
-        @click="openDialog"
-      >
-        <template #prefix><span class="lucide-bell size-4" aria-hidden="true" /></template>
-      </Button>
+      <div v-if="canManageBilling" class="mt-auto pt-4">
+        <Button
+          variant="ghost"
+          size="sm"
+          class="-ml-2"
+          :class="alertTint"
+          :label="alertLabel"
+          @click="openDialog"
+        >
+          <template #prefix><span class="lucide-bell size-4" aria-hidden="true" /></template>
+        </Button>
+      </div>
     </template>
 
     <Dialog v-model:open="dialogOpen" title="Set a budget alert">

--- a/console/src/components/billing/MeteredServicesCard.vue
+++ b/console/src/components/billing/MeteredServicesCard.vue
@@ -84,11 +84,7 @@ function exhausted(row: ServiceRow): boolean {
     title-info="Team-level services billed by usage (AI tokens, email, PDF, storage) — no server required."
   >
     <template v-if="canManageBilling && plans.length" #action>
-      <Button label="Add service" @click="dialogOpen = true">
-        <template #prefix>
-          <span class="lucide-plus size-4" aria-hidden="true" />
-        </template>
-      </Button>
+      <Button size="xs" label="Add service" icon-left="lucide-plus" @click="dialogOpen = true" />
     </template>
 
     <div v-if="loading" class="space-y-3 py-1">

--- a/console/src/components/billing/PaymentMethodsCard.vue
+++ b/console/src/components/billing/PaymentMethodsCard.vue
@@ -116,6 +116,7 @@ function onAdd(): void {
       <Button
         v-if="canManageBilling"
         variant="ghost"
+        size="xs"
         icon="lucide-plus"
         :aria-label="ordered.length ? 'Add backup method' : 'Add payment method'"
         @click="onAdd"

--- a/console/src/components/billing/WalletCard.vue
+++ b/console/src/components/billing/WalletCard.vue
@@ -79,10 +79,7 @@ function onAddCredit(): void {
         <span class="lucide-credit-card size-3.5 shrink-0 text-ink-gray-4" aria-hidden="true" />
         Card covers the rest
       </p>
-      <p v-else class="mt-1.5 flex items-center gap-1.5 text-p-sm text-ink-gray-5">
-        <span class="lucide-circle-check size-3.5 shrink-0 text-ink-green-2" aria-hidden="true" />
-        Covers this invoice
-      </p>
+      <p v-else class="mt-1.5 text-p-sm text-ink-gray-5">Covers this invoice</p>
 
       <!-- Funding actions, once there's a method to charge. -->
       <div

--- a/console/src/components/billing/WalletHistoryPanel.vue
+++ b/console/src/components/billing/WalletHistoryPanel.vue
@@ -39,9 +39,13 @@ function isCredit(entry: CreditLedgerEntry): boolean {
 </script>
 
 <template>
+  <!-- The tray animates its width (see the page's .wallet-tray-* classes); the
+       inner column keeps its own fixed width so content is revealed by the
+       clipping shell instead of reflowing while the width changes. -->
   <aside
-    class="flex w-full shrink-0 flex-col overflow-hidden border-outline-gray-1 bg-surface-elevation-1 sm:w-[30rem] sm:border-l"
+    class="w-full shrink-0 overflow-hidden border-outline-gray-1 bg-surface-elevation-1 sm:w-[30rem] sm:border-l"
   >
+    <div class="flex h-full w-full flex-col sm:w-[30rem]">
     <header class="flex items-start justify-between gap-3 border-b border-outline-gray-1 px-5 py-4">
       <div>
         <h2 class="text-base font-medium text-ink-gray-9">Wallet history</h2>
@@ -114,6 +118,7 @@ function isCredit(entry: CreditLedgerEntry): boolean {
       </Button>
     </footer>
 
-    <TopupDialog v-model="showTopup" :currency="currency" @done="reloadMoney" />
+      <TopupDialog v-model="showTopup" :currency="currency" @done="reloadMoney" />
+    </div>
   </aside>
 </template>

--- a/console/src/components/common/Alert.vue
+++ b/console/src/components/common/Alert.vue
@@ -1,0 +1,112 @@
+<template>
+  <!-- A token-only status alert. Two shapes from one component:
+       • block  — icon + title + description (multi-line)
+       • banner — icon + title with action(s) on the right
+       Neutral surface for every theme; colour comes from the solid status icon
+       and the ghost action buttons. Per spec: the red (error) theme turns its
+       *title* red (the description stays gray); the primary action is tinted the
+       icon colour, secondary actions are gray. -->
+  <div
+    v-if="visible"
+    role="alert"
+    class="flex gap-2.5 rounded-lg bg-surface-alpha-gray-1 px-4 py-3.5"
+    :class="hasBody ? 'items-start' : 'items-center'"
+  >
+    <slot name="icon">
+      <!-- Solid status icon — the glyph is negative space, so it reads through
+           on any background. Coloured via currentColor (the theme accent). -->
+      <svg
+        v-if="icon"
+        viewBox="0 0 16 16"
+        fill="none"
+        class="size-4 shrink-0"
+        :class="[accentText, hasBody ? 'mt-0.5' : '']"
+        aria-hidden="true"
+      >
+        <path :d="icon" fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" />
+      </svg>
+    </slot>
+
+    <div class="min-w-0 flex-1">
+      <div class="text-base font-medium" :class="titleColor">{{ title }}</div>
+      <div v-if="description || $slots.description" class="mt-0.5 text-p-sm text-ink-gray-6">
+        <slot name="description">{{ description }}</slot>
+      </div>
+    </div>
+
+    <div v-if="actions.length || $slots.action || $slots.footer || dismissible" class="-my-1 flex shrink-0 items-center gap-1 self-center">
+      <slot name="action" />
+      <slot name="footer" />
+      <button
+        v-for="(a, i) in actions"
+        :key="i"
+        type="button"
+        class="flex items-center gap-1.5 whitespace-nowrap rounded px-2 py-1 text-base font-medium transition-colors hover:bg-surface-gray-3"
+        :class="i === 0 ? accentText : 'text-ink-gray-7'"
+        @click="a.onClick"
+      >
+        <span v-if="a.icon" class="size-4" :class="a.icon" />
+        {{ a.label }}
+      </button>
+      <button v-if="dismissible" type="button" aria-label="Dismiss" class="ml-1" @click="dismiss">
+        <span class="lucide-x size-4 text-ink-gray-5" aria-hidden="true" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, useSlots } from 'vue'
+
+// Drop-in for frappe-ui's Alert: same theme names, props and slots.
+const props = defineProps({
+  theme: { type: String, default: '' }, // 'blue' | 'green' | 'yellow' | 'red'
+  title: { type: String, default: '' },
+  description: { type: String, default: '' },
+  variant: { type: String, default: 'subtle' }, // accepted for API parity
+  dismissible: { type: Boolean, default: false },
+  // One action object, or an array of them — each { label, onClick, icon? }.
+  action: { type: [Object, Array], default: null },
+})
+const visible = defineModel({ default: true })
+const emit = defineEmits(['dismiss'])
+const slots = useSlots()
+
+function dismiss() {
+  visible.value = false
+  emit('dismiss')
+}
+
+const actions = computed(() =>
+  !props.action ? [] : Array.isArray(props.action) ? props.action : [props.action],
+)
+
+// Block when there's a description; banner (centred) otherwise.
+const hasBody = computed(() => !!(props.description || slots.description))
+
+// Each theme's accent colour, reused for the icon and the primary action.
+const accentText = computed(
+  () =>
+    ({
+      blue: 'text-[var(--ink-blue-7)]',
+      green: 'text-[var(--ink-green-7)]',
+      red: 'text-[var(--ink-red-7)]',
+      yellow: 'text-[var(--ink-amber-7)]',
+    })[props.theme] || 'text-ink-gray-8',
+)
+
+// Solid 16×16 status icons (glyph is a cut-out, so currentColor fills the shape).
+const icon = computed(
+  () =>
+    ({
+      blue: 'M8 1C11.866 1 15 4.13401 15 8C15 11.866 11.866 15 8 15C4.13401 15 1 11.866 1 8C1 4.13401 4.13401 1 8 1ZM8 6.93652C7.72386 6.93652 7.5 7.16038 7.5 7.43652V11.1436C7.50005 11.4197 7.72389 11.6436 8 11.6436C8.27611 11.6436 8.49995 11.4197 8.5 11.1436V7.43652C8.5 7.16038 8.27614 6.93652 8 6.93652ZM8 4C7.51675 4 7.125 4.39175 7.125 4.875C7.125 5.35825 7.51675 5.75 8 5.75C8.48325 5.75 8.875 5.35825 8.875 4.875C8.875 4.39175 8.48325 4 8 4Z',
+      green: 'M8 1C11.866 1 15 4.13401 15 8C15 11.866 11.866 15 8 15C4.13401 15 1 11.866 1 8C1 4.13401 4.13401 1 8 1ZM11.1055 5.28125C10.8924 5.10562 10.5771 5.13567 10.4014 5.34863L6.95215 9.53223L5.61035 7.79883C5.44143 7.58051 5.12757 7.54022 4.90918 7.70898C4.69088 7.8779 4.65061 8.19177 4.81934 8.41016L6.54395 10.6396C6.63696 10.7598 6.77972 10.8306 6.93164 10.833C7.08364 10.8354 7.22849 10.7687 7.3252 10.6514L11.1729 5.98438C11.3481 5.77144 11.3181 5.45689 11.1055 5.28125Z',
+      red: 'M8 1C11.866 1 15 4.13401 15 8C15 11.866 11.866 15 8 15C4.13401 15 1 11.866 1 8C1 4.13401 4.13401 1 8 1ZM10.8535 5.14648C10.6583 4.95122 10.3417 4.95122 10.1465 5.14648L8 7.29297L5.85352 5.14648C5.65825 4.95122 5.34175 4.95122 5.14648 5.14648C4.95122 5.34175 4.95122 5.65825 5.14648 5.85352L7.29297 8L5.14648 10.1465C4.95122 10.3417 4.95122 10.6583 5.14648 10.8535C5.34175 11.0488 5.65825 11.0488 5.85352 10.8535L8 8.70703L10.1465 10.8535C10.3417 11.0488 10.6583 11.0488 10.8535 10.8535C11.0488 10.6583 11.0488 10.3417 10.8535 10.1465L8.70703 8L10.8535 5.85352C11.0488 5.65825 11.0488 5.34175 10.8535 5.14648Z',
+      yellow:
+        'M7.35174 1.97129C7.64143 1.47669 8.35697 1.47669 8.64666 1.97129L15.0519 12.9078C15.3447 13.4077 14.9847 14.0365 14.4055 14.0367H1.59295C1.0138 14.0364 0.653701 13.4077 0.946469 12.9078L7.35174 1.97129ZM7.9992 10.4117C7.51609 10.4118 7.12433 10.8036 7.1242 11.2867C7.1242 11.7699 7.51601 12.1617 7.9992 12.1617C8.48245 12.1617 8.8742 11.77 8.8742 11.2867C8.87408 10.8036 8.48238 10.4117 7.9992 10.4117ZM8.00018 5.50742C7.72411 5.50742 7.5003 5.73139 7.50018 6.00742V9.25742C7.50018 9.53356 7.72404 9.75742 8.00018 9.75742C8.27615 9.75723 8.50018 9.53344 8.50018 9.25742V6.00742C8.50006 5.73151 8.27608 5.50762 8.00018 5.50742Z',
+    })[props.theme] || '',
+)
+
+// Only the title carries the error colour; the description stays gray.
+const titleColor = computed(() => (props.theme === 'red' ? 'text-ink-red-7' : 'text-ink-gray-9'))
+</script>

--- a/console/src/components/common/EmptyState.vue
+++ b/console/src/components/common/EmptyState.vue
@@ -18,7 +18,7 @@ withDefaults(
     class="flex min-h-64 flex-col items-center justify-center rounded-lg border border-dashed border-outline-gray-3 px-6 py-12 text-center"
   >
     <div
-      class="flex size-10 items-center justify-center rounded-full bg-surface-gray-2 text-ink-gray-5"
+      class="flex size-10 items-center justify-center rounded-lg bg-surface-gray-2 text-ink-gray-5"
     >
       <span :class="[icon, 'size-4']" aria-hidden="true" />
     </div>

--- a/console/src/components/common/ErrorBoundary.vue
+++ b/console/src/components/common/ErrorBoundary.vue
@@ -30,7 +30,7 @@ function reload(): void {
     v-if="failed"
     class="flex min-h-screen flex-col items-center justify-center px-6 py-12 text-center"
   >
-    <div class="flex size-10 items-center justify-center rounded-full bg-surface-red-1 text-ink-red-7">
+    <div class="flex size-10 items-center justify-center rounded-lg bg-surface-red-1 text-ink-red-7">
       <span class="lucide-triangle-alert size-5" aria-hidden="true" />
     </div>
     <p class="mt-4 text-base font-medium text-ink-gray-8">This page ran into a problem</p>

--- a/console/src/components/common/PageHeader.vue
+++ b/console/src/components/common/PageHeader.vue
@@ -1,19 +1,14 @@
 <script setup lang="ts">
-
 defineProps<{
   title: string
-  subtitle?: string
 }>()
 </script>
 
 <template>
   <header
-    class="flex items-center justify-between gap-3 border-b border-outline-gray-1 px-4 py-3 sm:px-6"
+    class="flex h-12 items-center justify-between gap-3 border-b border-outline-gray-1 px-4 sm:px-6"
   >
-    <div class="min-w-0">
-      <h1 class="truncate text-lg font-semibold text-ink-gray-9">{{ title }}</h1>
-      <p v-if="subtitle" class="truncate text-p-sm text-ink-gray-5">{{ subtitle }}</p>
-    </div>
+    <h1 class="min-w-0 truncate text-lg font-medium text-ink-gray-9">{{ title }}</h1>
     <div class="flex shrink-0 items-center gap-2">
       <slot name="actions" />
     </div>

--- a/console/src/components/common/list-view/ListView.vue
+++ b/console/src/components/common/list-view/ListView.vue
@@ -16,6 +16,7 @@ import {
   type SortingState,
   type Updater,
 } from '@tanstack/vue-table'
+import Alert from '@/components/common/Alert.vue'
 import ListViewPagination from './ListViewPagination.vue'
 import ListViewState from './ListViewState.vue'
 import {
@@ -418,16 +419,17 @@ label="Clear"
       </div>
     </div>
 
-    <div
+    <Alert
       v-if="error && hasRows"
-      class="mb-2 flex items-center justify-between gap-3 rounded bg-surface-red-1 px-3 py-2"
-      role="alert"
-    >
-      <p class="text-p-sm text-ink-red-7">{{ error }}</p>
-      <Button label="Retry" variant="ghost" @click="$emit('retry')" />
-    </div>
+      theme="red"
+      :title="error"
+      :action="{ label: 'Retry', onClick: () => $emit('retry') }"
+      class="mb-2"
+    />
 
-    <div class="relative min-w-0 overflow-x-auto">
+    <!-- flex-1 is inert unless the caller makes the root section a flex column
+         (class fall-through) to pin the pagination footer to the bottom. -->
+    <div class="relative min-w-0 flex-1 overflow-x-auto">
       <div role="table" class="min-w-[720px]">
         <div v-if="hasRows || loading" role="row"
           class="grid h-10 items-center gap-4 border-b border-outline-gray-2 px-2" :style="{ gridTemplateColumns }">

--- a/console/src/components/notifications/NotificationItem.vue
+++ b/console/src/components/notifications/NotificationItem.vue
@@ -3,11 +3,13 @@ import { computed } from 'vue'
 import type { NotificationSeverity, TeamNotification } from '@/types/billing'
 
 // One feed row, shared by the bell dropdown (compact) and the /notifications page.
+// Plain list row: no background, no border — unread is the blue dot by the time.
+// Category is not shown here; it only drives the page's filter tabs.
 const props = defineProps<{ notification: TeamNotification; compact?: boolean }>()
 const emit = defineEmits<{ act: []; read: [] }>()
 
 const SEVERITY: Record<NotificationSeverity, { icon: string; color: string }> = {
-  Error: { icon: 'lucide-alert-circle', color: 'text-ink-red-3' },
+  Error: { icon: 'lucide-alert-circle', color: 'text-[var(--ink-red-8)]' },
   Warning: { icon: 'lucide-alert-triangle', color: 'text-ink-amber-3' },
   Success: { icon: 'lucide-check-circle-2', color: 'text-ink-green-3' },
   Info: { icon: 'lucide-info', color: 'text-ink-blue-3' },
@@ -33,19 +35,25 @@ function timeAgo(ts: string): string {
 </script>
 
 <template>
-  <div
-    class="flex gap-3 px-3 py-3"
-    :class="[notification.is_read ? 'bg-surface-white' : 'bg-surface-gray-1', compact ? '' : 'sm:px-4']"
-  >
-    <span :class="[look.icon, look.color, 'mt-0.5 size-[18px] shrink-0']" aria-hidden="true" />
+  <div class="flex gap-3 py-3" :class="compact ? 'px-3' : ''">
+    <span :class="[look.icon, look.color, 'mt-0.5 size-4 shrink-0']" aria-hidden="true" />
 
     <div class="min-w-0 flex-1">
-      <div class="flex items-start justify-between gap-2">
-        <p class="text-p-sm font-medium text-ink-gray-9" :class="compact ? 'truncate' : ''">
+      <div class="flex items-center gap-2">
+        <p
+          class="min-w-0 flex-1 text-sm font-medium text-ink-gray-9"
+          :class="compact ? 'truncate' : ''"
+        >
           {{ notification.title }}
         </p>
-        <span class="shrink-0 whitespace-nowrap text-[11px] text-ink-gray-4">{{ when }}</span>
+        <span class="shrink-0 whitespace-nowrap text-p-sm text-ink-gray-4">{{ when }}</span>
+        <span
+          v-if="!notification.is_read"
+          class="size-1.5 shrink-0 rounded-full bg-surface-blue-5"
+          aria-hidden="true"
+        />
       </div>
+
       <p
         v-if="notification.message"
         class="mt-0.5 text-p-sm text-ink-gray-6"
@@ -54,12 +62,7 @@ function timeAgo(ts: string): string {
         {{ notification.message }}
       </p>
 
-      <div class="mt-1.5 flex items-center gap-3">
-        <span
-          class="rounded-full bg-surface-gray-2 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-ink-gray-5"
-        >
-          {{ notification.category }}
-        </span>
+      <div v-if="notification.action_label || !notification.is_read" class="mt-2 flex items-center gap-4">
         <button
           v-if="notification.action_label"
           class="text-p-sm font-medium text-ink-gray-8 hover:text-ink-gray-9"
@@ -72,15 +75,9 @@ function timeAgo(ts: string): string {
           class="text-p-sm text-ink-gray-5 hover:text-ink-gray-8"
           @click="emit('read')"
         >
-          Mark read
+          Mark as read
         </button>
       </div>
     </div>
-
-    <span
-      v-if="!notification.is_read"
-      class="mt-1.5 size-2 shrink-0 rounded-full bg-surface-blue-5"
-      aria-hidden="true"
-    />
   </div>
 </template>

--- a/console/src/components/servers/ResizeServerDialog.vue
+++ b/console/src/components/servers/ResizeServerDialog.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from 'vue'
 import { Button, Dialog, LoadingIndicator, Tabs, useCall } from 'frappe-ui'
 import PlanGroup from '@/components/servers/PlanGroup.vue'
+import Alert from '@/components/common/Alert.vue'
 import { API, method } from '@/api/methods'
 import { usePlans } from '@/composables/usePlans'
 import { useSession } from '@/composables/useSession'
@@ -203,12 +204,7 @@ async function confirm() {
         This server can't be resized right now.
       </p>
       <div v-else class="space-y-4">
-        <div
-          v-if="resizeError"
-          class="rounded-lg border border-outline-red-2 bg-surface-red-1 px-3 py-2.5 text-p-sm text-ink-red-4"
-        >
-          {{ resizeError }}
-        </div>
+        <Alert v-if="resizeError" theme="red" :title="resizeError" />
         <div
           v-if="needsRestart"
           class="rounded-lg border border-outline-gray-2 bg-surface-gray-1 px-3 py-2.5 text-p-sm text-ink-gray-6"

--- a/console/src/components/team/MembersPanel.vue
+++ b/console/src/components/team/MembersPanel.vue
@@ -83,6 +83,7 @@ function getMemberKey(member: TeamMemberRow): string {
 <template>
   <div class="min-w-0 flex-1 overflow-y-auto px-4 py-5 sm:px-6">
     <ListView
+      class="mx-auto flex h-full max-w-4xl flex-col"
       v-model:query="query"
       :rows="members"
       :columns="columns"

--- a/console/src/components/team/RolesPanel.vue
+++ b/console/src/components/team/RolesPanel.vue
@@ -25,6 +25,7 @@ async function onDeleteRole(role: TeamRoleRow): Promise<void> {
 
 <template>
   <div class="min-w-0 flex-1 overflow-y-auto px-4 py-5 sm:px-6">
+    <div class="mx-auto max-w-4xl">
     <div class="mb-4 flex items-center justify-between gap-3">
       <p class="text-p-sm text-ink-gray-5">
         Every role and exactly what it can do. Roles are named sets of capabilities.
@@ -57,6 +58,7 @@ async function onDeleteRole(role: TeamRoleRow): Promise<void> {
       :deleting-name="deleting"
       @delete="onDeleteRole"
     />
+    </div>
   </div>
 
   <RoleBuilderDialog v-model:open="builderOpen" @created="reload" />

--- a/console/src/pages/billing/BillingInvoicesPage.vue
+++ b/console/src/pages/billing/BillingInvoicesPage.vue
@@ -107,7 +107,7 @@ const dotClass = (theme: string): string => DOTS[theme] || DOTS.gray
 
 <template>
   <div class="flex h-full flex-col">
-    <PageHeader title="Invoices" subtitle="Billing" />
+    <PageHeader title="Invoices" />
 
     <SplitView v-model:open="detailOpen" class="flex-1">
       <!-- The selected invoice's identity lives in the panel header (number +

--- a/console/src/pages/billing/BillingOverviewPage.vue
+++ b/console/src/pages/billing/BillingOverviewPage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { Button } from 'frappe-ui'
 import PageHeader from '@/components/common/PageHeader.vue'
+import Alert from '@/components/common/Alert.vue'
 import CollectionActionBanner from '@/components/billing/CollectionActionBanner.vue'
 import EstimatedCard from '@/components/billing/EstimatedCard.vue'
 import WalletCard from '@/components/billing/WalletCard.vue'
@@ -28,7 +28,7 @@ const showWalletHistory = ref(false)
 
 <template>
   <div class="flex h-full flex-col">
-    <PageHeader title="Billing" subtitle="One account funds every server." />
+    <PageHeader title="Billing" />
 
     <!-- Content + docked wallet-history panel (like the invoice tray): the panel
          shares the row, the content stays bright beside it — no modal overlay. -->
@@ -37,22 +37,13 @@ const showWalletHistory = ref(false)
         <div class="mx-auto w-full max-w-3xl space-y-5 px-6 py-8">
           <!-- Until the billing profile is filled, ask the team to complete it
                first — money-moving actions stay gated on it. -->
-          <div
+          <Alert
             v-if="!complete"
-            class="flex flex-col gap-3 rounded-lg border border-outline-amber-2 bg-surface-amber-1 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
-          >
-            <p class="text-p-sm text-ink-amber-7">
-              Add your billing details (currency, legal name, and address) to add credit, save a
-              payment method, and provision servers.
-            </p>
-            <Button
-              variant="solid"
-              theme="gray"
-              label="Add billing details"
-              class="shrink-0"
-              @click="setupDialogOpen = true"
-            />
-          </div>
+            theme="yellow"
+            title="Add your billing details"
+            description="Currency, legal name, and address are needed to add credit, save a payment method, and provision servers."
+            :action="{ label: 'Add billing details', onClick: () => (setupDialogOpen = true) }"
+          />
 
           <CollectionActionBanner />
           <div class="grid gap-4 sm:grid-cols-2">
@@ -67,9 +58,43 @@ const showWalletHistory = ref(false)
         </div>
       </div>
 
-      <WalletHistoryPanel v-if="showWalletHistory" v-model="showWalletHistory" />
+      <!-- Stays mounted; opening/closing tweens the shell width so rapid toggles
+           retarget mid-flight instead of remounting. inert when closed. -->
+      <WalletHistoryPanel
+        v-model="showWalletHistory"
+        class="wallet-tray"
+        :class="!showWalletHistory && 'wallet-tray-closed'"
+        :inert="!showWalletHistory"
+      />
     </div>
 
     <EditBillingProfileDialog v-model="setupDialogOpen" />
   </div>
 </template>
+
+<style scoped>
+/* Docked-tray reveal: the shell's width animates while the fixed-width content
+   inside is clipped — no reflow mid-flight. Exit is quicker than enter. */
+.wallet-tray {
+  transition:
+    width 300ms cubic-bezier(0.23, 1, 0.32, 1),
+    opacity 300ms cubic-bezier(0.23, 1, 0.32, 1),
+    border-color 300ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+.wallet-tray-closed {
+  width: 0 !important;
+  opacity: 0;
+  border-color: transparent;
+  transition-duration: 200ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wallet-tray {
+    transition: opacity 150ms ease;
+  }
+  .wallet-tray-closed {
+    width: auto !important;
+    display: none;
+  }
+}
+</style>

--- a/console/src/pages/billing/SpendingLimitsPage.vue
+++ b/console/src/pages/billing/SpendingLimitsPage.vue
@@ -84,7 +84,7 @@ const levels = computed(() => {
 
 <template>
   <div class="flex h-full flex-col">
-    <PageHeader title="Spending Limits" subtitle="Billing" />
+    <PageHeader title="Spending Limits" />
 
     <div class="min-h-0 flex-1 overflow-y-auto">
       <div class="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-8">

--- a/console/src/pages/notifications/NotificationsPage.vue
+++ b/console/src/pages/notifications/NotificationsPage.vue
@@ -1,27 +1,29 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { Button, LoadingText } from 'frappe-ui'
+import { Button, Dialog, LoadingText, TabButtons } from 'frappe-ui'
 import PageHeader from '@/components/common/PageHeader.vue'
+import EmptyState from '@/components/common/EmptyState.vue'
 import NotificationItem from '@/components/notifications/NotificationItem.vue'
 import NotificationPreferences from '@/components/notifications/NotificationPreferences.vue'
 import { useNotifications } from '@/composables/useNotifications'
 import type { TeamNotification } from '@/types/billing'
 
-// Notifications — the full inbox (all history + inline actions) plus a Preferences
-// tab that replaces the raw Desk form for delivery settings.
+// Notifications — the full inbox (all history + inline actions). Delivery
+// preferences live in a dialog behind the header's settings button.
 const { items, unread, loading, markAsRead, markAllAsRead } = useNotifications()
 const router = useRouter()
 
-const tab = ref<'inbox' | 'preferences'>('inbox')
+const preferencesOpen = ref(false)
+
 type Filter = 'all' | 'unread' | 'Billing' | 'Server'
 const filter = ref<Filter>('all')
 
-const FILTERS: { key: Filter; label: string }[] = [
-  { key: 'all', label: 'All' },
-  { key: 'unread', label: 'Unread' },
-  { key: 'Billing', label: 'Billing' },
-  { key: 'Server', label: 'Server' },
+const FILTERS: { label: string; value: Filter }[] = [
+  { label: 'All', value: 'all' },
+  { label: 'Unread', value: 'unread' },
+  { label: 'Billing', value: 'Billing' },
+  { label: 'Server', value: 'Server' },
 ]
 
 const visible = computed<TeamNotification[]>(() => {
@@ -38,56 +40,31 @@ async function onAct(n: TeamNotification): Promise<void> {
 
 <template>
   <div class="flex h-full flex-col">
-    <PageHeader title="Notifications" subtitle="Team">
+    <PageHeader title="Notifications">
       <template #actions>
         <Button
-          v-if="tab === 'inbox' && unread > 0"
+          v-if="unread > 0"
           variant="subtle"
           label="Mark all read"
           @click="markAllAsRead"
         />
+        <Button
+          variant="ghost"
+          icon="lucide-settings-2"
+          aria-label="Notification preferences"
+          @click="preferencesOpen = true"
+        />
       </template>
     </PageHeader>
 
-    <!-- Tabs -->
-    <div class="flex gap-1 border-b border-outline-gray-1 px-4 sm:px-6">
-      <button
-        v-for="t in (['inbox', 'preferences'] as const)"
-        :key="t"
-        class="-mb-px border-b-2 px-3 py-2.5 text-sm capitalize"
-        :class="tab === t
-          ? 'border-outline-gray-5 font-medium text-ink-gray-9'
-          : 'border-transparent text-ink-gray-5 hover:text-ink-gray-8'"
-        @click="tab = t"
-      >
-        {{ t }}
-      </button>
-    </div>
-
     <div class="min-h-0 flex-1 overflow-y-auto">
-      <!-- INBOX -->
-      <div v-if="tab === 'inbox'" class="mx-auto max-w-2xl px-4 py-5 sm:px-6">
-        <div class="mb-4 flex flex-wrap gap-2">
-          <button
-            v-for="f in FILTERS"
-            :key="f.key"
-            class="rounded-full px-3 py-1 text-p-sm"
-            :class="filter === f.key
-              ? 'bg-surface-gray-4 text-ink-gray-9'
-              : 'bg-surface-gray-2 text-ink-gray-6 hover:bg-surface-gray-3'"
-            @click="filter = f.key"
-          >
-            {{ f.label }}
-          </button>
-        </div>
+      <div class="mx-auto max-w-2xl px-4 py-5 sm:px-6">
+        <TabButtons v-model="filter" :options="FILTERS" class="mb-4" />
 
         <div v-if="loading && !items.length" class="p-4">
           <LoadingText :lines="6" />
         </div>
-        <div
-          v-else-if="visible.length"
-          class="divide-y divide-outline-gray-1 overflow-hidden rounded-lg ring-1 ring-outline-gray-1"
-        >
+        <div v-else-if="visible.length" class="divide-y divide-outline-gray-1">
           <NotificationItem
             v-for="n in visible"
             :key="n.name"
@@ -96,16 +73,19 @@ async function onAct(n: TeamNotification): Promise<void> {
             @read="markAsRead(n.name)"
           />
         </div>
-        <div v-else class="rounded-lg border border-dashed border-outline-gray-2 px-4 py-16 text-center">
-          <span class="lucide-bell-off mx-auto mb-2 block size-6 text-ink-gray-4" aria-hidden="true" />
-          <p class="text-p-sm text-ink-gray-5">Nothing here yet.</p>
-        </div>
-      </div>
-
-      <!-- PREFERENCES -->
-      <div v-else class="px-4 py-5 sm:px-6">
-        <NotificationPreferences />
+        <EmptyState
+          v-else
+          icon="lucide-bell-off"
+          title="Nothing here yet"
+          description="Billing and server alerts for your team will show up here."
+        />
       </div>
     </div>
+
+    <Dialog v-model:open="preferencesOpen" title="Notification preferences">
+      <template #default>
+        <NotificationPreferences />
+      </template>
+    </Dialog>
   </div>
 </template>

--- a/console/src/pages/servers/NewServerPage.vue
+++ b/console/src/pages/servers/NewServerPage.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch } from 'vue'
 import { Badge, Button, FormControl, Tabs, useCall } from 'frappe-ui'
 import { useRoute, useRouter } from 'vue-router'
 import PageHeader from '@/components/common/PageHeader.vue'
+import Alert from '@/components/common/Alert.vue'
 import PlanGroup from '@/components/servers/PlanGroup.vue'
 import ProviderAvatar from '@/components/servers/ProviderAvatar.vue'
 import ServerMap from '@/components/servers/ServerMap.vue'
@@ -373,16 +374,12 @@ async function submit() {
               </p>
               <p v-else-if="plansLoading" class="text-p-sm text-ink-gray-5">Loading plans…</p>
 
-              <div
+              <Alert
                 v-else-if="regionFull"
-                class="rounded-lg border border-outline-amber-1 bg-surface-amber-1 px-4 py-3"
-              >
-                <p class="text-p-sm font-medium text-ink-gray-8">This region is at capacity</p>
-                <p class="mt-1 text-p-sm text-ink-gray-6">
-                  {{ selectedRegion }} can't fit a new server right now. Try another region, or
-                  check back shortly — capacity frees up as machines are removed.
-                </p>
-              </div>
+                theme="yellow"
+                title="This region is at capacity"
+                :description="`${selectedRegion} can't fit a new server right now. Try another region, or check back shortly — capacity frees up as machines are removed.`"
+              />
 
               <div
                 v-else-if="bracketExhausted"

--- a/console/src/pages/servers/ServersPage.vue
+++ b/console/src/pages/servers/ServersPage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { computed, h, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { Badge, Button, Dropdown, FormControl, Spinner } from 'frappe-ui'
+import { Badge, Button, FormControl, Select, Spinner } from 'frappe-ui'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
 import CreateTeamDialog from '@/components/team/CreateTeamDialog.vue'
@@ -105,22 +105,10 @@ const rows = computed<ServerRow[]>(() =>
 
 // — Filters. Status and region scope the map and the panel; search only
 //   narrows the panel rows.
-const check = () => h('span', { class: 'lucide-check size-4 text-ink-gray-7' })
-const statusMenu = computed(() => [
-  {
-    label: 'All statuses',
-    onClick: () => (statusFilter.value = ''),
-    slots: { suffix: () => (statusFilter.value === '' ? check() : null) },
-  },
-  ...STATUS_FILTERS.map((s) => ({
-    label: s.label,
-    onClick: () => (statusFilter.value = s.key),
-    slots: { suffix: () => (statusFilter.value === s.key ? check() : null) },
-  })),
+const statusOptions = computed(() => [
+  { label: 'All statuses', value: '' },
+  ...STATUS_FILTERS.map((s) => ({ label: s.label, value: s.key })),
 ])
-const statusLabelText = computed(
-  () => STATUS_FILTERS.find((s) => s.key === statusFilter.value)?.label || 'Status',
-)
 const statusDot = computed(
   () => STATUS_FILTERS.find((s) => s.key === statusFilter.value)?.dot || 'var(--ink-gray-4)',
 )
@@ -137,32 +125,34 @@ const providerGroups = computed(() => {
   return [...groups.entries()].map(([provider, list]) => ({ provider, regions: list }))
 })
 
-const regionMenu = computed(() => [
-  {
-    label: 'All regions',
-    onClick: () => (regionFilter.value = { provider: '', region: '' }),
-    slots: { suffix: () => (!regionFilter.value.provider && !regionFilter.value.region ? check() : null) },
-  },
-  ...providerGroups.value.map((group) => ({
-    label: group.provider,
-    submenu: [
-      {
-        label: `All ${group.provider} regions`,
-        onClick: () => (regionFilter.value = { provider: group.provider, region: '' }),
-      },
-      ...group.regions.map((r) => ({
-        label: `${flagEmoji(r.country_code)} ${regionLabel(r)}`.trim(),
-        onClick: () => (regionFilter.value = { provider: group.provider, region: r.region }),
-      })),
-    ],
-  })),
+// Flat option list for the Select: "All <provider> regions" rows stand in for
+// the old nested provider menu. Selection is encoded as '' | 'p:<provider>' |
+// 'r:<provider>|<region>' and mapped onto regionFilter.
+const regionOptions = computed(() => [
+  { label: 'All regions', value: '' },
+  ...providerGroups.value.flatMap((group) => [
+    { label: `All ${group.provider} regions`, value: `p:${group.provider}` },
+    ...group.regions.map((r) => ({
+      label: `${flagEmoji(r.country_code)} ${regionLabel(r)}`.trim(),
+      value: `r:${group.provider}|${r.region}`,
+    })),
+  ]),
 ])
-const regionLabelText = computed(() => {
-  const { provider, region } = regionFilter.value
-  if (!provider && !region) return 'All regions'
-  if (!region) return `${provider} regions`
-  const r = regionsByName.value.get(region)
-  return `${provider} · ${(r ? regionLabel(r) : region).split(',')[0]}`
+const regionSelection = computed({
+  get(): string {
+    const { provider, region } = regionFilter.value
+    if (!provider && !region) return ''
+    if (!region) return `p:${provider}`
+    return `r:${provider}|${region}`
+  },
+  set(value: string) {
+    if (!value) regionFilter.value = { provider: '', region: '' }
+    else if (value.startsWith('p:')) regionFilter.value = { provider: value.slice(2), region: '' }
+    else {
+      const [provider, region] = value.slice(2).split('|')
+      regionFilter.value = { provider, region }
+    }
+  },
 })
 
 const filtered = computed(() =>
@@ -363,20 +353,15 @@ const pendingResize = ref<AssetRow | null>(null)
 
       <!-- Filters (top right) -->
       <div class="absolute right-4 top-4 flex items-center gap-2">
-        <Dropdown :options="statusMenu" placement="right">
-          <button class="sp-pill">
-            <span class="size-2 rounded-full transition-colors" :style="{ background: statusDot }" />
-            {{ statusLabelText }}
-            <span class="lucide-chevron-down size-3.5 text-ink-gray-5" />
-          </button>
-        </Dropdown>
-        <!-- Region = provider → region, drilled through a nested menu. -->
-        <Dropdown :options="regionMenu" placement="right">
-          <button class="sp-pill">
-            {{ regionLabelText }}
-            <span class="lucide-chevron-down size-3.5 text-ink-gray-5" />
-          </button>
-        </Dropdown>
+        <Select v-model="statusFilter" variant="outline" size="md" :options="statusOptions">
+          <template #prefix>
+            <span
+              class="size-2 shrink-0 rounded-full transition-colors"
+              :style="{ background: statusDot }"
+            />
+          </template>
+        </Select>
+        <Select v-model="regionSelection" variant="outline" size="md" :options="regionOptions" />
       </div>
 
       <!-- Your servers (top left): a floating card — the pill IS the panel,
@@ -388,7 +373,7 @@ const pendingResize = ref<AssetRow | null>(null)
         aria-label="Your servers"
         @keydown.esc="panelOpen = false"
       >
-        <button class="sp-float-pill" :inert="panelOpen" @click="panelOpen = true">
+        <button class="sp-float-pill text-base" :inert="panelOpen" @click="panelOpen = true">
           <span class="truncate">{{ pillLabel }}</span>
           <span class="lucide-maximize-2 size-3.5 shrink-0 text-ink-gray-6" />
         </button>
@@ -398,8 +383,9 @@ const pendingResize = ref<AssetRow | null>(null)
           :inert="!panelOpen"
           :aria-hidden="!panelOpen"
         >
-          <div class="flex shrink-0 items-center justify-between gap-2 px-4 pb-2 pt-4">
-            <h2 class="text-lg font-semibold text-ink-gray-9">Your servers ({{ filtered.length }})</h2>
+          <!-- Same label as the pill so the card reads as the pill expanding. -->
+          <div class="flex shrink-0 items-center justify-between gap-2 px-4 pb-2 pt-3">
+            <h2 class="truncate text-base font-semibold text-ink-gray-9">{{ pillLabel }}</h2>
             <Button variant="ghost" icon="lucide-minimize-2" aria-label="Collapse list" @click="panelOpen = false" />
           </div>
           <div class="shrink-0 px-4 pb-3">
@@ -519,35 +505,16 @@ const pendingResize = ref<AssetRow | null>(null)
 </template>
 
 <style scoped>
-.sp-pill {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  height: 2.25rem;
-  padding: 0 0.75rem;
-  border-radius: 0.5rem;
-  border: 1px solid var(--outline-gray-2);
-  background: var(--surface-elevation-1);
-  box-shadow: var(--shadow-sm, 0 1px 2px rgb(0 0 0 / 0.05));
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--ink-gray-7);
-  transition: background-color 150ms ease, transform 150ms cubic-bezier(0.23, 1, 0.32, 1);
-}
-.sp-pill:hover {
-  background: var(--surface-gray-1);
-}
-.sp-pill:active {
-  transform: scale(0.97);
-}
-
 /* "Your servers" morph: one floating card whose size change carries the whole
    story — the pill grows into the panel in place. Faster on close than open,
-   one strong ease-out; the two faces just crossfade inside it. */
+   one strong ease-out; the two faces just crossfade inside it. Collapsed, the
+   pill matches the Select (outline / md) filters across the map: 2rem tall,
+   same radius, px-2.5, text-base. */
 .sp-float {
   --sp-ease: cubic-bezier(0.23, 1, 0.32, 1);
   width: 10.5rem;
-  height: 2.25rem;
+  height: 2rem;
+  border-radius: 0.5rem;
   box-shadow: var(--shadow-sm, 0 1px 2px rgb(0 0 0 / 0.05));
   transition:
     width 180ms var(--sp-ease),
@@ -567,15 +534,14 @@ const pendingResize = ref<AssetRow | null>(null)
   left: 0;
   top: 0;
   display: flex;
-  height: 2.25rem;
+  height: 2rem;
   width: 10.5rem;
   align-items: center;
   justify-content: space-between;
   gap: 0.625rem;
-  padding: 0 0.75rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--ink-gray-9);
+  padding: 0 0.625rem;
+  font-weight: 420;
+  color: var(--ink-gray-7);
   transition: opacity 120ms ease-out, background-color 150ms ease;
 }
 .sp-float-pill:hover {

--- a/console/src/pages/team/AccessPage.vue
+++ b/console/src/pages/team/AccessPage.vue
@@ -24,3 +24,12 @@ const tabs = [
     </Tabs>
   </div>
 </template>
+
+<style scoped>
+/* frappe-ui's TabsContent doesn't grow; stretch the active panel so the list
+   fills the page and its pagination footer pins to the bottom. */
+:deep([role='tabpanel'][data-state='active']) {
+  flex: 1;
+  min-height: 0;
+}
+</style>

--- a/console/src/pages/team/TeamSettingsPage.vue
+++ b/console/src/pages/team/TeamSettingsPage.vue
@@ -69,7 +69,7 @@ async function onDelete() {
 
 <template>
   <div class="flex h-full flex-col">
-    <PageHeader title="Team settings" subtitle="Name, ownership, and deletion." />
+    <PageHeader title="Team settings" />
 
     <div class="min-h-0 flex-1 overflow-y-auto px-4 py-6 sm:px-6">
       <div class="mx-auto max-w-2xl space-y-6">


### PR DESCRIPTION
A UI-only polish pass over the console (no backend changes). All styling uses Frappe UI / espresso tokens.

## Changes

**Page headers**
- Slimmed to 48px with a medium-weight title; removed subtitle lines from all pages.

**Notifications**
- Rows are a flat list with dividers: no row background or category badge (category still drives the filter tabs), error icon on `--ink-red-8`, "Mark as read" label, tighter title / time / unread-dot layout.
- Inbox/Preferences tabs removed: preferences open in a dialog from a header icon button; the inbox filters use frappe-ui `TabButtons`.

**Alerts**
- Ported the `Alert` component from the frappe-cloud-v2-next prototype (`console/src/components/common/Alert.vue`) and replaced the inline amber/red banner divs on Billing overview, the collection-action banner, New Server's region-at-capacity notice, the resize dialog error, and ListView's inline error.

**Servers map**
- Status / region filters use frappe-ui `Select` (outline, md); the region Select flattens the old nested provider menu.
- The collapsed "All servers" pill matches the Selects (32px, same radius/type) and keeps the same label and type size when it expands, so it reads as one morphing card.

**Billing**
- Card headers center-aligned; header actions are `xs` buttons (prop-based icons so the glyph scales too); card bodies get `pt-4`; the budget-alert row has breathing room; wallet's "Covers this invoice" drops its check icon (error state keeps its icon).
- Wallet history tray animates open/closed (width tween with a strong ease-out, faster exit, `prefers-reduced-motion` fallback; stays mounted so rapid toggles retarget).

**Empty states**
- All on the shared `EmptyState` with `rounded-lg` icon tiles (was `rounded-full`); notifications inbox now uses it too.

**Members & roles**
- Content centered at `max-w-4xl`; list pagination pinned to the bottom of the page (opt-in flex stretch in ListView — block-layout callers are unaffected).

## Notes
- `vue-tsc` reports only the three pre-existing errors on develop (PaymentMethodRowActions, SubscriptionRowActions, SubscriptionsCard) — none in files this PR touches.
- Rebased on latest develop; the NotificationBell removal from PageHeader (1b3bb64) is respected — this PR keeps the bell removed and reverts no upstream changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)