### PR TITLE
fix: Credits negative balance

### DIFF
--- a/central/billing/ARCHITECTURE.md
+++ b/central/billing/ARCHITECTURE.md
@@ -14,7 +14,9 @@ provisions/records/enforces directly. Authorisation is Central's capability IAM
 (ADR 0004), not billing-owned roles.
 
 - **36 DocTypes**, **~10 sub-packages**, **87 whitelisted endpoints**.
-- Money is **integer minor units** (paisa/cent) everywhere; rates are minor×10⁶ (ADR 0003).
+- Money is **float `Currency` in major units** (₹10.00 is stored `10.0`). Conversion to gateway minor
+  units (Razorpay paise / Stripe cents) happens **only at the gateway boundary**. ADR 0003
+  (integer minor units) is **DEPRECATED — it was never implemented**; don't design against it.
 
 ---
 
@@ -417,7 +419,7 @@ get_team_caps resolves caps live (no per-team Trust Tier doctype — dropped)
 | Card declined repeatedly | `collection` (escalate don't repeat), `mandates.effective_cap`, dunning Day 1/3/7 |
 | ERPNext out of sync | `erpnext_sync` (async, never rolls back the invoice; check retry backoff) |
 | Catalog masters missing | `taxonomy_setup.ensure_catalog_masters` (runs on install/migrate/before_tests) |
-| Money rounding off | minor-units (ADR 0003): rates are minor×10⁶, round **once**; check own ISO-4217 factor table |
+| Money rounding off | money is float `Currency` (major units); check the rate field's decimal **precision** holds sub-cent rates, and that minor-unit conversion happens *only* in `gateways/` |
 
 ---
 

--- a/central/billing/doctype/credit_wallet/credit_wallet.json
+++ b/central/billing/doctype/credit_wallet/credit_wallet.json
@@ -1,9 +1,9 @@
 {
  "actions": [],
  "allow_rename": 0,
- "autoname": "field:team",
+ "autoname": "format:{team}-{currency}",
  "creation": "2026-06-03 00:00:00.000000",
- "description": "Per-team lock anchor for credit-ledger bookings. Carries the authoritative running balance, maintained under the row's FOR UPDATE lock so a booking reads/writes the balance on this single primary-key row — no FOR UPDATE on the ledger, so cross-team bookings never gap-lock each other. The append-only Credit Ledger Entry remains the audit trail; balance is the running sum and stays in lockstep with the newest entry's running_balance.",
+ "description": "Per-(team, currency) lock anchor for credit-ledger bookings. The composite key lives in the NAME so the primary key itself enforces one wallet per team per currency, and the booking's FOR UPDATE stays on the clustered PK (a secondary composite index would reintroduce the lock-order deadlock the anchor exists to avoid). Carries the authoritative balance for that currency, maintained under the row's lock. A CHECK (balance >= 0) constraint makes a negative balance impossible for every caller, not only those routed through credits.py (ADR 0018). The append-only Credit Ledger Entry remains the audit trail; balance stays in lockstep with the newest entry's running_balance for the same currency.",
  "doctype": "DocType",
  "editable_grid": 0,
  "engine": "InnoDB",
@@ -19,20 +19,24 @@
    "options": "Team",
    "in_list_view": 1,
    "label": "Team",
-   "unique": 1,
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "currency",
-   "fieldtype": "Data",
-   "label": "Currency"
+   "fieldtype": "Link",
+   "options": "Currency",
+   "in_list_view": 1,
+   "label": "Currency",
+   "reqd": 1
   },
   {
    "fieldname": "balance",
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Balance",
-   "description": "Authoritative running balance under this row's lock; equals the signed ledger sum."
+   "non_negative": 1,
+   "description": "Authoritative balance for this currency, under this row's lock; equals the signed ledger sum for the same (team, currency). Never negative — enforced by a CHECK constraint, since frappe.db.set_value skips this field's validation entirely."
   }
  ],
  "index_web_pages_for_search": 1,

--- a/central/billing/doctype/credit_wallet/credit_wallet.py
+++ b/central/billing/doctype/credit_wallet/credit_wallet.py
@@ -1,8 +1,32 @@
 # Copyright (c) 2026, Frappe and contributors
 # For license information, please see license.txt
+"""Credit Wallet — the (team, currency) lock anchor and authoritative balance.
 
+The balance may never be negative. That invariant is enforced at three rungs,
+deliberately (ADR 0018):
+
+  1. `CHECK (balance >= 0)` on the column — the only rung that holds against every
+     caller, including `frappe.db.set_value`, which skips this controller entirely
+     (and is exactly how `credits.py` writes the balance).
+  2. `validate` below — turns an ORM write into a clear message instead of an
+     OperationalError from the constraint.
+  3. The `InsufficientCredits` guard in `credits._book_entry_once`, under the row
+     lock, which is what a caller actually sees.
+
+Three rungs, because the failure this prevents is a customer's credit balance going
+quietly negative — the v1 bug.
+"""
+
+import frappe
 from frappe.model.document import Document
 
 
 class CreditWallet(Document):
