### PR TITLE
feat(central): RS256/JWKS trust anchor + bootstrap-token enrollment

### DIFF
--- a/central/api/jwks.py
+++ b/central/api/jwks.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import frappe
+from werkzeug.wrappers import Response
+
+from central.central.doctype.central_sso_settings.central_sso_settings import CentralSSOSettings
+
+# Public discovery endpoint. A bench fetches this to learn Central's RSA public key(s) and
+# verifies Central-minted tokens against them offline. Guest-readable by design — a public
+# key is not a secret — and never triggers key generation (that stays on the authenticated
+# signing path). Served as a RAW `{"keys": [...]}` document (not Frappe's `{"message": ...}`
+# envelope) so a standard JWKS client — including the bench's PyJWKClient — can consume it.
+
+
+def jwks_document() -> dict:
+	"""The JSON Web Key Set of Central's active signing key(s): ``{"keys": [...]}``."""
+	return CentralSSOSettings.instance().jwks()
+
+
+@frappe.whitelist(allow_guest=True, methods=["GET"])
+def get_jwks() -> Response:
+	response = Response(mimetype="application/json")
+	response.data = frappe.as_json(jwks_document())
+	return response

--- a/central/api/pilot.py
+++ b/central/api/pilot.py
@@ -73,12 +73,13 @@ def enroll(bootstrap_token: str) -> dict:
 
 	grant = verify_bootstrap_token(bootstrap_token)
 
-	# Single-use: burn the token's jti before minting so a replay (e.g. the token leaking
-	# from VM metadata) can't re-enrol and rotate a live pilot's credential out from under it.
-	consumed_key = f"pilot:enroll:consumed:{grant['jti']}"
-	if frappe.cache.get_value(consumed_key):
+	# Single-use: atomically claim the token's jti before minting, so a replay (the token
+	# leaking from VM metadata) — or two concurrent enrolments racing — can't both succeed
+	# and rotate a live pilot's credential out from under it. SETNX is atomic; a check-then-set
+	# would leave a window where both callers pass. Keyed via make_key so it stays site-scoped.
+	consumed_key = frappe.cache.make_key(f"pilot:enroll:consumed:{grant['jti']}")
+	if not frappe.cache.set(consumed_key, 1, nx=True, ex=BOOTSTRAP_TTL):
 		frappe.throw(_("This enrollment token has already been used."), frappe.AuthenticationError)
-	frappe.cache.set_value(consumed_key, 1, expires_in_sec=BOOTSTRAP_TTL)
 
 	# The pilot_credential_id is this bench's audience id: every downward token Central mints
 	# for it carries `aud = pcid`, and the bench verifies against it. issue_for preserves any

--- a/central/api/pilot.py
+++ b/central/api/pilot.py
@@ -47,3 +47,52 @@ def heartbeat() -> dict:
 		"pilot_credential_id": credential.pilot_credential_id,
 		"server_time": frappe.utils.now(),
 	}
+
+
+@frappe.whitelist(allow_guest=True, methods=["GET"])
+@pilot_credential_auth
+def config() -> dict:
+	"""Discovery the pilot pulls on boot (and refreshes on a TTL): where Central's JWKS
+	lives and this deployment's audience id — all a bench needs to verify minted tokens.
+	No issuer is returned: it is Central's own URL (the same host the pilot already calls),
+	and the bench binds tokens by signature + audience, not issuer."""
+	from central.sso import jwks_url
+
+	credential = frappe.local.pilot_credential
+	return {"jwks_url": jwks_url(), "audience_id": credential.audience_id}
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def enroll(bootstrap_token: str) -> dict:
+	"""First-boot handshake: exchange a single-use, create-time bootstrap token for this
+	pilot's long-lived credential plus its discovery config — in one call. The bootstrap
+	token (signed by Central, short-lived, single-use) is the only authentication; the
+	pilot has no credential yet."""
+	from central.central.doctype.pilot_credential.pilot_credential import PilotCredential
+	from central.sso import BOOTSTRAP_TTL, central_url, jwks_url, verify_bootstrap_token
+
+	grant = verify_bootstrap_token(bootstrap_token)
+
+	# Single-use: burn the token's jti before minting so a replay (e.g. the token leaking
+	# from VM metadata) can't re-enrol and rotate a live pilot's credential out from under it.
+	consumed_key = f"pilot:enroll:consumed:{grant['jti']}"
+	if frappe.cache.get_value(consumed_key):
+		frappe.throw(_("This enrollment token has already been used."), frappe.AuthenticationError)
+	frappe.cache.set_value(consumed_key, 1, expires_in_sec=BOOTSTRAP_TTL)
+
+	# The pilot_credential_id is this bench's audience id: every downward token Central mints
+	# for it carries `aud = pcid`, and the bench verifies against it. issue_for preserves any
+	# Asset link the VM events already bound (billing reads it) — enrollment only mints the token.
+	token = PilotCredential.issue_for(
+		team=grant["team"], pilot_credential_id=grant["pcid"], audience_id=grant["pcid"]
+	)
+	# Commit before returning: a rollback of this request must not strand the pilot with a
+	# token Central will not recognise.
+	frappe.db.commit()
+
+	return {
+		"auth_token": token,
+		"central_endpoint": central_url(),
+		"jwks_url": jwks_url(),
+		"audience_id": grant["pcid"],
+	}

--- a/central/api/sso.py
+++ b/central/api/sso.py
@@ -3,30 +3,26 @@ from __future__ import annotations
 import frappe
 
 from central.iam import can, resolve_team
-from central.integrations.atlas import AtlasClient
-from central.sso import _bench_sso_url, mint_bench_assertion
+from central.sso import bench_gateway, mint_bench_login
 
-# Open-in-bench: hand the signed-in user a one-click link into their bench VM. For a
-# real VM (asset) that link is a login URL Atlas mints in the guest — a scoped,
-# single-use admin SID (a 5-minute JWT). Because it's single-use, we re-mint on every
-# Open rather than reuse a stored URL, so the click always carries a live, unused SID.
-# The legacy SSO-assertion path (central.sso) survives only for the gateway_url dev
-# shortcut, until RS256 signing (#21) makes it prod-safe.
+# Open-in-bench: hand the signed-in user a one-click link into their bench. Central mints a
+# short-lived admin SID signed with its RSA key; the bench verifies it offline against the
+# JWKS (no Atlas round-trip, no per-bench secret). The SID rides `{gateway}/?sid=`, which the
+# bench SPA consumes and exchanges at POST /api/login. `aud` is the bench's audience id (its
+# pilot_credential_id), so a SID minted for one bench is rejected by any other. The SID is
+# single-use (jti + short TTL), so each Open mints a fresh one.
+
+DEV_AUDIENCE = "local-bench"  # audience for the explicit-gateway dev shortcut (no Asset)
 
 
 @frappe.whitelist(methods=["GET"])
 def get_bench_link(asset: str | None = None, team: str | None = None, gateway_url: str | None = None) -> dict:
-	"""Return the URL to open a bench VM at.
+	"""Return the URL to open a bench at, as ``{gateway}/sso?sid=<jwt>``.
 
-	Pass `asset` (a server resource_id) to open that server: `server:open` on its
-	team is the gate (distinct from `server:view`, which only lists it), and the VM
-	must be Running with a bench front door on an Active cluster. The URL handed back
-	is Atlas's one-click login URL — a scoped admin session minted in the guest. It is
-	short-lived (an admin JWT lasts minutes), so a stored URL past its expiry is
-	regenerated here before it's returned, keeping the click live.
-
-	`gateway_url` (no asset) is the dev shortcut: mint a shared-secret SSO assertion
-	against an explicit gateway, used only until the registry "Open" wires `asset` in."""
+	Pass `asset` (a VM resource_id) to open that server: `server:open` on its team is the
+	gate (distinct from `server:view`, which only lists it), and the VM must be Running with
+	a bench gateway on an Active cluster. `gateway_url` (no asset) is the dev shortcut: open
+	an explicit gateway, minting against a fixed dev audience."""
 	user = frappe.session.user
 	if not user or user == "Guest":
 		frappe.throw("Sign in first.", frappe.PermissionError)
