### PR TITLE
report(revenue): add MRR/YTD, Atlas-based & services revenue reports

### DIFF
--- a/central/billing/report/atlas_based_revenue/atlas_based_revenue.js
+++ b/central/billing/report/atlas_based_revenue/atlas_based_revenue.js
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, Frappe and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["Atlas-based Revenue"] = {
+	filters: [
+		{
+			fieldname: "from_date",
+			label: __("From (Period Start)"),
+			fieldtype: "Date",
+			default: frappe.datetime.month_start(),
+		},
+		{
+			fieldname: "to_date",
+			label: __("To (Period Start)"),
+			fieldtype: "Date",
+			default: frappe.datetime.month_end(),
+		},
+		{
+			fieldname: "team",
+			label: __("Team"),
+			fieldtype: "Link",
+			options: "Team",
+		},
+		{
+			fieldname: "currency",
+			label: __("Currency"),
+			fieldtype: "Link",
+			options: "Currency",
+		},
+	],
+};

--- a/central/billing/report/atlas_based_revenue/atlas_based_revenue.json
+++ b/central/billing/report/atlas_based_revenue/atlas_based_revenue.json
@@ -1,0 +1,26 @@
+{
+ "add_total_row": 0,
+ "columns": [],
+ "creation": "2026-07-05 00:00:00.000000",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letterhead": null,
+ "modified": "2026-07-06 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Billing",
+ "name": "Atlas-based Revenue",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Invoice",
+ "report_name": "Atlas-based Revenue",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "System Manager"
+  }
+ ]
+}