-	pass
+	def validate(self):
+		if frappe.utils.flt(self.balance) < 0:
+			frappe.throw(
+				frappe._("Credit balance cannot be negative (got {0} {1} for team {2}).").format(
+					self.balance, self.currency, self.team
+				),
+				frappe.ValidationError,
+			)

--- a/central/billing/platform/constraints.py
+++ b/central/billing/platform/constraints.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Database-level money invariants — rung 1 of the enforcement ladder (ADR 0018).
+
+Frappe's DocType JSON cannot express a `CHECK` constraint, so the invariants that
+belong in the database are declared here and applied as DDL. This module is the
+registry: every rung-1 invariant in billing is one row in `CONSTRAINTS`.
+
+**This is a hook, not a patch, and that distinction is load-bearing.** A patch runs
+once and is then recorded as done — and on a *fresh* site Frappe marks every patch
+in `patches.txt` as already-executed without running it. A constraint declared only
+in a patch would therefore exist on migrated sites and be silently absent on new
+ones, which is the "a fresh site is quietly weaker than a migrated one" failure the
+ADR forbids. Running from `after_install` / `after_migrate` / `before_tests` makes
+the constraint a property of the schema rather than of a site's migration history.
+
+Idempotent: each constraint is added only if it is not already present, so this is
+safe to run on every migrate.
+"""
+
+import frappe
+
+# (table, constraint name, check clause) — the invariant, at the only rung that
+# holds against every caller including `frappe.db.set_value`, which skips the
+# controller entirely.
+CONSTRAINTS = (
+	(
+		"tabCredit Wallet",
+		"credit_wallet_balance_non_negative",
+		"`balance` >= 0",
+	),
+)
+
+
+def existing_constraints(table: str) -> set[str]:
+	rows = frappe.db.sql(
+		"""
+		select constraint_name from information_schema.check_constraints
+		where constraint_schema = database() and table_name = %s
+		""",
+		(table,),
+	)
+	return {r[0] for r in rows}
+
+
+def ensure_constraints() -> list[str]:
+	"""Apply every missing rung-1 constraint. Returns the names newly added."""
+	added = []
+	for table, name, clause in CONSTRAINTS:
+		if not frappe.db.table_exists(table.removeprefix("tab")):
+			continue
+		if name in existing_constraints(table):
+			continue
+		frappe.db.sql_ddl(
+			f"alter table `{table}` add constraint `{name}` check ({clause})"
+		)
+		added.append(name)
+		frappe.logger("billing").info(f"added CHECK constraint {name} on {table}")
+	return added

--- a/central/billing/revenue/credits.py
+++ b/central/billing/revenue/credits.py
@@ -3,19 +3,29 @@
 """Credit ledger — the customer's prepaid wallet (issue #06).
 
 Every credit movement is an append-only Credit Ledger Entry (the audit trail).
-Bookings serialise on a per-team Credit Wallet anchor row via `SELECT ... FOR
-UPDATE`: a concurrent booking for the same team blocks on that single
-primary-key row until the prior transaction commits — closing the concurrent
-double-spend race.
+Bookings serialise on a Credit Wallet anchor row via `SELECT ... FOR UPDATE`: a
+concurrent booking for the same wallet blocks on that single primary-key row
+until the prior transaction commits — closing the concurrent double-spend race.
+
+The wallet is keyed **(team, currency)**, one anchor per currency a team holds
+([ADR 0018](../../../../docs/adr/0018-invariants-are-enforced-not-observed.md)).
+It was once keyed by team alone, with a single currency-blind `balance`: the
+invoice waterfall read a *per-currency* balance off the ledger but debited the
+*currency-blind* anchor, so a team holding two currencies could be driven
+negative in one of them while the anchor stayed positive. The composite key makes
+"the balance is never negative" true **per currency**, and the `CHECK (balance >=
+0)` constraint on the column makes it true against every caller, not only the
+polite ones.
 
 The balance is read and written ON the locked anchor row, not via a `FOR UPDATE`
 on the ledger. An earlier version read the latest balance with
 `... ORDER BY creation DESC LIMIT 1 FOR UPDATE`, which took a next-key lock on
 the HEAD of the global `creation` index — the gap every team's INSERT lands in —
 so bookings for *different* teams deadlocked there despite each holding only its