@@ -35,20 +31,17 @@ def get_bench_link(asset: str | None = None, team: str | None = None, gateway_ur
 	team = resolve_team(user, team)
 	if not can(user, team, "server:open"):
 		frappe.throw("You can't open servers for this team.", frappe.PermissionError)
-	target = (gateway_url or _bench_sso_url()).rstrip("/")
-	if not target.endswith("/sso"):
-		target += "/sso"
-	return {"url": f"{target}?assertion={mint_bench_assertion(user, team)}"}
+	target = gateway_url.rstrip("/") if gateway_url else bench_gateway()
+	return {"url": f"{target}/?sid={mint_bench_login(DEV_AUDIENCE)}"}
 
 
 def _asset_login_link(asset: str, team: str | None, user: str) -> dict:
-	"""Resolve a VM Asset to its usable one-click login URL, gated on `server:open`.
+	"""Resolve a VM Asset to its one-click login URL, gated on `server:open`.
 
-	get_doc enforces the team-scoped Asset read perm, so a user who can't see the VM
-	can't probe it here either. The VM must be Running and live on an Active cluster.
-	The login URL is always re-minted via Atlas (the admin SID is single-use, so the
-	stored mirror value is worthless on Open) and the mirror is refreshed before we
-	return; if the re-mint can't reach Atlas we hand back nothing and refuse below."""
+	get_doc enforces the team-scoped Asset read perm, so a user who can't see the VM can't
+	probe it here either. The VM must be Running and live on an Active cluster, with a bench
+	gateway. The SID is Central-signed, scoped to the VM's resource_id, and freshly minted on
+	every Open (it is single-use)."""
 	doc = frappe.get_doc("Asset", asset)
 	if team and team != doc.team:
 		frappe.throw("That VM isn't in this team.", frappe.PermissionError)
@@ -58,39 +51,15 @@ def _asset_login_link(asset: str, team: str | None, user: str) -> dict:
 		frappe.throw(f"VM is {doc.status.lower()}, not running.", frappe.ValidationError)
 	if frappe.db.get_value("Atlas Instance", doc.cluster, "status") != "Active":
 		frappe.throw("That cluster is not active.", frappe.ValidationError)
-	url = _fresh_asset_login_url(doc)
-	if not url:
-		# Running + Active but the re-mint couldn't reach Atlas. Surface it rather than
-		# hand back the stored (single-use, likely already-spent) SID as a dead link.
-		frappe.throw("Couldn't get a login URL for this VM. Try again shortly.", frappe.ValidationError)
-	return {"url": url}
-
-
-def _fresh_asset_login_url(doc) -> str:
-	"""The VM's usable login URL: always a freshly regenerated one.
-
-	Unlike a site session (a reusable 24h browser session), a bench Asset's login URL
-	is a **single-use** admin SID — a 5-minute JWT that `bench generate-admin-session`
-	invalidates the moment it's redeemed. So the stored mirror URL is worthless on
-	Open: even inside its 5-minute clock it may already be spent (the tenant clicked
-	once), and a spent SID is a dead login. We re-mint on every Open so the click
-	always carries a live, unused SID — the timestamp is not a usability signal here.
-
-	Re-minting also closes the just-went-Running window where the mirror carries no
-	URL at all: the guest mint lands on Atlas but the status push that carries it can
-	miss (the Running flip is a db_set that doesn't fire the push), so the mirror only
-	catches up on the next reconcile. Asking Atlas directly covers both cases.
-
-	NOT best-effort: if the re-mint can't reach Atlas we return empty (the caller then
-	refuses Open) rather than falling back to the stored URL. For a single-use SID the
-	stored value is almost certainly already consumed, so handing it back would open a
-	dead session — a clean "try again shortly" is better than a broken login."""
-	try:
-		fresh = AtlasClient(frappe.get_doc("Atlas Instance", doc.cluster)).regenerate_vm_login(doc.resource_id)
-		from central.central.doctype.asset.asset import Asset
-
-		Asset.mirror_vm(doc.cluster, fresh, synced_at=frappe.utils.now_datetime())
-		return fresh.get("login_url") or ""
-	except Exception:
-		frappe.log_error(title=f"Regenerate login failed for VM {doc.resource_id}")
-		return ""
+	gateway = (doc.gateway_url or "").rstrip("/")
+	if not gateway:
+		frappe.throw("This VM has no bench gateway yet.", frappe.ValidationError)
+	# The SID's audience is the bench's audience id (its pilot_credential_id), not the VM
+	# resource_id — that is what the bench verifies against. Resolve it from the pilot
+	# credential bound to this VM; a VM whose pilot hasn't enrolled yet can't be opened.
+	audience = frappe.db.get_value(
+		"Pilot Credential", {"asset": doc.resource_id, "status": "Active"}, "audience_id"
+	)
+	if not audience:
+		frappe.throw("This VM's pilot hasn't enrolled yet.", frappe.ValidationError)
+	return {"url": f"{gateway}/?sid={mint_bench_login(audience)}"}

--- a/central/central/doctype/central_sso_settings/central_sso_settings.json
+++ b/central/central/doctype/central_sso_settings/central_sso_settings.json
@@ -1,0 +1,70 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "creation": "2026-07-14 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "signing_section",
+  "kid",
+  "public_key",
+  "private_key"
+ ],
+ "fields": [
+  {
+   "fieldname": "signing_section",
+   "fieldtype": "Section Break",
+   "label": "Signing Key"
+  },
+  {
+   "description": "Key id of the active RSA signing key, stamped into every minted token's header and published in the JWKS.",
+   "fieldname": "kid",
+   "fieldtype": "Data",
+   "label": "Key ID",
+   "read_only": 1
+  },
+  {
+   "description": "PEM public key benches verify Central-minted tokens against. Published (as a JWK) at the JWKS endpoint.",
+   "fieldname": "public_key",
+   "fieldtype": "Code",
+   "label": "Public Key (PEM)",
+   "read_only": 1
+  },
+  {
+   "description": "PEM private key Central signs with. Encrypted at rest; never leaves Central.",
+   "fieldname": "private_key",
+   "fieldtype": "Password",
+   "label": "Private Key (PEM)",
+   "no_copy": 1,
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2026-07-14 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Central",
+ "name": "Central SSO Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/central/central/doctype/central_sso_settings/central_sso_settings.py
+++ b/central/central/doctype/central_sso_settings/central_sso_settings.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026, frappe and contributors
+# For license information, please see license.txt
+
+from __future__ import annotations
+
+import frappe
+from frappe.model.document import Document
+
+# Central's single asymmetric signing key. Central signs downward tokens (bench-login,
+# site-login) with the private half; benches hold only the public half (fetched from the
+# JWKS endpoint) and verify offline. A compromised bench can therefore forge nothing.
+
+RSA_KEY_SIZE = 2048
+ALGORITHM = "RS256"
+
+
+class CentralSSOSettings(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		kid: DF.Data | None
+		private_key: DF.Password | None
+		public_key: DF.Code | None
+	# end: auto-generated types
+
+	@classmethod
+	def instance(cls) -> "CentralSSOSettings":
+		return frappe.get_single("Central SSO Settings")
+
+	def signing_key(self) -> tuple[str, str]:
+		"""The active PEM private key and its `kid`, generating the keypair on first use.
+		Only the (authenticated) minting path calls this, so key generation never rides a
+		guest request."""
+		if not self.kid:
+			self._generate_keypair()
+		return self.get_password("private_key"), self.kid
+
+	def jwks(self) -> dict:
+		"""The public JWKS document benches verify against. Empty until a key exists — a
+		read never generates one (that stays on the signing path)."""
+		if not self.kid:
+			return {"keys": []}
+		return {"keys": [self._public_jwk()]}
+
+	def _public_jwk(self) -> dict:
+		from cryptography.hazmat.primitives.serialization import load_pem_public_key
+		from jwt.algorithms import RSAAlgorithm
+
+		public_key = load_pem_public_key(self.public_key.encode())
+		jwk = RSAAlgorithm.to_jwk(public_key, as_dict=True)
+		jwk.update({"kid": self.kid, "use": "sig", "alg": ALGORITHM})
+		return jwk
+
+	def _generate_keypair(self) -> None:
+		from cryptography.hazmat.primitives import serialization
+		from cryptography.hazmat.primitives.asymmetric import rsa
+
+		key = rsa.generate_private_key(public_exponent=65537, key_size=RSA_KEY_SIZE)
+		self.private_key = key.private_bytes(
+			encoding=serialization.Encoding.PEM,
+			format=serialization.PrivateFormat.PKCS8,
+			encryption_algorithm=serialization.NoEncryption(),
+		).decode()
+		self.public_key = (
+			key.public_key()
+			.public_bytes(
+				encoding=serialization.Encoding.PEM,
+				format=serialization.PublicFormat.SubjectPublicKeyInfo,
+			)
+			.decode()
+		)
+		self.kid = frappe.generate_hash(length=16)
+		# Password field → private key is encrypted at rest on save.
+		self.save(ignore_permissions=True)

--- a/central/central/doctype/pilot_credential/pilot_credential.json
+++ b/central/central/doctype/pilot_credential/pilot_credential.json
@@ -10,6 +10,7 @@
   "pilot_credential_id",
   "team",
   "asset",
+  "audience_id",
   "token_hash",
   "status",
   "expires_at",
@@ -36,12 +37,19 @@
    "reqd": 1
   },
   {
-   "description": "Soft reference to the hosting VM. Many benches may map to one Asset; not the identity key.",
+   "description": "Soft reference to the hosting VM. Many benches may map to one Asset; not the identity key. Bound later, once Atlas echoes the VM event.",
    "fieldname": "asset",
    "fieldtype": "Link",
    "in_standard_filter": 1,
    "label": "Asset",
    "options": "Asset"
+  },
+  {
+   "description": "The bench's audience id (its VM resource_id), stamped into the `aud` of every token Central mints for it. Set at enrollment; independent of the Asset link so it survives mirror lag.",
+   "fieldname": "audience_id",
+   "fieldtype": "Data",
+   "label": "Audience ID",
+   "read_only": 1
   },
   {
    "description": "Hash of the bearer token. The plaintext is returned once at mint and never stored.",

--- a/central/central/doctype/pilot_credential/pilot_credential.py
+++ b/central/central/doctype/pilot_credential/pilot_credential.py
@@ -19,6 +19,7 @@ class PilotCredential(Document):
 		from frappe.types import DF
 
 		asset: DF.Link | None
+		audience_id: DF.Data | None
 		pilot_credential_id: DF.Data
 		expires_at: DF.Datetime | None
 		last_used_at: DF.Datetime | None
@@ -36,7 +37,8 @@ class PilotCredential(Document):
 		return hashlib.sha256(token.encode()).hexdigest()
 
 	@classmethod
-	def mint(cls, team: str, pilot_credential_id: str, asset: str | None = None, expires_at=None) -> str:
+	def mint(cls, team: str, pilot_credential_id: str, asset: str | None = None,
+		expires_at=None, audience_id: str | None = None) -> str:
 		"""Issue a pilot's credential and return the plaintext token once. Idempotent per
 		pilot_credential_id: re-minting an existing pilot rotates its token in place."""
 		name, pcid = cls._DOCTYPE_NAME, pilot_credential_id
@@ -46,8 +48,36 @@ class PilotCredential(Document):
 		doc.pilot_credential_id = pcid
 		doc.team = team
 		doc.asset = asset
+		doc.audience_id = audience_id
 		doc.expires_at = expires_at
 
+		return doc._issue_token()
+
+	@classmethod
+	def reserve(cls, team: str, pilot_credential_id: str, audience_id: str) -> None:
+		"""Create the credential row at provision time WITHOUT issuing a token. The token is
+		issued only at enrollment, so the durable secret is never injected during
+		provisioning. Reserving early lets the `vm.*` events bind the Asset link (which
+		billing reads) no matter when the pilot boots and enrols."""
+		name = cls._DOCTYPE_NAME
+		doc = frappe.get_doc(name, pilot_credential_id) if frappe.db.exists(name, pilot_credential_id) else frappe.new_doc(name)
+		doc.pilot_credential_id = pilot_credential_id
+		doc.team = team
+		doc.audience_id = audience_id
+		doc.status = "Active"
+		# No token_hash: until enrollment issues one, no bearer token can resolve this row.
+		doc.save(ignore_permissions=True)
+
+	@classmethod
+	def issue_for(cls, team: str, pilot_credential_id: str, audience_id: str) -> str:
+		"""Issue (or re-issue) the token for a pilot at enrollment and return the plaintext
+		once. Upserts identity fields but deliberately leaves `asset` untouched — the VM
+		events own that link, and enrollment may land after they do."""
+		name = cls._DOCTYPE_NAME
+		doc = frappe.get_doc(name, pilot_credential_id) if frappe.db.exists(name, pilot_credential_id) else frappe.new_doc(name)
+		doc.pilot_credential_id = pilot_credential_id
+		doc.team = team
+		doc.audience_id = audience_id
 		return doc._issue_token()
 
 	@classmethod

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -275,30 +275,35 @@ class AtlasClient:
 			params["region"] = region
 		params.update(self._pilot_credential(team))
 
-		# Durability handoff: the token is about to leave for Atlas → the bench's
-		# bench.toml. Commit it BEFORE the call so a rollback of the enclosing
-		# request (e.g. the Site-mirror save right after this returns) can't wipe the
-		# credential and strand the bench with a token Central can't verify — a permanent
-		# 401 with no self-heal. The inverse failure is benign: if the Atlas call fails,
-		# the committed credential is simply unused (no one holds the plaintext), which we
-		# deliberately prefer over revoking here — a lost response could mean Atlas *did*
-		# provision, and revoking would then be what strands the bench.
+		# Durability: minting the bootstrap token lazily generates Central's signing key on
+		# first use. Commit BEFORE the Atlas call so a rollback of the enclosing request
+		# can't discard a freshly-generated key while the bench boots with a token signed by
+		# it. The bootstrap token itself is stateless (a signed JWT, no DB row) and the
+		# long-lived credential is created only later at enrollment, so nothing else here
+		# needs committing; an unused token after a failed Atlas call is harmless.
 		frappe.db.commit()
 		return self.client().post_api("atlas.atlas.api.site.create_site", params=params)
 
 	def _pilot_credential(self, team: str) -> dict:
 		"""
-		Mint this pilot's Central credential and hand Atlas the token + callback URL to
-		store on the bench (bench.toml), so later pilot→Central calls authenticate.
-		Atlas binds pilot_credential_id to the pilot and echoes it back to join events. The
-		plaintext token leaves Central only here — never in the reply to Central's caller
+		Mint a single-use enrollment (bootstrap) token and hand Atlas the token + callback
+		URL to seed on the bench (bench.toml). On first boot the pilot exchanges it for its
+		long-lived credential (`central.api.pilot.enroll`) — the durable secret is never
+		injected during provisioning, only a short-lived, single-use one. Atlas binds
+		pilot_credential_id to the pilot and echoes it back to join events, which links the
+		enrolled credential to its VM.
 		"""
+		from central.sso import central_url, mint_bootstrap_token
+
 		pilot_credential_id = f"pcred-{frappe.generate_hash(length=16)}"
+		# Reserve the row now (no token) so the vm.* events can bind its Asset link even if
+		# they arrive before the pilot boots and enrols. The token is issued only at enroll.
+		PilotCredential.reserve(team=team, pilot_credential_id=pilot_credential_id, audience_id=pilot_credential_id)
 
 		return {
 			"pilot_credential_id": pilot_credential_id,
-			"central_endpoint": frappe.conf.get("central_url") or frappe.utils.get_url(),
-			"central_auth_token": PilotCredential.mint(team=team, pilot_credential_id=pilot_credential_id),
+			"central_endpoint": central_url(),
+			"bootstrap_token": mint_bootstrap_token(team=team, pilot_credential_id=pilot_credential_id),
 		}
 
 	def get_site(self, name: str) -> dict:
@@ -319,20 +324,6 @@ class AtlasClient:
 		return self.client().post_api(
 			"run_doc_method",
 			params={"dt": "Site", "dn": name, "method": "regenerate_login_url"},
-		)
-
-	def regenerate_vm_login(self, name: str) -> dict:
-		"""Re-mint a bench VM's one-click login URL and return the fresh Asset-mirror
-		shape (gateway_url + login_url + login_url_expires_at). Central calls this on
-		Open when the Asset's stored URL has expired (the admin JWT lasts 5 minutes, so
-		this is the common path).
-
-		A bench VM's login URL lives on the Pilot that owns the VM, not the pure-microVM
-		Virtual Machine, so this goes through Atlas's provision endpoint, which resolves
-		the VM to its Pilot and re-mints in the guest before returning the payload."""
-		return self.client().post_api(
-			"atlas.atlas.api.provision.regenerate_vm_login",
-			params={"name": name},
 		)
 
 	def check_subdomain(self, subdomain: str, region: str | None = None) -> dict:

--- a/central/sso.py
+++ b/central/sso.py
@@ -1,108 +1,85 @@
 from __future__ import annotations
 
-import json
 import time
 
 import frappe
 import jwt
 
-from central.iam import CAPABILITY_VERSION, resolve_user_grants
+from central.central.doctype.central_sso_settings.central_sso_settings import ALGORITHM, CentralSSOSettings
 
-# The bench admin backend verifies these assertions (HS256, audience=client_id,
-# issuer=central_url, requiring exp/aud/iss/sub). Keep the mint in lockstep.
-APP_NAME = "local-bench"  # OAuth Client we look up / create
-ASSERTION_TTL = 60  # seconds — short-lived, stateless
+# Central signs every downward token — the bench-login SID and the first-boot enrollment
+# token — with its single RSA key. Benches verify offline against the published JWKS, so a
+# compromised bench (holding only the public key) can forge nothing. `aud` scopes a token to
+# one deployment (its VM resource_id), so a SID minted for bench A is rejected by bench B.
+
+BENCH_LOGIN_TTL = 5 * 60  # a short-lived, single-use admin SID
+BOOTSTRAP_TTL = 30 * 60  # the first-boot enrollment window
+ENROLL_SCOPE = "enroll"
 
 
-def _central_url() -> str:
+def central_url() -> str:
 	return frappe.conf.get("central_url") or frappe.utils.get_url()
 
 
-def _insecure_hs256_allowed() -> bool:
-	"""Explicit opt-in dev switch. Default (unset) is off, so the shared-secret path
-	can never ship to prod by accident — a dev site sets `sso_allow_insecure_hs256`."""
-	return bool(frappe.conf.get("sso_allow_insecure_hs256"))
+def jwks_url() -> str:
+	"""Where a bench fetches Central's public key(s) to verify minted tokens."""
+	return f"{central_url()}/api/method/central.api.jwks.get_jwks"
 
 
-def _bench_sso_url() -> str:
-	"""The bench's /sso endpoint. Until the Asset registry lands (#28) this is the
-	dev target; get_bench_link accepts an explicit gateway_url to override it."""
-	configured = frappe.conf.get("bench_sso_redirect")
-	if configured:
-		return configured
-	if not _insecure_hs256_allowed():
-		frappe.throw(
-			"No bench gateway configured — pass gateway_url or set bench_sso_redirect.",
-			frappe.ValidationError,
+def bench_gateway() -> str:
+	"""The dev bench's gateway base, used when opening by explicit gateway (no Asset). The
+	SID rides `/?sid=`, which the bench SPA consumes and exchanges at POST /api/login."""
+	return (frappe.conf.get("bench_sso_redirect") or "http://localhost:3030").rstrip("/")
+
+
+def mint_bench_login(audience: str) -> str:
+	"""A short-lived admin SID that opens a bench. The bench verifies it against the JWKS
+	and checks `aud` equals its own audience id."""
+	return _mint(audience, {"sub": "admin", "scope": "bench"}, BENCH_LOGIN_TTL)
+
+
+def mint_bootstrap_token(team: str, pilot_credential_id: str) -> str:
+	"""A single-use enrollment token seeded into a VM at create time. The pilot presents it
+	once to `central.api.pilot.enroll` to fetch its long-lived credential.
+
+	`aud` is the `pilot_credential_id` — the per-deployment audience id. Central controls it
+	up front (the VM's resource_id isn't known until Atlas provisions), so it doubles as the
+	audience every downward token to this bench will carry."""
+	return _mint(pilot_credential_id, {"scope": ENROLL_SCOPE, "team": team}, BOOTSTRAP_TTL)
+
+
+def verify_bootstrap_token(token: str) -> dict:
+	"""Validate an enrollment token with Central's own public key and return the grant it
+	carries: ``{team, pcid, jti}`` (pcid = the `aud`). Raises on a bad/expired/wrong-scope
+	token."""
+	from cryptography.hazmat.primitives.serialization import load_pem_public_key
+
+	settings = CentralSSOSettings.instance()
+	if not settings.public_key:
+		frappe.throw("Central signing key is not initialised.", frappe.ValidationError)
+	try:
+		claims = jwt.decode(
+			token,
+			load_pem_public_key(settings.public_key.encode()),
+			algorithms=[ALGORITHM],
+			options={"verify_aud": False, "require": ["exp", "aud", "jti"]},
 		)
-	return "http://localhost:3030/sso"
+	except jwt.InvalidTokenError as exc:
+		frappe.throw(f"Invalid enrollment token: {exc}", frappe.AuthenticationError)
+	if claims.get("scope") != ENROLL_SCOPE:
+		frappe.throw("Not an enrollment token.", frappe.AuthenticationError)
+	return {"team": claims["team"], "pcid": claims["aud"], "jti": claims["jti"]}
 
 
-def _assert_insecure_signing_allowed() -> None:
-	"""Fail closed. Until RS256/JWKS (#21) lands, the mint uses a shared HS256 secret
-	— forgeable by any bench that holds it, so it is gated on the explicit
-	`sso_allow_insecure_hs256` flag and stays broken in prod until real signing
-	replaces it."""
-	if not _insecure_hs256_allowed():
-		frappe.throw(
-			"Refusing to mint a shared-secret (HS256) SSO assertion: set "
-			"sso_allow_insecure_hs256 in dev, or land RS256 signing (#21) for prod.",
-			frappe.ValidationError,
-		)
-
-
-def _ensure_oauth_client():
-	"""The `local-bench` OAuth Client — the shared-secret trust anchor. Idempotent."""
-	name = frappe.db.get_value("OAuth Client", {"app_name": APP_NAME})
-	if name:
-		return frappe.get_doc("OAuth Client", name)
-	return frappe.get_doc(
-		{
-			"doctype": "OAuth Client",
-			"app_name": APP_NAME,
-			"default_redirect_uri": _bench_sso_url(),
-			"grant_type": "Authorization Code",
-			"response_type": "Code",
-			"scopes": "openid",
-			"skip_authorization": 1,
-		}
-	).insert(ignore_permissions=True)
-
-
-def _bench_caps(user: str, team: str) -> list[str]:
-	"""The user's bench-plane capabilities on a team — the only caps the bench enforces."""
-	bench_plane = set(frappe.get_all("Capability", filters={"plane": "bench"}, pluck="name"))
-	granted = {c for g in resolve_user_grants(user).get(team, []) for c in g.get("caps", [])}
-	return sorted(granted & bench_plane)
-
-
-def mint_bench_assertion(user: str, team: str) -> str:
-	_assert_insecure_signing_allowed()
-	client = _ensure_oauth_client()
+def _mint(audience: str, claims: dict, ttl: int) -> str:
+	private_pem, kid = CentralSSOSettings.instance().signing_key()
 	now = int(time.time())
 	payload = {
-		"sub": user,
-		"team": team,
-		"caps": _bench_caps(user, team),
-		"cap_version": CAPABILITY_VERSION,
-		"aud": client.client_id,
-		"iss": _central_url(),
+		"iss": central_url(),
+		"aud": audience,
 		"iat": now,
-		"exp": now + ASSERTION_TTL,
+		"exp": now + ttl,
+		"jti": frappe.generate_hash(length=16),
+		**claims,
 	}
-	return jwt.encode(payload, client.client_secret, algorithm="HS256")
-
-
-def print_local_bench_credentials() -> None:
-	"""Emit the bench's SSO trust config for admin/scripts/setup_sso.sh to capture."""
-	_assert_insecure_signing_allowed()
-	client = _ensure_oauth_client()
-	# CLI helper: persist the just-created OAuth Client so the external setup script
-	# can read its credentials from stdout in a separate connection.
-	frappe.db.commit()
-	cfg = {
-		"central_url": _central_url(),
-		"client_id": client.client_id,
-		"client_secret": client.client_secret,
-	}
-	print(f"SSO_CONFIG={json.dumps(cfg)}")
+	return jwt.encode(payload, private_pem, algorithm=ALGORITHM, headers={"kid": kid})

--- a/central/tests/test_enroll.py
+++ b/central/tests/test_enroll.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026, frappe and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests import IntegrationTestCase
+from frappe.utils import set_request
+
+from central.api.pilot import config, enroll
+from central.central.doctype.pilot_credential.pilot_credential import PilotCredential
+from central.sso import jwks_url, mint_bootstrap_token
+from central.tests.test_iam import ensure_user
+
+
+class TestEnrollment(IntegrationTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.owner = ensure_user("enroll.owner@example.test")
+		self.team = frappe.get_doc(
+			{
+				"doctype": "Team",
+				"team_name": "Enroll Team",
+				"owner_user": self.owner,
+				"members": [{"user": self.owner, "role": "Owner", "status": "Active"}],
+			}
+		).insert().name
+		self.pcid = "pcred-enroll-1"
+		if frappe.db.exists("Pilot Credential", self.pcid):
+			frappe.delete_doc("Pilot Credential", self.pcid, force=True)
+
+	def _token(self) -> str:
+		return mint_bootstrap_token(team=self.team, pilot_credential_id=self.pcid)
+
+	def test_enroll_returns_a_working_credential_and_discovery(self):
+		result = enroll(self._token())
+
+		# The audience id is the pilot_credential_id — Central controls it up front.
+		self.assertEqual(result["audience_id"], self.pcid)
+		self.assertEqual(result["jwks_url"], jwks_url())
+		# The returned token authenticates as this pilot, bound to the team + audience.
+		credential = PilotCredential.verify(result["auth_token"])
+		self.assertIsNotNone(credential)
+		self.assertEqual(credential.team, self.team)
+		self.assertEqual(credential.audience_id, self.pcid)
+
+	def test_bootstrap_token_is_single_use(self):
+		token = self._token()
+		enroll(token)
+		with self.assertRaises(frappe.AuthenticationError):
+			enroll(token)
+
+	def test_a_non_enrollment_token_is_rejected(self):
+		from central.sso import mint_bench_login
+
+		with self.assertRaises(frappe.AuthenticationError):
+			enroll(mint_bench_login(self.pcid))
+
+	def test_garbage_token_is_rejected(self):
+		with self.assertRaises(frappe.AuthenticationError):
+			enroll("not-a-jwt")
+
+	def test_config_reports_this_pilots_audience(self):
+		token = enroll(self._token())["auth_token"]
+		set_request(method="GET", path="/api/method/central.api.pilot.config",
+			    headers={"X-Pilot-Token": token})
+		result = config()
+		self.assertEqual(result["audience_id"], self.pcid)
+		self.assertEqual(result["jwks_url"], jwks_url())

--- a/central/tests/test_open_bench.py
+++ b/central/tests/test_open_bench.py
@@ -1,22 +1,22 @@
-from unittest.mock import patch
-
 import frappe
+import jwt
 from frappe.tests import IntegrationTestCase
+from jwt.algorithms import RSAAlgorithm
 
+from central.api.jwks import jwks_document
 from central.api.sso import get_bench_link
+from central.central.doctype.central_sso_settings.central_sso_settings import ALGORITHM
+from central.central.doctype.pilot_credential.pilot_credential import PilotCredential
+from central.sso import central_url
 from central.tests.test_iam import ensure_user
 
-# Open-in-bench for a real VM (asset) now hands back Atlas's one-click login URL —
-# the scoped admin SID minted in the guest — not a Central-signed SSO assertion.
-# The SID is single-use (a 5-minute JWT `bench generate-admin-session` invalidates on
-# redeem), so Open ALWAYS re-mints via Atlas — even a stored, unexpired URL is spent
-# once clicked. If the re-mint can't reach Atlas, Open is refused (the stored SID is
-# no fallback — it's dead). The legacy SSO-assertion path survives only for the
-# explicit `gateway_url` dev shortcut (covered by test_sso.py).
+# Open-in-bench for a real VM (asset) now hands back a Central-signed admin SID as
+# `{gateway}/?sid=<jwt>`. Central mints it locally against its RSA key, scoped to the bench's
+# audience id (its pilot_credential_id); the bench verifies it offline against the JWKS. No
+# Atlas round-trip: opening a Running VM on an Active cluster just needs a gateway + an
+# enrolled pilot. The SID is single-use (jti + short TTL), so a fresh one is minted on every Open.
 
-FUTURE = "2099-01-01 00:00:00"
-PAST = "2000-01-01 00:00:00"
-STORED_URL = "https://vm-open-1.blr1.frappe.dev/app?sid=stored"
+GATEWAY = "https://vm-open-1.blr1.frappe.dev"
 
 
 class TestOpenBench(IntegrationTestCase):
@@ -27,10 +27,18 @@ class TestOpenBench(IntegrationTestCase):
 		self.viewer = ensure_user("open.viewer@example.test")
 		self.team = self._team()
 		self.cluster = self._cluster("blr-open")
-		self.asset = self._asset("vm-open-1", "Running", login_url=STORED_URL, expires_at=FUTURE)
+		self.asset = self._asset("vm-open-1", "Running")
+		self.pcid = "pcred-open-1"
+		self._credential(self.pcid, "vm-open-1")
 
 	def tearDown(self):
 		frappe.set_user("Administrator")
+
+	def _credential(self, pcid, rid):
+		"""An enrolled pilot bound to the VM — its audience_id is what SIDs are minted for."""
+		if frappe.db.exists("Pilot Credential", pcid):
+			frappe.delete_doc("Pilot Credential", pcid, force=True)
+		PilotCredential.mint(team=self.team.name, pilot_credential_id=pcid, asset=rid, audience_id=pcid)
 
 	def _team(self):
 		name = "Open Bench Team"
@@ -51,6 +59,8 @@ class TestOpenBench(IntegrationTestCase):
 		).insert()
 
 	def _cluster(self, region):
+		if not frappe.db.exists("Region", region):
+			frappe.get_doc({"doctype": "Region", "region": region}).insert()
 		if frappe.db.exists("Atlas Instance", region):
 			frappe.delete_doc("Atlas Instance", region, force=True)
 		frappe.get_doc(
@@ -65,7 +75,7 @@ class TestOpenBench(IntegrationTestCase):
 		).insert()
 		return region
 
-	def _asset(self, rid, status, *, login_url="", expires_at=None, gateway="https://vm-open-1.blr1.frappe.dev"):
+	def _asset(self, rid, status, *, gateway=GATEWAY):
 		if frappe.db.exists("Asset", rid):
 			frappe.delete_doc("Asset", rid, force=True, ignore_permissions=True)
 		return frappe.get_doc(
@@ -76,112 +86,56 @@ class TestOpenBench(IntegrationTestCase):
 				"cluster": self.cluster,
 				"status": status,
 				"gateway_url": gateway or None,
-				"login_url": login_url or None,
-				"login_url_expires_at": expires_at,
 			}
 		).insert(ignore_permissions=True)
 