--- a/central/billing/report/atlas_based_revenue/atlas_based_revenue.py
+++ b/central/billing/report/atlas_based_revenue/atlas_based_revenue.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Atlas-based revenue — where billed revenue is earned, by Atlas instance / region.
+
+An Asset's `cluster` is the Atlas instance it runs on (one Atlas instance is one
+region/cluster), so grouping line-item revenue by cluster is revenue-by-Atlas. One
+row per (cluster, currency): the revenue provisioned on that Atlas instance, its
+human region label, and its share of that currency's total. Recurring (bundle) vs
+usage is split out so you can see a region's compute base separately from its
+metered spend.
+
+Revenue is grouped per currency and never summed across them; the share % is each
+Atlas instance's slice of its own currency's total, so the percentages add to 100
+within a currency.
+"""
+
+import frappe
+from frappe import _
+from frappe.utils import flt
+
+from central.billing.regions import region_label
+from central.billing.report._revenue import billable_line_items
+
+
+def execute(filters: dict | None = None):
+	filters = filters or {}
+	columns = get_columns()
+	rows = get_data(filters)
+	chart = get_chart(rows)
+	summary = get_summary(rows)
+	return columns, rows, None, chart, summary
+
+
+def get_columns() -> list[dict]:
+	return [
+		{"label": _("Cluster"), "fieldname": "cluster", "fieldtype": "Data", "width": 130},
+		{"label": _("Region"), "fieldname": "region", "fieldtype": "Data", "width": 180},
+		{"label": _("Currency"), "fieldname": "currency", "fieldtype": "Data", "width": 90},
+		{"label": _("Recurring"), "fieldname": "recurring", "fieldtype": "Currency", "options": "currency", "width": 140},
+		{"label": _("Usage & Services"), "fieldname": "usage", "fieldtype": "Currency", "options": "currency", "width": 150},
+		{"label": _("Revenue"), "fieldname": "revenue", "fieldtype": "Currency", "options": "currency", "width": 150},
+		{"label": _("Share %"), "fieldname": "share", "fieldtype": "Percent", "width": 100},
+	]
+
+
+def get_data(filters: dict) -> list[dict]:
+	agg: dict[tuple, dict] = {}
+	for line in billable_line_items(filters):
+		cluster = line["cluster"] or _("(unassigned)")
+		g = agg.setdefault((cluster, line["currency"]), {"recurring": 0.0, "usage": 0.0})
+		g["recurring" if line["recurring"] else "usage"] += line["amount"]
+
+	# Per-currency totals, for the share column.
+	currency_total: dict[str, float] = {}
+	for (_cluster, currency), g in agg.items():
+		currency_total[currency] = currency_total.get(currency, 0.0) + g["recurring"] + g["usage"]
+
+	rows = []
+	for (cluster, currency), g in agg.items():
+		revenue = g["recurring"] + g["usage"]
+		total = currency_total.get(currency) or 0.0
+		rows.append({
+			"cluster": cluster, "region": region_label(cluster) or cluster, "currency": currency,
+			"recurring": flt(g["recurring"], 2), "usage": flt(g["usage"], 2),
+			"revenue": flt(revenue, 2),
+			"share": flt(revenue / total * 100, 2) if total else 0.0,
+		})
+	rows.sort(key=lambda r: (r["currency"], -r["revenue"]))
+	return rows
+
+
+def get_chart(rows: list[dict]) -> dict | None:
+	if not rows:
+		return None
+	clusters = sorted({r["cluster"] for r in rows})
+	currencies = sorted({r["currency"] for r in rows})
+	by_key = {(r["cluster"], r["currency"]): r["revenue"] for r in rows}
+	datasets = [
+		{"name": _("Revenue ({0})").format(currency),
+		 "values": [flt(by_key.get((c, currency), 0.0), 2) for c in clusters]}
+		for currency in currencies
+	]
+	# One bar per cluster, grouped by currency (a single-currency run reads as a
+	# plain revenue-by-cluster bar).
+	return {"data": {"labels": clusters, "datasets": datasets}, "type": "bar"}
+
+
+def get_summary(rows: list[dict]) -> list[dict]:
+	summary = []
+	for currency in sorted({r["currency"] for r in rows}):
+		crows = [r for r in rows if r["currency"] == currency]
+		total = sum(flt(r["revenue"]) for r in crows)
+		top = max(crows, key=lambda r: r["revenue"])
+		summary.append({"label": _("Revenue ({0})").format(currency), "value": flt(total, 2),
+						"datatype": "Float", "indicator": "green"})
+		summary.append({"label": _("Top Cluster ({0})").format(currency),
+						"value": f"{top['cluster']} · {top['share']}%", "datatype": "Data"})
+	return summary

--- a/central/billing/tests/test_revenue_reports.py
+++ b/central/billing/tests/test_revenue_reports.py
@@ -11,7 +11,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from central.billing.report.mrr_and_ytd_revenue.mrr_and_ytd_revenue import execute as mrr_execute
-from central.billing.report.cluster_wise_revenue.cluster_wise_revenue import execute as cluster_execute
+from central.billing.report.atlas_based_revenue.atlas_based_revenue import execute as cluster_execute
 from central.billing.report.services_revenue.services_revenue import execute as services_execute
 from central.billing.tests.utils import ensure_team
 

--- a/central/billing/workspace/billing/billing.json
+++ b/central/billing/workspace/billing/billing.json
@@ -75,9 +75,9 @@
   {
    "hidden": 0,
    "is_query_report": 1,
-   "label": "Cluster-wise Revenue",
+   "label": "Atlas-based Revenue",
    "link_count": 0,
-   "link_to": "Cluster-wise Revenue",
+   "link_to": "Atlas-based Revenue",
    "link_type": "Report",
    "onboard": 0,
    "type": "Link"
@@ -522,7 +522,7 @@
    "type": "Link"
   }
  ],
- "modified": "2026-07-05 00:00:00.000000",
+ "modified": "2026-07-06 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Billing",
  "name": "Billing",


### PR DESCRIPTION
Three revenue visualisations the workspace was missing, all reading one grain — Invoice Line Items joined to their parent invoice (Billable, non-Cancelled), the pre-tax line amount — so every cut is additive and reconciles to the same total. A line is recurring when its resource_type is `bundle`; everything else is usage.

- MRR and YTD Revenue: monthly recurring run-rate vs usage, with a year-to-date running total (reset each January) and a per-currency revenue trend line.
- Atlas-based Revenue: revenue by Atlas instance / region (an Asset's cluster is the Atlas instance it runs on) with each instance's share of its currency, as a grouped bar.
- Services Revenue: revenue by product family (plan -> Plan Category, with metered resource types mapped to their family and composed compute folded into VM Plans), as a family-share pie / grouped bar.

A shared report/_revenue.py provides the billable-line-item source. Money is per-currency throughout — never summed across currencies. Reports are wired into a new "Revenue Analytics" workspace card (workspace `modified` bumped so migrate re-imports the layout). Covered by test_revenue_reports.