### PR TITLE
refactor: Drop email from Atlas provisioning calls

### DIFF
--- a/central/api/servers.py
+++ b/central/api/servers.py
@@ -193,15 +193,12 @@ def create_server(
 	_validate_frappe_version(frappe_version, region)
 
 	client = AtlasClient.for_region(region)
-	# Seed the Atlas tenant (first use) with the team owner's email.
-	email = frappe.db.get_value("Team", team, "owner_user")
 	vm = client.create_vm(
 		team=team,
 		title=title or "server",
 		vcpus=int(vcpus or 1),
 		memory_megabytes=int(memory_megabytes or 512),
 		disk_gigabytes=int(disk_gigabytes or 10),
-		email=email,
 		cpu_max_cores=cpu_max_cores,
 		frappe_version=frappe_version,
 	)
@@ -271,14 +268,12 @@ def create_composed_server(
 
 	qty = composition_quantities(includes)
 	client = AtlasClient.for_region(region)
-	email = frappe.db.get_value("Team", team, "owner_user")
 	vm = client.create_vm(
 		team=team,
 		title=title or "server",
 		vcpus=int(qty.get(COMPUTE, 1)) or 1,
 		memory_megabytes=int(qty.get(MEMORY, 0) * 1024) or 512,
 		disk_gigabytes=int(qty.get(DISK, 0)) or 10,
-		email=email,
 		frappe_version=frappe_version,
 	)
 	resource_id = vm.get("name")

--- a/central/api/sites.py
+++ b/central/api/sites.py
@@ -33,10 +33,10 @@ def create_site(subdomain: str, region: str | None = None) -> dict:
 	Server is the atomic unit, so deploying a site is authorized by the same
 	provisioning capability as standing up a server (site-level capabilities are
 	deferred). Central supplies *what* (the owning team + the subdomain); Atlas
-	owns placement, the fixed size, and the region/domain. We seed the Atlas tenant
-	with the team owner's email on first use, then mirror the returned Pending row
-	so the onboarding screen has something to poll immediately — the site.* events
-	keep it fresh from there."""
+	owns placement, the fixed size, and the region/domain. Atlas get-or-creates the
+	tenant (keyed on the team) and returns the Pending row, which we mirror so the
+	onboarding screen has something to poll immediately — the site.* events keep it
+	fresh from there."""
 	user = frappe.session.user
 	team = resolve_team(user)
 	if not can(user, team, "server:create"):
@@ -44,8 +44,7 @@ def create_site(subdomain: str, region: str | None = None) -> dict:
 
 	region = region or _default_region()
 	client = AtlasClient.for_region(region)
-	email = frappe.db.get_value("Team", team, "owner_user")
-	site = client.create_site(team=team, subdomain=subdomain, email=email)
+	site = client.create_site(team=team, subdomain=subdomain)
 
 	from central.central.doctype.site.site import Site
 

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -115,7 +115,6 @@ class AtlasClient:
 		vcpus: int,
 		memory_megabytes: int,
 		disk_gigabytes: int,
-		email: str | None = None,
 		cpu_max_cores: float | None = None,
 		frappe_version: str | None = None,
 	) -> dict:
@@ -133,8 +132,6 @@ class AtlasClient:
 			"memory_megabytes": memory_megabytes,
 			"disk_gigabytes": disk_gigabytes,
 		}
-		if email:
-			params["email"] = email
 		if cpu_max_cores:
 			params["cpu_max_cores"] = cpu_max_cores
 		if frappe_version:
@@ -265,7 +262,6 @@ class AtlasClient:
 		*,
 		team: str,
 		subdomain: str,
-		email: str | None = None,
 		region: str | None = None,
 	) -> dict:
 		"""
@@ -275,8 +271,6 @@ class AtlasClient:
 
 		params: dict = {"team": team, "subdomain": subdomain}
 
-		if email:
-			params["email"] = email
 		if region:
 			params["region"] = region
 		params.update(self._pilot_credential(team))


### PR DESCRIPTION
Atlas dropped the `email` field from `Tenant` and from the `ensure_tenant` / `create_vm` / `create_site` APIs (Central performs every permission check now; the tenant is just the tag that groups a team's resources into its VPC).

This removes the matching Central-side sender:

- `AtlasClient.create_vm` / `create_site` — drop the `email` param and the `if email: params["email"] = email` blocks.
- `create_server` / `create_composed_server` / `create_site` API handlers — stop looking up `Team.owner_user` to seed it.

### Compatibility
`email` was already optional on the Atlas side (`email: str | None = None`), so omitting it is compatible with both old and new Atlas. The `team` id still get-or-creates the tenant. The `atlas-<region>@<site>` service-user email in `atlas.py` is Central's own auth identity and is untouched.

### Tests
Ran on `central-tests.local`. The create-path suites that stub `AtlasClient` (`test_frappe_version`, `test_create_server`, `test_pilot_credential_delivery`) behave identically with and without this change — the only red tests are pre-existing and unrelated (a missing `blr-delivery` Region fixture and an unrelated subscription assertion), confirmed by reproducing them with the diff stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)