-	def _as(self, user, fn):
+	def _open(self, user, **kwargs):
 		frappe.set_user(user)
 		try:
-			return fn()
+			return get_bench_link(**kwargs)
 		finally:
 			frappe.set_user("Administrator")
 
-	def test_open_running_vm_always_regenerates_sid(self):
-		"""Even a stored, unexpired login URL is re-minted on Open — the bench SID is
-		single-use, so the stored value may already be spent. The fresh URL is returned
-		(and mirrored back), never the stored one."""
-		fresh_url = "https://vm-open-1.blr1.frappe.dev/app?sid=fresh"
-		fresh_payload = {
-			"name": "vm-open-1",
-			"team": self.team.name,
-			"status": "Running",
-			"gateway_url": "https://vm-open-1.blr1.frappe.dev",
-			"login_url": fresh_url,
-			"login_url_expires_at": FUTURE,
-		}
-		with patch(
-			"central.integrations.atlas.AtlasClient.regenerate_vm_login", return_value=fresh_payload
-		) as regen:
-			link = self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
-		regen.assert_called_once_with("vm-open-1")
-		self.assertEqual(link["url"], fresh_url)
-		self.assertEqual(frappe.db.get_value("Asset", "vm-open-1", "login_url"), fresh_url)
+	def test_open_running_vm_mints_local_sid(self):
+		"""Opening a Running VM returns a Central-signed SID at the VM's gateway, scoped to
+		the bench's audience id (its pilot_credential_id) — verifiable against the JWKS, with
+		no Atlas call."""
+		link = self._open(self.dev, asset="vm-open-1")
+		self.assertTrue(link["url"].startswith(f"{GATEWAY}/?sid="))
 
