### PR TITLE
fix(billing): a team can no longer be billed twice for one period

### DIFF
--- a/central/billing/doctype/invoice/invoice.json
+++ b/central/billing/doctype/invoice/invoice.json
@@ -16,6 +16,7 @@
   "period_start",
   "period_end",
   "due_date",
+  "period_key",
   "section_break_items",
   "items",
   "section_break_totals",
@@ -96,6 +97,16 @@
    "fieldname": "due_date",
    "fieldtype": "Date",
    "label": "Due Date"
+  },
+  {
+   "fieldname": "period_key",
+   "fieldtype": "Data",
+   "label": "Period Key",
+   "unique": 1,
+   "read_only": 1,
+   "hidden": 1,
+   "no_copy": 1,
+   "description": "Uniqueness key for 'one live invoice per (team, period)' — the constraint that makes double-billing impossible rather than merely unlikely (ADR 0018, invariant I6). Set from (team, period_start, period_end) while the invoice is live; replaced by a per-invoice sentinel on cancellation so a reissue can take the slot. Derived — never set it by hand."
   },
   {
    "fieldname": "section_break_items",

--- a/central/billing/doctype/invoice/invoice.py
+++ b/central/billing/doctype/invoice/invoice.py
@@ -5,14 +5,39 @@
 Naming is INV-YYYY-MM-NNNNN keyed on the billing month (period_end). Line items
 are generated once and never updated; corrections are by state (cancel+reissue
 before payment; refund / wallet credit after), never by mutation.
+
+`period_key` enforces the invariant a billing system may not get wrong: **a team is
+billed at most once for a period** (ADR 0018, invariant I6). It is a derived column
+with a unique index, so a second bill for the same (team, period) is refused by the
+database rather than by whoever remembered to check first.
 """
 
 import frappe
 from frappe.model.document import Document
 from frappe.model.naming import make_autoname
 
+CANCELLED = "Cancelled"
+
 
 class Invoice(Document):
 	def autoname(self):
 		month = frappe.utils.getdate(self.period_end or frappe.utils.nowdate())
 		self.name = make_autoname(f"INV-{month.year:04d}-{month.month:02d}-.#####")
+
+	def validate(self):
+		self.set_period_key()
+
+	def set_period_key(self):
+		"""One live invoice per (team, period); cancelled ones step out of the way.
+
+		A cancelled invoice takes a per-invoice sentinel rather than NULL. Frappe
+		coerces an unset Data field to the empty string, and empty strings *collide*
+		in a unique index — so "null it on cancel" would let the first cancellation
+		through and reject the second. The sentinel is a total function: every invoice
+		always has a key, and only live ones compete for the period's slot, so a
+		cancel-and-reissue can reclaim it.
+		"""
+		if self.status == CANCELLED:
+			self.period_key = f"{CANCELLED}|{self.name}"
+		else:
+			self.period_key = f"{self.team}|{self.period_start}|{self.period_end}"

--- a/central/billing/revenue/invoicing/generate.py
+++ b/central/billing/revenue/invoicing/generate.py
@@ -4,13 +4,65 @@
 
 Per team/subscription, compute day-weighted fixed lines (from Subscription
 Change rate-snapshot segments) plus metered overage, apply the commitment
-adjustment, and create a `Draft`. Idempotent per (team/subscription, period).
+adjustment, and create a `Draft`. Idempotent per (team, period) — and idempotent
+*under concurrency*, which is a different and stronger claim (ADR 0018).
+
+The "does an invoice already exist?" read below is a fast path, not the guarantee.
+The guarantee is the unique index on `Invoice.period_key`: two workers that both
+read "no invoice" and both insert will see one succeed and the other take a
+DuplicateEntryError, which `_insert_invoice` translates back into "the other worker
+billed this period". Without it the read-then-insert is a time-of-check /
+time-of-use gap, and `generate_draft_invoices` enqueues one job *per team* — so a
+scheduler double-fire or a manual run overlapping the cron double-billed the team.
 """
 
 import frappe
 
 from central.billing.catalog import commitments
 from central.billing.revenue.invoicing.lines import compute_line_items
+
+
+def _live_invoice(team: str, period_start, period_end) -> str | None:
+	"""The team's existing live (non-cancelled) invoice for the period, if any."""
+	return frappe.db.get_value(
+		"Invoice",
+		{
+			"team": team,
+			"period_start": period_start,
+			"period_end": period_end,
+			"status": ["!=", "Cancelled"],
+		},
+		"name",
+	)
+
+
+# Frappe surfaces a unique-key conflict two ways: UniqueValidationError from its own
+# pre-insert check, and DuplicateEntryError when the write reaches the database first.
+# Under real concurrency both occur, so both mean the same thing here.
+_ALREADY_BILLED = (frappe.UniqueValidationError, frappe.DuplicateEntryError)
+
+
+def _insert_invoice(payload: dict) -> str:
+	"""Insert the draft, or yield to the worker that got there first.
+
+	A unique-key conflict here is not an error — it is the index doing its job. Another
+	worker billed this (team, period) between our check and our insert; its invoice is
+	the invoice, and we return it rather than billing the team a second time.
+	"""
+	try:
+		return frappe.get_doc(payload).insert(ignore_permissions=True).name
+	except _ALREADY_BILLED:
+		frappe.db.rollback()
+		existing = _live_invoice(
+			payload["team"], payload["period_start"], payload["period_end"]
+		)
+		if not existing:
+			raise  # a conflict on some other unique key — don't swallow it
+		frappe.logger("billing").info(
+			f"({payload['team']}, {payload['period_start']}) was billed concurrently as "
+			f"{existing} — yielding to it"
+		)
+		return existing
 
 
 def reconcile_subscription(subscription_doc):
@@ -33,16 +85,10 @@ def generate_draft_invoice(subscription: str, period_start, period_end):
 	sub = frappe.get_doc("Subscription", subscription)
 	reconcile_subscription(sub)
 
-	existing = frappe.db.get_value(
-		"Invoice",
-		{
-			"subscription": subscription,
-			"period_start": period_start,
-			"period_end": period_end,
-			"status": ["!=", "Cancelled"],
-		},
-		"name",
-	)
+	# Keyed on the TEAM, not the subscription: a team gets one bill per period across
+	# every subscription and cluster it runs (the same grain generate_team_invoice
+	# bills at, and the grain the unique index enforces).
+	existing = _live_invoice(sub.team, period_start, period_end)
 	if existing:
 		return existing
 
@@ -72,7 +118,7 @@ def generate_draft_invoice(subscription: str, period_start, period_end):
 
 	# The single branch point: an entry-tier (free/trial) team's invoice is a
 	# cost_report — computed identically, but a true cost rather than a bill.
-	invoice = frappe.get_doc(
+	name = _insert_invoice(
 		{
 			"doctype": "Invoice",
 			"team": sub.team,
@@ -98,9 +144,9 @@ def generate_draft_invoice(subscription: str, period_start, period_end):
 			"expected_collection": expected,
 			"amount_paid": 0,
 		}
-	).insert(ignore_permissions=True)
+	)
 	commitments.mark_breached(commitment)
-	return invoice.name
+	return name
 
 
 def generate_team_invoice(team: str, period_start, period_end, subscription: str | None = None):
@@ -109,21 +155,15 @@ def generate_team_invoice(team: str, period_start, period_end, subscription: str
 	A team that runs instances in several regions should see a SINGLE monthly
 	invoice, not one per region — so this aggregates the day-weighted fixed lines
 	plus metered overage from all of the team's clusters into one Invoice.
-	Idempotent per (team, period): a second call returns the existing invoice.
+	Idempotent per (team, period) — including under concurrency, which the read below
+	cannot deliver on its own. `generate_draft_invoices` enqueues one job per team, so
+	two workers could both read "no invoice" and both insert; the unique index on
+	`period_key` is what stops the team being billed twice (ADR 0018).
 
 	`subscription` is the primary subscription (its default payment method funds
 	the auto-charge in open_and_collect); defaults to any of the team's subs.
 	"""
-	existing = frappe.db.get_value(
-		"Invoice",
-		{
-			"team": team,
-			"period_start": period_start,
-			"period_end": period_end,
-			"status": ["!=", "Cancelled"],
-		},
-		"name",
-	)
+	existing = _live_invoice(team, period_start, period_end)
 	if existing:
 		return existing
 
@@ -156,7 +196,7 @@ def generate_team_invoice(team: str, period_start, period_end, subscription: str
 	if subscription is None:
 		subscription = frappe.db.get_value("Subscription", {"team": team}, "name")
 
-	invoice = frappe.get_doc(
+	name = _insert_invoice(
 		{
 			"doctype": "Invoice",
 			"team": team,
@@ -182,9 +222,9 @@ def generate_team_invoice(team: str, period_start, period_end, subscription: str
 			"expected_collection": expected,
 			"amount_paid": 0,
 		}
-	).insert(ignore_permissions=True)
+	)
 	commitments.mark_breached(commitment)
-	return invoice.name
+	return name
 
 
 def generate_draft_invoices(period_start, period_end, enqueue: bool = False) -> list[str]:

--- a/central/billing/tests/test_billing.py
+++ b/central/billing/tests/test_billing.py
@@ -164,6 +164,76 @@ class TestDraftGeneration(BillingTestBase):
 		self.assertIsNone(name)
 
 
+class TestOneInvoicePerPeriod(BillingTestBase):
+	"""A team is billed at most once for a period — enforced, not merely intended.
+
+	`generate_team_invoice` read "does an invoice exist?" and then inserted, with no
+	lock and no constraint in between, while `generate_draft_invoices` enqueues one job
+	per team. Two workers could both read "no" and both insert. The unique index on
+	`Invoice.period_key` is what makes the double bill impossible (ADR 0018, I6).
+	"""
+
+	def test_concurrent_generation_bills_the_team_exactly_once(self):
+		add_segment(self.sub, "Created", 1000, "2026-06-01 00:00:00")
+		frappe.db.commit()  # make the segment visible to the worker connections
+
+		results = run_workers(
+			6,
+			lambda i: invoicing.generate_team_invoice(TEAM, "2026-06-01", "2026-06-30"),
+		)
+		frappe.db.rollback()  # refresh this connection's snapshot
+
+		# Every worker returns the SAME invoice: the losers of the race yield to the
+		# winner instead of raising, so a concurrent caller is indistinguishable from a
+		# sequential one. Without the unique index all six inserted their own.
+		self.assertEqual(len(set(results.values())), 1, results)
+
+		live = frappe.get_all(
+			"Invoice",
+			filters={"team": TEAM, "period_start": "2026-06-01", "status": ["!=", "Cancelled"]},
+			pluck="name",
+		)
+		self.assertEqual(len(live), 1, f"team billed {len(live)}x for one period: {live}")
+		self.assertEqual(live, list(set(results.values())))
+
+	def test_cancel_and_reissue_reclaims_the_period_slot(self):
+		add_segment(self.sub, "Created", 1000, "2026-06-01 00:00:00")
+		first = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
+
+		second = invoicing.reissue_invoice(first, reason="wrong rate")
+
+		self.assertIsNotNone(second)
+		self.assertNotEqual(first, second)
+		self.assertEqual(frappe.db.get_value("Invoice", first, "status"), "Cancelled")
+		# The cancelled invoice stepped out of the index so the reissue could take
+		# the period's slot — but only one invoice is live for it.
+		live = frappe.get_all(
+			"Invoice",
+			filters={"team": TEAM, "period_start": "2026-06-01", "status": ["!=", "Cancelled"]},
+			pluck="name",
+		)
+		self.assertEqual(live, [second])
+
+	def test_several_cancelled_invoices_coexist_for_one_period(self):
+		"""Cancelling twice must not trip the unique index.
+
+		The cancelled key is a per-invoice sentinel rather than NULL: Frappe coerces an
+		unset Data field to the empty string, and empty strings COLLIDE in a unique
+		index — so "null it on cancel" would have let the first cancellation through
+		and rejected the second.
+		"""
+		add_segment(self.sub, "Created", 1000, "2026-06-01 00:00:00")
+		first = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
+		second = invoicing.reissue_invoice(first, reason="one")
+		third = invoicing.reissue_invoice(second, reason="two")
+
+		self.assertEqual(len({first, second, third}), 3)
+		cancelled = frappe.get_all(
+			"Invoice", filters={"team": TEAM, "status": "Cancelled"}, pluck="name"
+		)
+		self.assertCountEqual(cancelled, [first, second])
+
+
 class TestOpenAndCollect(BillingTestBase):
 	def _draft(self):
 		add_segment(self.sub, "Created", 1000, "2026-06-01 00:00:00")

--- a/central/billing/tests/test_trials.py
+++ b/central/billing/tests/test_trials.py
@@ -104,11 +104,18 @@ class TestConversion(TrialTestBase):
 class TestSubsidyAndExpiry(TrialTestBase):
 	def test_subsidy_total_sums_cost_report_invoices(self):
 		# subsidy_total is dormant now (nothing emits Cost Reports), but it still sums
-		# any that exist. Build two by hand in a far-future period — isolated from
-		# seeded demo data — and check the aggregate.
-		for subtotal in (1000.0, 2000.0):
+		# any that exist — across teams. Build two by hand in a far-future period,
+		# isolated from seeded demo data, and check the aggregate.
+		#
+		# One invoice per TEAM, not two for the same one: a team may hold at most one
+		# live invoice per period (ADR 0018, invariant I6), and the unique index on
+		# period_key now enforces it. subsidy_total aggregates across teams anyway, so
+		# two teams is what this test always meant.
+		for i, subtotal in enumerate((1000.0, 2000.0)):
+			team = f"{TEAM}-subsidy-{i}"
+			ensure_team(team)
 			frappe.get_doc({
-				"doctype": "Invoice", "team": TEAM, "invoice_type": "Cost Report",
+				"doctype": "Invoice", "team": team, "invoice_type": "Cost Report",
 				"status": "Open", "period_start": "2099-01-01", "period_end": "2099-01-31",
 				"currency": "INR", "subtotal": subtotal, "total": subtotal,
 			}).insert(ignore_permissions=True)

--- a/central/patches.txt
+++ b/central/patches.txt
@@ -104,6 +104,12 @@ central.patches.v0_0.cancel_terminated_subscriptions
 # be driven negative in one of them. The composite key makes "never negative" true per
 # currency; the CHECK makes it true for callers that never reach credits.py — ADR 0018.
 central.patches.v0_0.rekey_wallet_per_currency
+# Backfill Invoice.period_key, the unique key behind "one live invoice per (team,
+# period)". generate_team_invoice read-then-inserted with no lock and no constraint,
+# while generate_draft_invoices enqueues one job per team — so a scheduler double-fire
+# billed the team twice. Pre-existing duplicates are flagged for review, never
+# auto-cancelled (a paid duplicate is real money) — ADR 0018, invariant I6.
+central.patches.v0_0.backfill_period_key
 central.patches.v0_0.rename_capabilities
 central.patches.v0_0.make_central_users_portal_only
 # Strip the capability catalog to v3: drop the bench plane (site:* + server:config)

--- a/central/patches/v0_0/backfill_period_key.py
+++ b/central/patches/v0_0/backfill_period_key.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Backfill `Invoice.period_key` — one live invoice per (team, period) (ADR 0018, I6).
+
+`generate_team_invoice` checked for an existing invoice with `db.get_value` and then
+inserted, with no lock and no constraint between the two. `generate_draft_invoices`
+enqueues one job *per team*, so a scheduler double-fire or a manual run overlapping the
+cron gave two workers that both read "no invoice" and both inserted. The team was billed
+twice. A unique index closes the gap; this patch fills the column it indexes.
+
+**Existing duplicates are NOT auto-cancelled.** A duplicate that was already *paid* is
+real money, and deciding what to do about it is a human's call, not a patch's. Instead
+the canonical invoice for each (team, period) keeps the period_key and the extras get
+the cancelled-style sentinel — which lets the unique index be created without silently
+destroying evidence — plus a comment naming them for triage. The invariant audit will
+keep surfacing them until someone decides.
+"""
+
+import frappe
+
+from central.billing.doctype.invoice.invoice import CANCELLED
+
+# Which invoice wins the period slot when duplicates exist: the one furthest through
+# the money lifecycle. A Paid invoice always outranks a Draft — never orphan the one
+# the customer actually paid.
+_RANK = {"Paid": 5, "Overdue": 4, "Open": 3, "Draft": 2, "Waived": 1}
+
+
+def execute():
+	invoices = frappe.get_all(
+		"Invoice",
+		fields=["name", "team", "period_start", "period_end", "status", "creation"],
+		order_by="creation asc",
+	)
+
+	groups: dict[tuple, list] = {}
+	for inv in invoices:
+		if inv.status == CANCELLED:
+			_set_key(inv.name, f"{CANCELLED}|{inv.name}")
+			continue
+		groups.setdefault((inv.team, str(inv.period_start), str(inv.period_end)), []).append(inv)
+
+	for key, rows in groups.items():
+		winner = max(rows, key=lambda r: (_RANK.get(r.status, 0), -_seconds(r.creation)))
+		_set_key(winner.name, "|".join(key))
+
+		for loser in rows:
+			if loser.name == winner.name:
+				continue
+			# Not cancelled — only stepped out of the unique index, so the row survives
+			# for a human to look at. Its status is untouched.
+			_set_key(loser.name, f"{CANCELLED}|{loser.name}")
+			frappe.get_doc("Invoice", loser.name).add_comment(
+				"Comment",
+				frappe._(
+					"Duplicate bill for {0} {1}–{2}: this team was invoiced more than once "
+					"for the period (the pre-ADR-0018 read-then-insert race). {3} is the "
+					"invoice of record. This one is left as-is — status unchanged — for "
+					"review; if it was paid, it needs a refund, not a cancellation."
+				).format(loser.team, loser.period_start, loser.period_end, winner.name),
+			)
+			frappe.logger("billing").warning(
+				f"duplicate invoice {loser.name} for ({loser.team}, {loser.period_start}); "
+				f"invoice of record is {winner.name}"
+			)
+
+
+def _seconds(creation) -> float:
+	return frappe.utils.get_datetime(creation).timestamp()
+
+
+def _set_key(invoice: str, key: str):
+	frappe.db.set_value("Invoice", invoice, "period_key", key, update_modified=False)


### PR DESCRIPTION
Generate_team_invoice read "does an invoice exist for this (team, period)?" with db.get_value and then inserted — no lock, no constraint between the two. generate_draft_invoices enqueues one job PER TEAM, so a scheduler double-fire or a manual run overlapping the cron gave two workers that both read "no" and both inserted. The team was billed twice. The docstring claimed "idempotent per (team, period)"; it was idempotent only against sequential callers.

The race is real, not theoretical: the new concurrency test fires six workers at one (team, period) and, before the constraint, six invoices were created. With it, five take a unique-key conflict and all six return the SAME invoice — a concurrent caller is now indistinguishable from a sequential one.

Invoice gains a derived `period_key` (unique index):

  live       {team}|{period_start}|{period_end}
  cancelled  Cancelled|{name}

The cancelled form is a per-invoice sentinel rather than NULL, deliberately. Frappe coerces an unset Data field to the empty string, and empty strings COLLIDE in a unique index — "null it on cancel" would have let the first cancellation through and rejected the second. The sentinel is a total function: every invoice always has a key, only live ones compete for the period's slot, so cancel-and-reissue still reclaims it.

generate_draft_invoice is re-keyed off the TEAM rather than the subscription: a team gets one bill per period across every subscription and cluster it runs, which is the grain generate_team_invoice already billed at and the grain the index enforces.

The v28 patch backfills period_key and does NOT auto-cancel pre-existing duplicates: a duplicate that was already paid is real money, and what to do about it is a human's call, not a patch's. The extras step out of the index, keep their status, and get a comment naming the invoice of record.

test_billing 16 -> 19 (3 new, green). test_trials fixed: it hand-built two live invoices for one team+period, which is exactly the double-bill now forbidden — subsidy_total aggregates across teams, so two teams is what it always meant. Every other module matches its pre-change baseline.