-own wallet lock. Locking a single PK row (per team) takes no gap locks, so
-cross-team bookings never contend. The anchor's `balance` stays in lockstep with
-the newest ledger entry's `running_balance`; the ledger remains the audit truth.
+own wallet lock. Locking a single PK row takes no gap locks, so bookings for
+different wallets never contend. The anchor's `balance` stays in lockstep with
+the newest ledger entry's `running_balance` **for that currency**; the ledger
+remains the audit truth.
 """
 
 import random
@@ -24,6 +34,8 @@ import time
 import frappe
 from frappe.query_builder import Case
 from frappe.query_builder.functions import Sum
+
+from central.billing.catalog.entitlements import team_currency
 
 # Bookings serialise on the wallet lock, but a busy InnoDB can still surface a
 # transient cross-transaction deadlock; the loser rolls back and retries.
@@ -35,9 +47,24 @@ class InsufficientCredits(frappe.ValidationError):
 	"""A debit would drive the wallet negative."""
 
 
-def _ensure_wallet(team: str, currency: str | None = None):
-	"""Create the team's wallet anchor if absent (race-safe on the unique key)."""
-	if frappe.db.exists("Credit Wallet", team):
+def wallet_name(team: str, currency: str) -> str:
+	"""The anchor's primary key — mirrors the `format:{team}-{currency}` autoname."""
+	return f"{team}-{currency}"
+
+
+def _resolve_currency(team: str, currency: str | None) -> str:
+	"""The currency a credit movement is denominated in.
+
+	Defaults to the team's billing currency (Billing Profile — the source of truth,
+	locked after first money activity) rather than a hardcoded INR, so a USD team's
+	wallet is never booked in the wrong currency by an omitted argument.
+	"""
+	return currency or team_currency(team)
+
+
+def _ensure_wallet(team: str, currency: str):
+	"""Create the (team, currency) wallet anchor if absent (race-safe on the PK)."""
+	if frappe.db.exists("Credit Wallet", wallet_name(team, currency)):
 		return
 	try:
 		frappe.get_doc(
@@ -47,28 +74,30 @@ def _ensure_wallet(team: str, currency: str | None = None):
 		pass  # a concurrent booking created it first — fine
 
 
-def _lock_and_read_balance(team: str) -> float:
-	"""Lock the team's wallet anchor and return its current balance.
+def _lock_and_read_balance(team: str, currency: str) -> float:
+	"""Lock the (team, currency) wallet anchor and return its current balance.
 
-	A locking read (`FOR UPDATE`) on the single PK row: it both takes the per-team
+	A locking read (`FOR UPDATE`) on the single PK row: it both takes the per-wallet
 	serialization lock (held until the caller commits) AND reads the *latest
 	committed* balance, bypassing this transaction's REPEATABLE-READ snapshot
 	(which a concurrent prior booking has since moved past). Because it targets one
-	primary-key row it takes no gap locks, so different teams never contend.
+	primary-key row it takes no gap locks, so different wallets never contend.
 
-	The lock is taken on the PRIMARY KEY (`name`, which equals `team` under the
-	`field:team` autoname), NOT the secondary unique `team` index. A secondary-index
-	locking read locks the index record then the clustered record, the OPPOSITE
-	order from the INSERT that creates the wallet (clustered then unique index) and
-	from the `set_value` UPDATE (clustered only) — an opposite-order cycle some
-	InnoDB versions deadlock on. Locking the clustered record directly keeps every
-	path on one lock in one order.
+	The lock is taken on the PRIMARY KEY (`name` = `{team}-{currency}` under the
+	`format:` autoname), NOT a secondary index. A secondary-index locking read locks
+	the index record then the clustered record, the OPPOSITE order from the INSERT
+	that creates the wallet (clustered then secondary) and from the `set_value`
+	UPDATE (clustered only) — an opposite-order cycle some InnoDB versions deadlock
+	on. Locking the clustered record directly keeps every path on one lock in one
+	order. This reasoning is why the composite key lives in the *name*: it keeps the
+	lock on the clustered PK instead of moving it to a secondary (team, currency)
+	index, which would reintroduce exactly the deadlock this design exists to avoid.
 	"""
 	wallet = frappe.qb.DocType("Credit Wallet")
 	rows = (
 		frappe.qb.from_(wallet)
 		.select(wallet.balance)
-		.where(wallet.name == team)
+		.where(wallet.name == wallet_name(team, currency))
 		.for_update()
 		.run(pluck=True)
 	)
@@ -85,11 +114,11 @@ def _book_entry(
 	note: str | None = None,
 	gateway_payment_id: str | None = None,
 ):
-	"""Append one ledger entry under the per-team lock, retrying on deadlock.
+	"""Append one ledger entry under the per-wallet lock, retrying on deadlock.
 
-	The wallet FOR UPDATE serialises same-team bookings, but a busy InnoDB can
-	still raise a transient deadlock (`QueryDeadlockError`) under heavy
-	cross-transaction contention — InnoDB picks a victim and rolls its
+	The wallet FOR UPDATE serialises bookings against the same (team, currency),
+	but a busy InnoDB can still raise a transient deadlock (`QueryDeadlockError`)
+	under heavy cross-transaction contention — InnoDB picks a victim and rolls its
 	transaction back. The canonical remedy is to roll back and retry: each retry
 	re-locks the wallet and re-reads the now-current balance, so the
 	double-spend / InsufficientCredits guards still hold. `InsufficientCredits`
@@ -97,15 +126,16 @@ def _book_entry(
 
 	`gateway_payment_id` (top-ups) makes the booking idempotent on the gateway
 	payment: the synchronous confirm callback and the async webhook race to credit
-	the SAME payment, so exactly one must win. The per-team wallet lock serialises
-	them and the under-lock pre-check in `_book_entry_once` skips the duplicate;
-	the unique index on the column is the belt-and-braces backstop — if a second
-	insert still reaches the DB it raises DuplicateEntryError, which we treat as
-	"already credited" and return the winning entry rather than double-booking.
+	the SAME payment, so exactly one must win. The wallet lock serialises them and
+	the under-lock pre-check in `_book_entry_once` skips the duplicate; the unique
+	index on the column is the belt-and-braces backstop — if a second insert still
+	reaches the DB it raises DuplicateEntryError, which we treat as "already
+	credited" and return the winning entry rather than double-booking.
 	"""
 	amount = frappe.utils.flt(amount)
 	if amount <= 0:
 		frappe.throw("Credit amount must be positive.", frappe.ValidationError)
+	currency = _resolve_currency(team, currency)
 
 	for attempt in range(_DEADLOCK_RETRIES):
 		try:
@@ -139,9 +169,9 @@ def _book_entry_once(
 	note: str | None,
 	gateway_payment_id: str | None = None,
 ):
-	"""One booking attempt under the per-team lock; returns (doc, new_balance)."""
+	"""One booking attempt under the per-wallet lock; returns (doc, new_balance)."""
 	_ensure_wallet(team, currency)
-	balance = _lock_and_read_balance(team)
+	balance = _lock_and_read_balance(team, currency)
 
 	# Idempotency for top-ups: the wallet FOR UPDATE above serialises the confirm
 	# callback and the webhook for this (same-team) payment, and a consistent read
@@ -157,12 +187,18 @@ def _book_entry_once(
 	new_balance = balance + (amount if entry_type == "Credit" else -amount)
 	if new_balance < 0:
 		raise InsufficientCredits(
-			f"Debit of {amount} exceeds wallet balance {balance} for {team}."
+			f"Debit of {amount} {currency} exceeds wallet balance {balance} for {team}."
 		)
 
 	# Advance the authoritative balance on the locked anchor, then append the
 	# immutable ledger entry mirroring it. Both commit together under the lock.
-	frappe.db.set_value("Credit Wallet", team, "balance", new_balance, update_modified=False)
+	# `set_value` skips the controller, so the guard above is the only application-
+	# level check — the CHECK (balance >= 0) constraint on the column is what makes
+	# a negative balance impossible for callers that never reach this function.
+	frappe.db.set_value(
+		"Credit Wallet", wallet_name(team, currency), "balance", new_balance,
+		update_modified=False,
+	)
 	entry = frappe.get_doc(
 		{
 			"doctype": "Credit Ledger Entry",
@@ -191,11 +227,15 @@ def _existing_payment_entry(gateway_payment_id: str | None):
 		# Duplicate fired but the row is gone (or no id) — nothing to return to.
 		frappe.throw("Credit booking conflicted but no prior entry found.", frappe.ValidationError)
 	entry = frappe.get_doc("Credit Ledger Entry", name)
-	return entry, frappe.utils.flt(frappe.db.get_value("Credit Wallet", entry.team, "balance"))
+	balance = frappe.db.get_value(
+		"Credit Wallet", wallet_name(entry.team, entry.currency), "balance"
+	)
+	return entry, frappe.utils.flt(balance)
 
 
 @frappe.whitelist()
-def purchase(team: str, amount: float, currency: str = "INR", payment_method: str | None = None,
+def purchase(team: str, amount: float, currency: str | None = None,
+			 payment_method: str | None = None,
 			 reference_name: str | None = None, note: str | None = None,
 			 gateway_payment_id: str | None = None) -> dict:
 	"""Top-up: book a credit entry for purchased credits.
@@ -221,13 +261,14 @@ def purchase(team: str, amount: float, currency: str = "INR", payment_method: st
 
 
 def apply_credit(
-	team, amount, currency="INR", reference_type=None, reference_name=None, note=None
+	team, amount, currency=None, reference_type=None, reference_name=None, note=None
 ) -> dict:
-	"""Debit the wallet (e.g. credits applied to an open invoice).
+	"""Debit the (team, currency) wallet (e.g. credits applied to an open invoice).
 
-	Raises InsufficientCredits rather than going negative. The waterfall logic
-	that decides *how much* to apply against a card backstop lives in #11; this
-	is the locked primitive it builds on.
+	Raises InsufficientCredits rather than going negative — per currency, since the
+	anchor it debits is the same one the caller read. The waterfall logic that
+	decides *how much* to apply against a card backstop lives in #11; this is the
+	locked primitive it builds on.
 	"""
 	entry, new_balance = _book_entry(
 		team, "Debit", amount, currency, reference_type, reference_name, note
@@ -235,7 +276,7 @@ def apply_credit(
 	return {"ledger_entry": entry.name, "new_balance": new_balance}
 
 
-def refund_to_wallet(team, amount, currency="INR", reference_type=None, reference_name=None, note=None) -> dict:
+def refund_to_wallet(team, amount, currency=None, reference_type=None, reference_name=None, note=None) -> dict:
 	"""Book a credit entry for a partial-overcharge / gateway refund to wallet."""
 	entry, new_balance = _book_entry(
 		team, "Credit", amount, currency, reference_type, reference_name, note or "Refund to wallet"
@@ -256,7 +297,7 @@ def grant_promotional_credits(team, amount, currency, note=None) -> dict:
 
 
 @frappe.whitelist()
-def adjust_credits(team: str, amount: float, entry_type: str, currency: str = "INR",
+def adjust_credits(team: str, amount: float, entry_type: str, currency: str | None = None,
 				   note: str | None = None) -> dict:
 	"""Admin manual correction — a credit or debit entry with an audit note."""
 	if entry_type not in ("Credit", "Debit"):
@@ -269,31 +310,47 @@ def adjust_credits(team: str, amount: float, entry_type: str, currency: str = "I
 
 @frappe.whitelist()
 def get_balance(team: str, currency: str | None = None) -> dict:
-	"""Current wallet balance for the team, optionally filtered to one currency.
+	"""The team's credit balance in one currency — read off that currency's anchor.
 
-	When `currency` is supplied only entries in that currency are summed — useful
-	once a team holds credits in multiple currencies. `running_balance` is a
-	single currency-blind cumulative, so a per-currency read must sum that
-	currency's signed amounts rather than read the newest matching row's
-	`running_balance` (which carries the team's overall balance at that point).
-	When omitted the overall balance is the newest entry's running_balance
-	(backward-compatible while teams are single-currency).
+	`currency` defaults to the team's billing currency, so the common caller
+	("what are this team's credits?") gets the balance in the currency the team is
+	actually billed in. There is deliberately no "overall balance" across
+	currencies: summing INR and USD floats produced a number that meant nothing and
+	that the debit path then enforced its non-negative guard against. Use
+	`get_balances` for the multi-currency view.
+
+	Reads the anchor, not the ledger — the anchor is the authoritative balance
+	(maintained under its row lock) and the ledger is the audit trail. The two are
+	reconciled by the C2 invariant check, not by disagreeing at read time.
 	"""
-	if currency:
-		cle = frappe.qb.DocType("Credit Ledger Entry")
-		signed = Case().when(cle.entry_type == "Credit", cle.amount).else_(-cle.amount)
-		balance = (
-			frappe.qb.from_(cle)
-			.select(Sum(signed))
-			.where((cle.team == team) & (cle.currency == currency))
-			.run()
-		)[0][0]
-		return {"balance": frappe.utils.flt(balance), "currency": currency}
-
-	balance = frappe.db.get_value(
-		"Credit Ledger Entry",
-		{"team": team},
-		"running_balance",
-		order_by="creation desc, name desc",
-	)
+	currency = _resolve_currency(team, currency)
+	balance = frappe.db.get_value("Credit Wallet", wallet_name(team, currency), "balance")
 	return {"balance": frappe.utils.flt(balance), "currency": currency}
+
+
+@frappe.whitelist()
+def get_balances(team: str) -> list[dict]:
+	"""Every currency this team holds credits in — never summed across currencies."""
+	return frappe.get_all(
+		"Credit Wallet",
+		filters={"team": team},
+		fields=["currency", "balance"],
+		order_by="currency asc",
+	)
+
+
+def ledger_balance(team: str, currency: str) -> float:
+	"""The balance implied by the append-only ledger, summed from the entries.
+
+	The independent second opinion the anchor is checked against (invariant C2,
+	[ADR 0018]). Not a read path — nothing in the write path should call this.
+	"""
+	cle = frappe.qb.DocType("Credit Ledger Entry")
+	signed = Case().when(cle.entry_type == "Credit", cle.amount).else_(-cle.amount)
+	balance = (
+		frappe.qb.from_(cle)
+		.select(Sum(signed))
+		.where((cle.team == team) & (cle.currency == currency))
+		.run()
+	)[0][0]
+	return frappe.utils.flt(balance)

--- a/central/billing/tests/test_credits.py
+++ b/central/billing/tests/test_credits.py
@@ -9,6 +9,7 @@ from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
 
 from central.billing.tests.utils import ensure_team
 
+from central.billing.platform.constraints import existing_constraints
 from central.billing.revenue import credits
 from central.billing.revenue.credits import InsufficientCredits
 
@@ -127,12 +128,96 @@ class TestLedgerBasics(CreditTestBase):
 		self.assertEqual(credits.get_balance(TEAM, currency="INR")["balance"], 600)
 		self.assertEqual(credits.get_balance(TEAM, currency="USD")["balance"], 100)
 
-	def test_get_balance_unfiltered_returns_latest_overall(self):
+	def test_get_balance_unfiltered_uses_the_team_currency(self):
+		"""Omitting currency reads the team's BILLING currency, not a blind sum.
+
+		It used to return the newest entry's currency-blind `running_balance` — i.e.
+		INR + USD added together as bare floats. Nothing is summed across currencies
+		now; the unfiltered read is simply the team's own currency (ADR 0018).
+		"""
 		credits.purchase(TEAM, 300, "INR")
 		credits.purchase(TEAM, 50, "USD")
-		# Omitting currency returns the running balance of the most recent entry.
+
 		result = credits.get_balance(TEAM)
-		self.assertGreater(result["balance"], 0)
+		self.assertEqual(result["currency"], "INR")  # TEAM's billing currency
+		self.assertEqual(result["balance"], 300)  # NOT 350
+
+	def test_get_balances_lists_each_currency_separately(self):
+		credits.purchase(TEAM, 300, "INR")
+		credits.purchase(TEAM, 50, "USD")
+
+		balances = {b["currency"]: b["balance"] for b in credits.get_balances(TEAM)}
+		self.assertEqual(balances, {"INR": 300, "USD": 50})
+
+
+class TestNonNegativePerCurrency(CreditTestBase):
+	"""The wallet may not go negative — in EVERY currency it holds, not just overall.
+
+	The anchor was once one currency-blind float per team, so the debit guard compared
+	a USD debit against a balance that included the team's INR credits. A team could be
+	driven negative in USD while the anchor stayed positive. The anchor is now keyed
+	(team, currency), so the guard is per-currency by construction (ADR 0018).
+	"""
+
+	def test_usd_debit_cannot_be_funded_by_inr_credits(self):
+		credits.purchase(TEAM, 1000, "INR")
+		credits.purchase(TEAM, 10, "USD")
+
+		# 50 USD against a 10 USD balance. The team holds 1000 INR, which under the
+		# old currency-blind anchor would have made this debit "affordable".
+		with self.assertRaises(InsufficientCredits):
+			credits.apply_credit(TEAM, 50, "USD", reference_name="INV-USD")
+
+		self.assertEqual(credits.get_balance(TEAM, "USD")["balance"], 10)
+		self.assertEqual(credits.get_balance(TEAM, "INR")["balance"], 1000)
+
+	def test_debiting_one_currency_leaves_the_other_untouched(self):
+		credits.purchase(TEAM, 1000, "INR")
+		credits.purchase(TEAM, 80, "USD")
+
+		credits.apply_credit(TEAM, 30, "USD", reference_name="INV-USD")
+
+		self.assertEqual(credits.get_balance(TEAM, "USD")["balance"], 50)
+		self.assertEqual(credits.get_balance(TEAM, "INR")["balance"], 1000)
+
+	def test_anchor_agrees_with_the_ledger_per_currency(self):
+		"""Invariant C2: the anchor equals the signed ledger sum, for each currency."""
+		credits.purchase(TEAM, 500, "INR")
+		credits.purchase(TEAM, 90, "USD")
+		credits.apply_credit(TEAM, 200, "INR", reference_name="INV-1")
+		credits.apply_credit(TEAM, 40, "USD", reference_name="INV-2")
+
+		for currency, expected in (("INR", 300), ("USD", 50)):
+			self.assertEqual(credits.get_balance(TEAM, currency)["balance"], expected)
+			self.assertEqual(credits.ledger_balance(TEAM, currency), expected)
+
+	def test_the_check_constraint_is_actually_installed(self):
+		"""The constraint must exist on EVERY site, not just ones that migrated.
+
+		Frappe marks patches as executed without running them on a fresh install, so a
+		constraint declared only in a patch is silently absent on new sites — a fresh
+		site quietly weaker than a migrated one. It is applied from an
+		after_install/after_migrate hook instead, and this test is what keeps that true.
+		"""
+		self.assertIn(
+			"credit_wallet_balance_non_negative",
+			existing_constraints("tabCredit Wallet"),
+		)
+
+	def test_check_constraint_refuses_a_negative_balance_from_raw_sql(self):
+		"""The rung that actually holds: `set_value` skips the controller entirely.
+
+		This is the write `credits.py` itself performs, so a Python guard alone would
+		leave the invariant unenforced against our own code.
+		"""
+		credits.purchase(TEAM, 100, "INR")
+		wallet = credits.wallet_name(TEAM, "INR")
+
+		with self.assertRaises(Exception) as ctx:
+			frappe.db.set_value("Credit Wallet", wallet, "balance", -1, update_modified=False)
+			frappe.db.commit()
+		frappe.db.rollback()
+		self.assertIn("credit_wallet_balance_non_negative", str(ctx.exception).lower())
 
 
 class TestConcurrency(CreditTestBase):
@@ -209,7 +294,8 @@ class TestConcurrency(CreditTestBase):
 			for t in teams:
 				# 1000 seed − 5×10 debited; anchor and ledger agree.
 				self.assertEqual(credits.get_balance(t)["balance"], 950)
-				self.assertEqual(frappe.db.get_value("Credit Wallet", t, "balance"), 950)
+				anchor = credits.wallet_name(t, "INR")
+				self.assertEqual(frappe.db.get_value("Credit Wallet", anchor, "balance"), 950)
 		finally:
 			for t in teams:
 				frappe.db.delete("Credit Ledger Entry", {"team": t})

--- a/central/hooks.py
+++ b/central/hooks.py
@@ -107,7 +107,14 @@ website_user_home_page = "dashboard"
 # Seed the catalog taxonomy masters (Plan Category / Sub-Category / Resource Type) on a
 # fresh install — patches are skipped on fresh installs, so the seed can't live only
 # there. Idempotent (ADR 0007).
-after_install = "central.billing.catalog.taxonomy_setup.ensure_catalog_masters"
+#
+# `ensure_constraints` is here for exactly the same reason: a CHECK constraint declared
+# only in a patch would exist on migrated sites and be silently ABSENT on fresh ones.
+# The money invariants are a property of the schema, not of a site's history (ADR 0018).
+after_install = [
+	"central.billing.catalog.taxonomy_setup.ensure_catalog_masters",
+	"central.billing.platform.constraints.ensure_constraints",
+]
 
 # Uninstallation
 # ------------
@@ -203,15 +210,23 @@ scheduler_events = {
 # Billing (module): authorisation is Central's capability IAM (ADR 0004) — no
 # billing-owned roles or User->team field to provision. The catalog taxonomy masters,
 # however, are reference data the catalog can't run without, so re-assert them on every
-# migrate too (idempotent — ADR 0007).
-after_migrate = "central.billing.catalog.taxonomy_setup.ensure_catalog_masters"
+# migrate too (idempotent — ADR 0007). The money CHECK constraints are re-asserted for
+# the same reason: a dropped or never-applied constraint must heal on migrate, not wait
+# for someone to notice the balance went negative (ADR 0018).
+after_migrate = [
+	"central.billing.catalog.taxonomy_setup.ensure_catalog_masters",
+	"central.billing.platform.constraints.ensure_constraints",
+]
 
 # Testing
 # -------
 
 # Tests run on a fresh site (patches skipped), so seed the taxonomy masters the test
-# fixtures depend on before the suite runs.
-before_tests = "central.billing.catalog.taxonomy_setup.ensure_catalog_masters"
+# fixtures depend on — and apply the money constraints — before the suite runs.
+before_tests = [
+	"central.billing.catalog.taxonomy_setup.ensure_catalog_masters",
+	"central.billing.platform.constraints.ensure_constraints",
+]
 
 # Extend DocType Class
 # ------------------------------

--- a/central/patches.txt
+++ b/central/patches.txt
@@ -98,6 +98,12 @@ central.patches.v0_0.retire_price_lock
 # Close the open billing segment for VMs already Terminated before termination learned
 # to cancel — frees their run-rate + trust-tier headroom (ADR 0010).
 central.patches.v0_0.cancel_terminated_subscriptions
+# Re-key Credit Wallet from `team` to `(team, currency)` and add CHECK (balance >= 0).
+# The anchor was currency-blind while the ledger was per-currency: the invoice waterfall
+# READ a per-currency balance and DEBITED the blind anchor, so a two-currency team could
+# be driven negative in one of them. The composite key makes "never negative" true per
+# currency; the CHECK makes it true for callers that never reach credits.py — ADR 0018.
+central.patches.v0_0.rekey_wallet_per_currency
 central.patches.v0_0.rename_capabilities
 central.patches.v0_0.make_central_users_portal_only
 # Strip the capability catalog to v3: drop the bench plane (site:* + server:config)

--- a/central/patches/v0_0/rekey_wallet_per_currency.py
+++ b/central/patches/v0_0/rekey_wallet_per_currency.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Re-key Credit Wallet from `team` to `(team, currency)` and forbid a negative
+balance at the database (ADR 0018).
+
+The wallet carried ONE currency-blind `balance` per team while the ledger carried
+per-currency entries. The invoice waterfall read a per-currency balance
+(`get_balance(team, currency)`, which summed the ledger) but debited the
+currency-blind anchor — so the read and the write used different definitions of
+"balance", and a team holding two currencies could be driven negative in one of
+them while the anchor stayed positive. It was closed only by Billing Profile
+locking a team to a single currency: an invariant living nowhere near the code
+that depended on it.
+
+This patch:
+
+1.  Rebuilds the anchors as one row per (team, currency), named `{team}-{currency}`,
+    with the balance recomputed from that currency's ledger entries.
+2.  Rewrites `Credit Ledger Entry.running_balance` as a per-currency cumulative
+    (it was a currency-blind one), so the anchor and the newest entry agree.
+3.  Applies `CHECK (balance >= 0)` — the point of the exercise, since `frappe.db.
+    set_value` skips the controller and so a Python guard protects only polite callers.
+
+The constraint itself is declared in `billing/platform/constraints.py` and applied by
+an `after_install` / `after_migrate` hook, NOT here. A constraint that lived only in a
+patch would be absent on fresh sites (Frappe marks patches as executed without running
+them on a new install). This patch just calls the same idempotent helper so a site
+migrating through v27 gets it immediately rather than on its next migrate.
+
+Idempotent: recomputes from the ledger each run.
+"""
+
+import frappe
+from frappe.query_builder import Case
+from frappe.query_builder.functions import Sum
+
+from central.billing.platform.constraints import ensure_constraints
+
+
+def execute():
+	_backfill_missing_currency()
+	_rebuild_anchors()
+	_rewrite_running_balance()
+	ensure_constraints()
+
+
+def _team_currencies() -> dict[str, list[str]]:
+	"""Every (team, currency) pair the ledger knows about — one query, no N+1."""
+	cle = frappe.qb.DocType("Credit Ledger Entry")
+	signed = Case().when(cle.entry_type == "Credit", cle.amount).else_(-cle.amount)
+	rows = (
+		frappe.qb.from_(cle)
+		.select(cle.team, cle.currency, Sum(signed).as_("balance"))
+		.groupby(cle.team, cle.currency)
+		.run(as_dict=True)
+	)
+	pairs: dict[str, list[str]] = {}
+	for r in rows:
+		pairs.setdefault(r.team, []).append(r)
+	return pairs
+
+
+def _backfill_missing_currency():
+	"""Ledger entries predating the currency column: stamp the team's billing currency.
+
+	A NULL currency would otherwise group into its own phantom wallet and the Link
+	field is now required.
+	"""
+	cle = frappe.qb.DocType("Credit Ledger Entry")
+	orphans = (
+		frappe.qb.from_(cle)
+		.select(cle.name, cle.team)
+		.where(cle.currency.isnull() | (cle.currency == ""))
+		.run(as_dict=True)
+	)
+	if not orphans:
+		return
+	teams = list({o.team for o in orphans})
+	profile = dict(
+		frappe.get_all(
+			"Billing Profile",
+			filters={"team": ["in", teams]},
+			fields=["team", "currency"],
+			as_list=True,
+		)
+	)
+	for o in orphans:
+		frappe.db.set_value(
+			"Credit Ledger Entry", o.name, "currency", profile.get(o.team) or "INR",
+			update_modified=False,
+		)
+
+
+def _rebuild_anchors():
+	"""One anchor per (team, currency), balance recomputed from that currency's ledger."""
+	pairs = _team_currencies()
+
+	# Wallets with no ledger history at all (a provisioned-but-unused wallet) keep a
+	# zero-balance anchor in the team's billing currency so nothing 404s on read.
+	for w in frappe.get_all("Credit Wallet", fields=["name", "team", "currency"]):
+		if w.team not in pairs:
+			currency = w.currency or frappe.db.get_value(
+				"Billing Profile", w.team, "currency"
+			) or "INR"
+			pairs[w.team] = [frappe._dict({"team": w.team, "currency": currency, "balance": 0})]
+
+	frappe.db.delete("Credit Wallet")  # names change; rebuild rather than rename
+
+	for team, rows in pairs.items():
+		if not frappe.db.exists("Team", team):
+			continue  # a deleted team's ledger is history, not a live wallet
+		for r in rows:
+			frappe.get_doc(
+				{
+					"doctype": "Credit Wallet",
+					"team": team,
+					"currency": r["currency"],
+					"balance": max(frappe.utils.flt(r["balance"]), 0.0),
+				}
+			).insert(ignore_permissions=True)
+
+
+def _rewrite_running_balance():
+	"""`running_balance` becomes a per-currency cumulative, matching the new anchor."""
+	entries = frappe.get_all(
+		"Credit Ledger Entry",
+		fields=["name", "team", "currency", "entry_type", "amount"],
+		order_by="team asc, currency asc, creation asc, name asc",
+	)
+	running: dict[tuple[str, str], float] = {}
+	for e in entries:
+		key = (e.team, e.currency)
+		delta = frappe.utils.flt(e.amount) * (1 if e.entry_type == "Credit" else -1)
+		running[key] = running.get(key, 0.0) + delta
+		frappe.db.set_value(
+			"Credit Ledger Entry", e.name, "running_balance", running[key],
+			update_modified=False,
+		)
+
+


### PR DESCRIPTION
The Credit Wallet anchor was ONE currency-blind float per team while the
ledger carried per-currency entries. get_balance(team, currency) summed the
ledger per currency, but _book_entry_once enforced its non-negative guard
against the blind anchor — so the invoice waterfall READ a per-currency
balance and DEBITED a different number. A team holding INR and USD could be
driven negative in USD while the anchor stayed positive; the guard would
approve the debit. The v1 negative-balance bug, via a currency seam. It was
closed only by Billing Profile locking a team to one currency — an invariant
living nowhere near the code that relied on it.

Credit Wallet is re-keyed to (team, currency). The composite key lives in the
NAME (format:{team}-{currency}) so the primary key itself is the uniqueness
constraint AND the booking's FOR UPDATE stays on the clustered PK — a
secondary composite index would have reintroduced the exact lock-order
deadlock the anchor exists to avoid (the reasoning in _lock_and_read_balance
is re-derived for the new key, not inherited).

Enforcement climbs the ADR 0018 ladder rather than resting on a Python if:

  rung 1  CHECK (balance >= 0) on the column — holds against frappe.db
          .set_value, which skips the controller entirely and is exactly how
          credits.py writes the balance
  rung 3  CreditWallet.validate + the InsufficientCredits guard under the lock

The constraint is applied from after_install/after_migrate (billing/platform/
constraints.py), NOT from the patch. Frappe marks patches as executed without
running them on a fresh install, so a patch-only constraint would exist on
migrated sites and be silently absent on new ones — a fresh site quietly
weaker than a migrated one. Found by a test, which is the point.