-	def test_expired_login_url_is_regenerated(self):
-		"""An expired stored URL triggers a re-mint via Atlas, and the fresh URL is
-		returned (and mirrored back onto the Asset)."""
-		self._asset("vm-open-1", "Running", login_url=STORED_URL, expires_at=PAST)
-		fresh_url = "https://vm-open-1.blr1.frappe.dev/app?sid=fresh"
-		fresh_payload = {
-			"name": "vm-open-1",
-			"team": self.team.name,
-			"status": "Running",
-			"gateway_url": "https://vm-open-1.blr1.frappe.dev",
-			"login_url": fresh_url,
-			"login_url_expires_at": FUTURE,
-		}
-		with patch(
-			"central.integrations.atlas.AtlasClient.regenerate_vm_login", return_value=fresh_payload
-		) as regen:
-			link = self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
-		regen.assert_called_once_with("vm-open-1")
-		self.assertEqual(link["url"], fresh_url)
-		self.assertEqual(frappe.db.get_value("Asset", "vm-open-1", "login_url"), fresh_url)
+		public_key = RSAAlgorithm.from_jwk(jwks_document()["keys"][0])
+		claims = jwt.decode(
+			link["url"].split("sid=", 1)[1],
+			public_key,
+			algorithms=[ALGORITHM],
+			audience=self.pcid,
+			issuer=central_url(),
+		)
+		self.assertEqual(claims["sub"], "admin")
+		self.assertEqual(claims["scope"], "bench")
 
-	def test_regenerate_failure_refuses_rather_than_serving_stored_url(self):
-		"""If Atlas is unreachable when regenerating, Open is refused — the stored SID is
-		single-use and almost certainly spent, so handing it back would open a dead
-		session. A clean 'try again shortly' beats a broken login."""
-		self._asset("vm-open-1", "Running", login_url=STORED_URL, expires_at=FUTURE)
-		with patch(
-			"central.integrations.atlas.AtlasClient.regenerate_vm_login", side_effect=Exception("down")
-		):
-			with self.assertRaises(frappe.ValidationError):
-				self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
+	def test_unenrolled_vm_refused(self):
+		"""A Running VM whose pilot hasn't enrolled has no audience id yet — Open is refused
+		rather than minting a SID no bench would accept."""
+		frappe.delete_doc("Pilot Credential", self.pcid, force=True)
+		with self.assertRaises(frappe.ValidationError):
+			self._open(self.dev, asset="vm-open-1")
 
 	def test_viewer_without_vm_open_is_blocked(self):
 		with self.assertRaises(frappe.PermissionError):
-			self._as(self.viewer, lambda: get_bench_link(asset="vm-open-1"))
+			self._open(self.viewer, asset="vm-open-1")
 
 	def test_stopped_vm_refused(self):
-		self._asset("vm-open-1", "Stopped", login_url=STORED_URL, expires_at=FUTURE)
+		self._asset("vm-open-1", "Stopped")
 		with self.assertRaises(frappe.ValidationError):
-			self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
+			self._open(self.dev, asset="vm-open-1")
 
-	def test_missing_login_url_is_regenerated(self):
-		"""An empty mirror login_url (the push that carries it lagged behind the reconcile)
-		is re-minted via Atlas rather than refused — Open shouldn't block on mirror lag."""
-		self._asset("vm-open-1", "Running", login_url="", expires_at=None)
-		fresh_url = "https://vm-open-1.blr1.frappe.dev/app?sid=minted"
-		fresh_payload = {
-			"name": "vm-open-1",
-			"team": self.team.name,
-			"status": "Running",
-			"gateway_url": "https://vm-open-1.blr1.frappe.dev",
-			"login_url": fresh_url,
-			"login_url_expires_at": FUTURE,
-		}
-		with patch(
-			"central.integrations.atlas.AtlasClient.regenerate_vm_login", return_value=fresh_payload
-		) as regen:
-			link = self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
-		regen.assert_called_once_with("vm-open-1")
-		self.assertEqual(link["url"], fresh_url)
-		self.assertEqual(frappe.db.get_value("Asset", "vm-open-1", "login_url"), fresh_url)
-
-	def test_missing_login_url_and_atlas_down_refused(self):
-		"""Empty mirror URL AND Atlas unreachable: there's no live link to hand back, so
-		Open is refused with a clear message rather than opening a dead/empty URL."""
-		self._asset("vm-open-1", "Running", login_url="", expires_at=None)
-		with patch(
-			"central.integrations.atlas.AtlasClient.regenerate_vm_login", side_effect=Exception("down")
-		):
-			with self.assertRaises(frappe.ValidationError):
-				self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
+	def test_missing_gateway_refused(self):
+		self._asset("vm-open-1", "Running", gateway=None)
+		with self.assertRaises(frappe.ValidationError):
+			self._open(self.dev, asset="vm-open-1")
 
 	def test_disabled_cluster_refused(self):
 		frappe.db.set_value("Atlas Instance", self.cluster, "status", "Disabled")
 		with self.assertRaises(frappe.ValidationError):
-			self._as(self.dev, lambda: get_bench_link(asset="vm-open-1"))
+			self._open(self.dev, asset="vm-open-1")

--- a/central/tests/test_pilot_credential_delivery.py
+++ b/central/tests/test_pilot_credential_delivery.py
@@ -7,11 +7,15 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import now_datetime
 
+from central.api.pilot import enroll
 from central.central.doctype.pilot_credential.pilot_credential import PilotCredential
 from central.integrations.atlas import AtlasClient, _on_vm, _on_vm_deleted
+from central.sso import verify_bootstrap_token
 from central.tests.test_iam import ensure_user
 
-_CREDENTIAL_KEYS = {"pilot_credential_id", "central_endpoint", "central_auth_token"}
+# What create_site now hands Atlas to seed on the bench: the endpoint + a single-use
+# bootstrap token. The long-lived auth_token is NOT here — the pilot mints it at enrollment.
+_SEED_KEYS = {"pilot_credential_id", "central_endpoint", "bootstrap_token"}
 
 
 class TestPilotCredentialDelivery(IntegrationTestCase):
@@ -27,6 +31,8 @@ class TestPilotCredentialDelivery(IntegrationTestCase):
 			}
 		).insert().name
 		self.region = "blr-delivery"
+		if not frappe.db.exists("Region", self.region):
+			frappe.get_doc({"doctype": "Region", "region": self.region}).insert()
 		if not frappe.db.exists("Atlas Instance", self.region):
 			frappe.get_doc(
 				{
@@ -38,8 +44,8 @@ class TestPilotCredentialDelivery(IntegrationTestCase):
 					"api_secret": "s",
 				}
 			).insert()
-		# create_site commits the credential before handing it to Atlas (durability). Stub
-		# the commit so it can't break test isolation, and so we can assert it fires.
+		# create_site commits before handing off to Atlas (durability — the lazily-generated
+		# signing key). Stub the commit so it can't break test isolation, and so we can assert it fires.
 		commit = patch("frappe.db.commit")
 		self.mock_commit = commit.start()
 		self.addCleanup(commit.stop)
@@ -52,30 +58,45 @@ class TestPilotCredentialDelivery(IntegrationTestCase):
 			AtlasClient.for_region(self.region).create_site(team=self.team, subdomain="acme")
 		return transport.post_api.call_args.kwargs["params"]
 
-	def test_create_site_emits_credential_params(self):
+	def test_create_site_emits_bootstrap_seed(self):
 		params = self.create_site_capturing_params()
-		self.assertLessEqual(_CREDENTIAL_KEYS, set(params))
+		self.assertLessEqual(_SEED_KEYS, set(params))
+		self.assertNotIn("central_auth_token", params)  # the durable secret is never injected
 		self.assertTrue(params["pilot_credential_id"].startswith("pcred-"))
 		self.assertEqual(params["central_endpoint"], frappe.utils.get_url())
 
-	def test_emitted_token_is_a_working_active_credential(self):
+	def test_credential_is_reserved_without_a_token(self):
+		"""The row exists after create_site so the vm.* events can bind it, but carries no
+		token yet — so nothing can authenticate as this pilot until it enrols."""
+		pcid = self.create_site_capturing_params()["pilot_credential_id"]
+		self.assertEqual(frappe.db.get_value("Pilot Credential", pcid, "status"), "Active")
+		self.assertFalse(frappe.db.get_value("Pilot Credential", pcid, "token_hash"))
+
+	def test_bootstrap_token_is_a_valid_enrollment_grant(self):
 		params = self.create_site_capturing_params()
-		self.assertEqual(frappe.db.get_value("Pilot Credential", params["pilot_credential_id"], "status"), "Active")
-		credential = PilotCredential.verify(params["central_auth_token"])
+		grant = verify_bootstrap_token(params["bootstrap_token"])
+		self.assertEqual(grant["team"], self.team)
+		self.assertEqual(grant["pcid"], params["pilot_credential_id"])
+
+	def test_enrolling_the_seed_yields_a_working_credential(self):
+		params = self.create_site_capturing_params()
+		result = enroll(params["bootstrap_token"])
+		credential = PilotCredential.verify(result["auth_token"])
 		self.assertIsNotNone(credential)
 		self.assertEqual(credential.team, self.team)
+		self.assertEqual(credential.audience_id, params["pilot_credential_id"])
 
-	def test_token_is_not_returned_to_central_caller(self):
-		"""The plaintext token must reach Atlas only — never the Central API response."""
+	def test_seed_is_not_returned_to_central_caller(self):
+		"""The bootstrap token must reach Atlas only — never the Central API response."""
 		transport = MagicMock()
 		transport.post_api.return_value = {"name": "acme.blr.test", "status": "Pending", "team": self.team}
 		with patch.object(AtlasClient, "client", return_value=transport):
 			result = AtlasClient.for_region(self.region).create_site(team=self.team, subdomain="acme")
-		self.assertNotIn("central_auth_token", result)
+		self.assertNotIn("bootstrap_token", result)
 
-	def test_credential_is_committed_before_the_atlas_call(self):
-		"""Durability: the credential is committed BEFORE the token is handed to Atlas, so a
-		rollback of the enclosing request can't strand the bench with an unverifiable token."""
+	def test_commit_fires_before_the_atlas_call(self):
+		"""Durability: the (lazily-generated) signing key is committed BEFORE the token is
+		handed to Atlas, so a rollback can't discard a key the bench boots with a token from."""
 		order: list[str] = []
 		self.mock_commit.side_effect = lambda: order.append("commit")
 		transport = MagicMock()
@@ -88,19 +109,20 @@ class TestPilotCredentialDelivery(IntegrationTestCase):
 			AtlasClient.for_region(self.region).create_site(team=self.team, subdomain="acme")
 		self.assertEqual(order, ["commit", "post_api"])
 
-	def test_vm_created_event_links_credential_to_its_asset(self):
-		"""Once Atlas echoes pilot_credential_id on the VM event, the credential binds to
-		the Asset (VM) it runs on."""
+	def test_vm_created_event_links_reserved_credential_to_its_asset(self):
+		"""The reserved credential binds to its Asset on the vm event — even before the pilot
+		enrols — so billing can resolve the bench's server straight away."""
 		pcid = self.create_site_capturing_params()["pilot_credential_id"]
 		payload = {"name": "vm-link-1", "team": self.team, "pilot_credential_id": pcid, "status": "Running"}
 		_on_vm(self.region, payload, now_datetime())
 		self.assertEqual(frappe.db.get_value("Pilot Credential", pcid, "asset"), "vm-link-1")
 
 	def test_vm_deleted_event_revokes_credential(self):
-		"""The pilot dies with its VM — vm.deleted revokes the credential, so a leaked
-		token is inert."""
+		"""The pilot dies with its VM — vm.deleted revokes the credential, so an enrolled
+		token is inert afterwards."""
 		params = self.create_site_capturing_params()
-		pcid, token = params["pilot_credential_id"], params["central_auth_token"]
+		pcid = params["pilot_credential_id"]
+		token = enroll(params["bootstrap_token"])["auth_token"]
 		self.assertIsNotNone(PilotCredential.verify(token))
 		_on_vm_deleted(self.region, {"name": "vm-del-1", "pilot_credential_id": pcid}, now_datetime())
 		self.assertEqual(frappe.db.get_value("Pilot Credential", pcid, "status"), "Revoked")

--- a/central/tests/test_sso.py
+++ b/central/tests/test_sso.py
@@ -1,25 +1,23 @@
 import frappe
 import jwt
 from frappe.tests import IntegrationTestCase
+from jwt.algorithms import RSAAlgorithm
 
-from central.api.sso import get_bench_link
-from central.sso import _central_url, _ensure_oauth_client
+from central.api.jwks import jwks_document
+from central.api.sso import DEV_AUDIENCE, get_bench_link
+from central.central.doctype.central_sso_settings.central_sso_settings import ALGORITHM
+from central.sso import central_url
 from central.tests.test_iam import ensure_user
 
 
 class TestCentralSSO(IntegrationTestCase):
 	def setUp(self):
 		frappe.set_user("Administrator")
-		# The shared-secret mint is dev-gated; enable the opt-in for these tests so
-		# they don't depend on the site's config (CI's test_site has it off).
-		self._orig_insecure = frappe.conf.get("sso_allow_insecure_hs256")
-		frappe.conf.sso_allow_insecure_hs256 = 1
 		self.owner = ensure_user("sso.owner@example.test")
 		self.developer = ensure_user("sso.developer@example.test")
 		self.viewer = ensure_user("sso.viewer@example.test")
 
 	def tearDown(self):
-		frappe.conf.sso_allow_insecure_hs256 = self._orig_insecure
 		frappe.set_user("Administrator")
 
 	def make_team(self, user: str, role: str):
@@ -35,64 +33,42 @@ class TestCentralSSO(IntegrationTestCase):
 			}
 		).insert()
 
-	def _verify_like_bench(self, token: str) -> dict:
-		"""Decode exactly as admin/backend/auth.py:verify_assertion does."""
-		client = _ensure_oauth_client()
+	def _verify_like_bench(self, token: str, audience: str) -> dict:
+		"""Verify exactly as a bench would: reconstruct the public key from Central's JWKS
+		and check the signature, audience, and issuer."""
+		public_key = RSAAlgorithm.from_jwk(jwks_document()["keys"][0])
 		return jwt.decode(
 			token,
-			client.client_secret,
-			algorithms=["HS256"],
-			audience=client.client_id,
-			issuer=_central_url(),
+			public_key,
+			algorithms=[ALGORITHM],
+			audience=audience,
+			issuer=central_url(),
 			options={"require": ["exp", "aud", "iss", "sub"]},
 		)
 
-	def test_mint_is_bench_verifiable_and_carries_only_bench_caps(self):
-		team = self.make_team(self.developer, "Developer")
-		frappe.set_user(self.developer)
+	def _open(self, user: str, **kwargs) -> dict:
+		frappe.set_user(user)
 		try:
-			link = get_bench_link(team=team.name, gateway_url="http://localhost:3030")
+			return get_bench_link(**kwargs)
 		finally:
 			frappe.set_user("Administrator")
 
-		self.assertTrue(link["url"].startswith("http://localhost:3030/sso?assertion="))
-		claims = self._verify_like_bench(link["url"].split("assertion=", 1)[1])
-
-		self.assertEqual(claims["sub"], self.developer)
-		self.assertEqual(claims["team"], team.name)
-		# The bench plane is deferred (v3), so the token carries no caps yet — but the
-		# mint still filters by plane, so central/atlas caps never leak to the bench.
-		# When site:* returns under the bench plane it will flow through unchanged.
-		self.assertEqual(claims["caps"], [])
-		self.assertNotIn("billing:view", claims["caps"])
-		self.assertNotIn("server:view", claims["caps"])
-		self.assertNotIn("server:create", claims["caps"])
-
-	def test_production_site_refuses_shared_secret_mint(self):
-		# Fail closed: without the explicit sso_allow_insecure_hs256 opt-in (i.e. a
-		# prod site) the shared-secret mint must refuse until RS256 (#21) replaces it.
+	def test_dev_gateway_mint_is_bench_verifiable(self):
 		team = self.make_team(self.developer, "Developer")
-		original = frappe.conf.get("sso_allow_insecure_hs256")
-		frappe.conf.sso_allow_insecure_hs256 = 0
-		frappe.set_user(self.developer)
-		try:
-			with self.assertRaises(frappe.ValidationError):
-				get_bench_link(team=team.name, gateway_url="http://localhost:3030")
-		finally:
-			frappe.conf.sso_allow_insecure_hs256 = original
-			frappe.set_user("Administrator")
+		link = self._open(self.developer, team=team.name, gateway_url="http://localhost:3030")
+
+		self.assertTrue(link["url"].startswith("http://localhost:3030/?sid="))
+		claims = self._verify_like_bench(link["url"].split("sid=", 1)[1], DEV_AUDIENCE)
+		self.assertEqual(claims["sub"], "admin")
+		self.assertEqual(claims["scope"], "bench")
+		self.assertEqual(claims["aud"], DEV_AUDIENCE)
 
 	def test_server_open_gates_the_handoff(self):
-		# server:open (the old vm:open) is the console gate, distinct from server:view
-		# which only lists servers. A Developer carries it and can open; a Viewer sees
-		# servers in the inventory but cannot open the console.
+		# server:open is the console gate, distinct from server:view (which only lists).
+		# A Developer carries it and can open; a Viewer sees servers but cannot open one.
 		dev_team = self.make_team(self.developer, "Developer")
-		frappe.set_user(self.developer)
-		try:
-			link = get_bench_link(team=dev_team.name, gateway_url="http://localhost:3030")
-			self.assertIn("/sso?assertion=", link["url"])
-		finally:
-			frappe.set_user("Administrator")
+		link = self._open(self.developer, team=dev_team.name, gateway_url="http://localhost:3030")
+		self.assertIn("/?sid=", link["url"])
 
 		view_team = self.make_team(self.viewer, "Viewer")
 		frappe.set_user(self.viewer)

--- a/central/tests/test_sso_keys.py
+++ b/central/tests/test_sso_keys.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, frappe and Contributors
+# See license.txt
+
+import time
+
+import frappe
+import jwt
+from frappe.tests import IntegrationTestCase
+from jwt.algorithms import RSAAlgorithm
+
+import json
+
+from central.api.jwks import get_jwks, jwks_document
+from central.central.doctype.central_sso_settings.central_sso_settings import ALGORITHM, CentralSSOSettings
+
+
+class TestSSOKeys(IntegrationTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+		# Start each test from an un-keyed singleton so generation is exercised deterministically.
+		settings = CentralSSOSettings.instance()
+		settings.db_set("kid", None)
+		settings.db_set("public_key", None)
+		settings.db_set("private_key", None)
+
+	def test_jwks_is_empty_until_a_key_exists(self):
+		self.assertEqual(jwks_document(), {"keys": []})
+
+	def test_signing_key_generates_a_usable_keypair(self):
+		private_pem, kid = CentralSSOSettings.instance().signing_key()
+		self.assertTrue(kid)
+		self.assertIn("BEGIN PRIVATE KEY", private_pem)
+
+	def test_jwks_publishes_the_active_public_key(self):
+		_, kid = CentralSSOSettings.instance().signing_key()
+		keys = jwks_document()["keys"]
+		self.assertEqual(len(keys), 1)
+		jwk = keys[0]
+		self.assertEqual(jwk["kid"], kid)
+		self.assertEqual(jwk["kty"], "RSA")
+		self.assertEqual(jwk["use"], "sig")
+		self.assertEqual(jwk["alg"], ALGORITHM)
+
+	def test_endpoint_serves_raw_jwks_without_the_message_envelope(self):
+		"""A JWKS client (the bench's PyJWKClient) reads `keys` at the top level — the
+		endpoint must not wrap it in Frappe's `{"message": ...}` envelope."""
+		CentralSSOSettings.instance().signing_key()
+		body = json.loads(get_jwks().get_data())
+		self.assertIn("keys", body)
+		self.assertNotIn("message", body)
+
+	def test_token_signed_by_central_verifies_against_published_jwks(self):
+		"""End-to-end: a bench reconstructs the public key from the JWKS and verifies a
+		token Central signed with the private half."""
+		private_pem, kid = CentralSSOSettings.instance().signing_key()
+		now = int(time.time())
+		token = jwt.encode(
+			{"sub": "admin", "aud": "vm-1", "iss": "central", "iat": now, "exp": now + 60},
+			private_pem,
+			algorithm=ALGORITHM,
+			headers={"kid": kid},
+		)
+
+		jwk = jwks_document()["keys"][0]
+		public_key = RSAAlgorithm.from_jwk(jwk)
+		claims = jwt.decode(token, public_key, algorithms=[ALGORITHM], audience="vm-1", issuer="central")
+		self.assertEqual(claims["sub"], "admin")
+
+	def test_a_forged_token_is_rejected(self):
+		"""A token signed by a different key must fail verification against the JWKS."""
+		_, kid = CentralSSOSettings.instance().signing_key()
+		from cryptography.hazmat.primitives import serialization
+		from cryptography.hazmat.primitives.asymmetric import rsa
+
+		attacker = rsa.generate_private_key(public_exponent=65537, key_size=2048).private_bytes(
+			encoding=serialization.Encoding.PEM,
+			format=serialization.PrivateFormat.PKCS8,
+			encryption_algorithm=serialization.NoEncryption(),
+		).decode()
+		now = int(time.time())
+		token = jwt.encode({"sub": "admin", "iat": now, "exp": now + 60}, attacker, algorithm=ALGORITHM,
+				   headers={"kid": kid})
+
+		public_key = RSAAlgorithm.from_jwk(jwks_document()["keys"][0])
+		with self.assertRaises(jwt.InvalidSignatureError):
+			jwt.decode(token, public_key, algorithms=[ALGORITHM], options={"verify_aud": False})


### PR DESCRIPTION
This is in reference to simplifying the Central - Pilot communication via Atlas. [Pilot Issue 172](https://github.com/frappe/pilot/issues/172). The idea is fundamentally derived from this comment - https://github.com/frappe/pilot/issues/172#issuecomment-4959938197

The idea is basically - 

To make Central the single signer for tokens benches trust, and mints pilot credentials only when a bench enrolls.

- One RSA signing key (Central SSO Settings) + a JWKS endpoint publishing the public half. Replaces the old dead HS256 shared-secret path.
- Minters (central/sso.py): a short-lived bench-login SID and a single-use bootstrap token, both signed with that key. Token aud = the pilot_credential_id (the per-bench audience Central controls up front).
- Enrollment (central.api.pilot.enroll): a bench exchanges its bootstrap token for its long-lived credential + JWKS config, in one call. Credentials are reserved (no token) at provision time and the token is issued only at enroll — so the durable secret is never handed out early.
- Open-in-bench now mints the login SID locally ({gateway}/?sid=) — no Atlas round-trip.

Tests: JWKS, enrollment, open-bench, and credential delivery all covered.

This mostly takes care of the Downward flow of the communication from Central to Pilot and also builds the foundation for upward communication from Pilot.

Related PRs - [Atlas](https://github.com/frappe/atlas/pull/116) [Pilot](https://github.com/frappe/pilot/pull/164)