### PR TITLE
feat: Billing invariant audit

### DIFF
--- a/central/billing/platform/invariants.py
+++ b/central/billing/platform/invariants.py
@@ -1,0 +1,435 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Rung 4 of the enforcement ladder — the invariants no constraint can hold (ADR 0018).
+
+An invariant belongs here ONLY if it cannot be pushed lower. `balance >= 0` is a
+`CHECK` constraint (rung 1) and has no business being audited. But
+`wallet.balance == Σ(ledger)` spans two tables, and no `CHECK` can see both — so it is
+audited, and audit is the *weakest* rung: it detects, it does not prevent.
+
+Every check answers one question with a second, independent derivation of a number the
+system already believes. Where the two disagree, money has drifted. That is a defect
+with a team and an amount attached, not a metric.
+
+`observability.md` §6 asked for these as counters. A counter has no teeth, which is
+why it was specified and never built. These return violations — rows a human reads,
+surfaced by the **Billing Invariant Violations** report and a daily job that only
+speaks up when something is wrong.
+
+**Adding a check:** write a function returning `list[Violation]`, register it in
+`CHECKS`. Aggregate in SQL; never loop a query per row — this runs over the whole
+ledger.
+"""
+
+from dataclasses import asdict, dataclass
+
+import frappe
+from frappe.query_builder import Case
+from frappe.query_builder.functions import Count, Sum
+
+# Money is float `Currency` in major units, so an exact `==` is a bug. Anything at or
+# under a minor unit is rounding, not drift; anything above it is real.
+TOLERANCE = 0.01
+
+# Payment Attempts are pruned on a rolling window (charges.cleanup_payment_logs), so an
+# invoice older than the window has no attempts to reconcile against and would report a
+# false violation. Audits that read attempts stay inside the window.
+from central.billing.payments.charges import LOG_RETENTION_DEFAULT_DAYS
+
+STUCK_ATTEMPT_MINUTES = 30
+
+# Attempt statuses that mean money actually moved. `Refunded` belongs here: it is a
+# CAPTURED attempt that was later reversed, and the reversal does not un-pay the
+# invoice (refunds go to source or to the wallet; the invoice stays Paid).
+TOOK_MONEY = ("Captured", "Refunded")
+
+# Non-terminal: the gateway's answer is not yet known. Anything here past the threshold
+# is a question the system has failed to answer (ADR 0017).
+IN_FLIGHT = ("Initiated", "Authorised")
+
+
+@dataclass
+class Violation:
+	check: str
+	detail: str
+	team: str | None = None
+	currency: str | None = None
+	subject_doctype: str | None = None
+	subject: str | None = None
+	expected: float | None = None
+	actual: float | None = None
+
+	@property
+	def drift(self) -> float:
+		if self.expected is None or self.actual is None:
+			return 0.0
+		return frappe.utils.flt(self.actual - self.expected, 2)
+
+
+def _differs(a, b) -> bool:
+	return abs(frappe.utils.flt(a) - frappe.utils.flt(b)) > TOLERANCE
+
+
+def _attempt_cutoff():
+	days = int(frappe.conf.get("payment_log_retention_days") or LOG_RETENTION_DEFAULT_DAYS)
+	return frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-days)
+
+
+# --- C2: the wallet anchor agrees with the ledger ----------------------------
+
+
+def check_wallet_matches_ledger() -> list[Violation]:
+	"""`Credit Wallet.balance` == Σ signed `Credit Ledger Entry`, per (team, currency).
+
+	The canary for the anchor/ledger split. The anchor is the authoritative balance
+	(maintained under its row lock) and the ledger is the audit trail; if they part
+	company, one of them is lying about a customer's money.
+	"""
+	cle = frappe.qb.DocType("Credit Ledger Entry")
+	signed = Case().when(cle.entry_type == "Credit", cle.amount).else_(-cle.amount)
+	ledger = {
+		(r.team, r.currency): frappe.utils.flt(r.balance)
+		for r in frappe.qb.from_(cle)
+		.select(cle.team, cle.currency, Sum(signed).as_("balance"))
+		.groupby(cle.team, cle.currency)
+		.run(as_dict=True)
+	}
+
+	violations = []
+	seen = set()
+	for w in frappe.get_all(
+		"Credit Wallet", fields=["name", "team", "currency", "balance"]
+	):
+		key = (w.team, w.currency)
+		seen.add(key)
+		expected = ledger.get(key, 0.0)
+		if _differs(w.balance, expected):
+			violations.append(
+				Violation(
+					check="C2",
+					team=w.team,
+					currency=w.currency,
+					subject_doctype="Credit Wallet",
+					subject=w.name,
+					expected=expected,
+					actual=frappe.utils.flt(w.balance),
+					detail="Wallet balance does not equal the signed sum of its ledger.",
+				)
+			)
+
+	# Ledger entries with no anchor at all: the balance is unreachable by the booking
+	# path, so the customer's credits are invisible to settlement.
+	for key, balance in ledger.items():
+		if key not in seen and abs(balance) > TOLERANCE:
+			team, currency = key
+			violations.append(
+				Violation(
+					check="C2",
+					team=team,
+					currency=currency,
+					subject_doctype="Credit Ledger Entry",
+					expected=balance,
+					actual=0.0,
+					detail="Ledger entries exist for this currency with no Credit Wallet anchor.",
+				)
+			)
+	return violations
+
+
+# --- C4: the running_balance chain is unbroken -------------------------------
+
+
+def check_running_balance_chain() -> list[Violation]:
+	"""Each entry's `running_balance` == the previous one ± its own signed amount.
+
+	This is what makes the ledger *self-verifying*: a deleted, reordered or tampered
+	entry breaks the chain even if the final balance happens to add up. Reports only
+	the FIRST break per (team, currency) — everything after it is the same defect.
+	"""
+	entries = frappe.get_all(
+		"Credit Ledger Entry",
+		fields=["name", "team", "currency", "entry_type", "amount", "running_balance"],
+		order_by="team asc, currency asc, creation asc, name asc",
+	)
+
+	violations = []
+	running: dict[tuple, float] = {}
+	broken: set[tuple] = set()
+	for e in entries:
+		key = (e.team, e.currency)
+		if key in broken:
+			continue
+		delta = frappe.utils.flt(e.amount) * (1 if e.entry_type == "Credit" else -1)
+		running[key] = running.get(key, 0.0) + delta
+		if _differs(e.running_balance, running[key]):
+			broken.add(key)
+			violations.append(
+				Violation(
+					check="C4",
+					team=e.team,
+					currency=e.currency,
+					subject_doctype="Credit Ledger Entry",
+					subject=e.name,
+					expected=running[key],
+					actual=frappe.utils.flt(e.running_balance),
+					detail="running_balance chain breaks here — an entry is missing, "
+					"reordered or altered.",
+				)
+			)
+	return violations
+
+
+# --- I1: the line items add up to the subtotal -------------------------------
+
+
+def check_invoice_line_sum() -> list[Violation]:
+	"""Σ(line items) == `Invoice.subtotal`. Should be impossible; >0 is an assembly bug."""
+	item = frappe.qb.DocType("Invoice Line Item")
+	lines = {
+		r.parent: frappe.utils.flt(r.total)
+		for r in frappe.qb.from_(item)
+		.select(item.parent, Sum(item.amount).as_("total"))
+		.groupby(item.parent)
+		.run(as_dict=True)
+	}
+
+	violations = []
+	for inv in frappe.get_all(
+		"Invoice",
+		filters={"status": ["!=", "Cancelled"]},
+		fields=["name", "team", "currency", "subtotal"],
+	):
+		expected = lines.get(inv.name, 0.0)
+		if _differs(inv.subtotal, expected):
+			violations.append(
+				Violation(
+					check="I1",
+					team=inv.team,
+					currency=inv.currency,
+					subject_doctype="Invoice",
+					subject=inv.name,
+					expected=expected,
+					actual=frappe.utils.flt(inv.subtotal),
+					detail="Invoice subtotal does not equal the sum of its line items.",
+				)
+			)
+	return violations
+
+
+# --- I5: a Paid invoice is actually covered ----------------------------------
+
+
+def check_paid_invoice_is_covered() -> list[Violation]:
+	"""A `Paid` invoice was covered: `amount_paid` + `credit_applied` >= `total` − TDS.
+
+	Covers both settlement routes: the card path stamps `amount_paid`, the
+	credits-cover-it-in-full path leaves it at zero and stamps `credit_applied`. An
+	invoice marked Paid that neither covers is revenue we believe we collected and
+	did not.
+	"""
+	violations = []
+	for inv in frappe.get_all(
+		"Invoice",
+		filters={"status": "Paid", "invoice_type": ["!=", "Cost Report"]},
+		fields=["name", "team", "currency", "total", "tds_amount", "amount_paid",
+				"credit_applied"],
+	):
+		owed = frappe.utils.flt(inv.total) - frappe.utils.flt(inv.tds_amount)
+		settled = frappe.utils.flt(inv.amount_paid) + frappe.utils.flt(inv.credit_applied)
+		if settled + TOLERANCE < owed:
+			violations.append(
+				Violation(
+					check="I5",
+					team=inv.team,
+					currency=inv.currency,
+					subject_doctype="Invoice",
+					subject=inv.name,
+					expected=owed,
+					actual=settled,
+					detail="Invoice is Paid but card + credits do not cover what was owed.",
+				)
+			)
+	return violations
+
+
+# --- I6: one live invoice per (team, period) ---------------------------------
+
+
+def check_one_live_invoice_per_period() -> list[Violation]:
+	"""A team is billed at most once for a period.
+
+	The unique index on `period_key` makes this impossible going forward; the audit
+	is what surfaces the duplicates that predate it (the v28 patch flags them rather
+	than cancelling them, because a *paid* duplicate is real money and needs a human).
+	"""
+	inv = frappe.qb.DocType("Invoice")
+	rows = (
+		frappe.qb.from_(inv)
+		.select(inv.team, inv.period_start, inv.period_end, Count("*").as_("bills"))
+		.where(inv.status != "Cancelled")
+		.groupby(inv.team, inv.period_start, inv.period_end)
+		.having(Count("*") > 1)
+		.run(as_dict=True)
+	)
+	return [
+		Violation(
+			check="I6",
+			team=r.team,
+			subject_doctype="Invoice",
+			expected=1,
+			actual=r.bills,
+			detail=f"Team billed {r.bills}x for {r.period_start} – {r.period_end}. "
+			"If any duplicate was paid it needs a refund, not a cancellation.",
+		)
+		for r in rows
+	]
+
+
+# --- P2: captured payments equal what the invoice says was paid --------------
+
+
+def check_captured_matches_amount_paid() -> list[Violation]:
+	"""`Invoice.amount_paid` <= Σ(attempts that took money). Never more than was captured.
+
+	This is an **inequality, and deliberately so.** Equality is not assertable today,
+	because `amount_paid` has no defined meaning after a refund. Both of these are real,
+	from live data:
+
+	  - a fully-refunded invoice stays `Paid` with `amount_paid` intact (a dispute
+	    refunds to source; the invoice is not un-billed) — so subtracting refunds from
+	    the captured sum would flag a perfectly healthy invoice;
+	  - a charge → refund → re-charge history has TWO money-taking attempts for one
+	    invoice — so requiring the sum to *equal* `amount_paid` would flag that one.
+
+	Any equality would therefore cry wolf on real histories, and a check that cries wolf
+	is worse than no check (see `observability.md` §6, which specified equalities and was
+	never built). What IS sound: we cannot have paid out more than the gateway ever took
+	in. That catches the defect worth catching — an invoice marked `Paid` with nothing
+	behind it — and stays silent on legitimate refund histories.
+
+	Pinning `amount_paid`'s post-refund semantics is an open design question; when it is
+	settled this check can be tightened to an equality.
+
+	Scoped to the retention window because `cleanup_payment_logs` prunes terminal
+	attempts after ~90 days — outside it there is nothing left to reconcile against.
+	"""
+	cutoff = _attempt_cutoff()
+	pa = frappe.qb.DocType("Payment Attempt")
+	captured = {
+		r.invoice: frappe.utils.flt(r.total)
+		for r in frappe.qb.from_(pa)
+		.select(pa.invoice, Sum(pa.amount).as_("total"))
+		.where(pa.status.isin(TOOK_MONEY) & pa.invoice.notnull())
+		.groupby(pa.invoice)
+		.run(as_dict=True)
+	}
+
+	violations = []
+	for inv in frappe.get_all(
+		"Invoice",
+		filters={"status": "Paid", "creation": [">=", cutoff]},
+		fields=["name", "team", "currency", "amount_paid"],
+	):
+		took = captured.get(inv.name, 0.0)
+		if frappe.utils.flt(inv.amount_paid) > took + TOLERANCE:
+			violations.append(
+				Violation(
+					check="P2",
+					team=inv.team,
+					currency=inv.currency,
+					subject_doctype="Invoice",
+					subject=inv.name,
+					expected=took,
+					actual=frappe.utils.flt(inv.amount_paid),
+					detail="Invoice is Paid for more than the gateway ever captured — "
+					"revenue we believe we collected with no payment behind it.",
+				)
+			)
+	return violations
+
+
+# --- P4: no intent is left non-terminal --------------------------------------
+
+
+def check_no_stuck_attempts() -> list[Violation]:
+	"""No Payment Attempt sits non-terminal past the threshold.
+
+	An `Initiated` attempt is a charge whose outcome we do not know. Not knowing is a
+	defect, not a resting state ([ADR 0017]): reconciliation must drive every one of
+	them to terminal by asking the gateway. One that is still sitting here is one the
+	sweeper has not answered — and possibly money taken with no settled record.
+	"""
+	stale = frappe.utils.add_to_date(
+		frappe.utils.now_datetime(), minutes=-STUCK_ATTEMPT_MINUTES
+	)
+	return [
+		Violation(
+			check="P4",
+			team=a.team,
+			currency=a.currency,
+			subject_doctype="Payment Attempt",
+			subject=a.name,
+			actual=frappe.utils.flt(a.amount),
+			detail=f"Attempt still '{a.status}' after {STUCK_ATTEMPT_MINUTES} minutes — "
+			"its outcome at the gateway is unknown and unreconciled.",
+		)
+		for a in frappe.get_all(
+			"Payment Attempt",
+			filters={"status": ["in", IN_FLIGHT], "initiated_at": ["<", stale]},
+			fields=["name", "team", "currency", "amount", "status"],
+		)
+	]
+
+
+CHECKS = {
+	"C2": ("Wallet balance equals its ledger", check_wallet_matches_ledger),
+	"C4": ("Ledger running_balance chain is unbroken", check_running_balance_chain),
+	"I1": ("Invoice subtotal equals its line items", check_invoice_line_sum),
+	"I5": ("Paid invoice is covered by card + credits", check_paid_invoice_is_covered),
+	"I6": ("One live invoice per team per period", check_one_live_invoice_per_period),
+	"P2": ("Paid invoice never exceeds what was captured", check_captured_matches_amount_paid),
+	"P4": ("No payment attempt left non-terminal", check_no_stuck_attempts),
+}
+
+
+def audit(only: str | None = None) -> list[Violation]:
+	"""Run every registered check (or one) and return the violations, worst drift first."""
+	keys = [only] if only else list(CHECKS)
+	found: list[Violation] = []
+	for key in keys:
+		_title, fn = CHECKS[key]
+		try:
+			found.extend(fn())
+		except Exception:
+			# One broken check must not blind the other six.
+			frappe.log_error(
+				title=f"Billing invariant check {key} failed",
+				message=frappe.get_traceback(),
+			)
+	found.sort(key=lambda v: abs(v.drift), reverse=True)
+	return found
+
+
+def run_invariant_audit() -> dict:
+	"""Daily: assert the money invariants and speak up only when one is broken.
+
+	Silence is the success case. A violation is logged with its team and amount so it
+	is actionable without opening a dashboard.
+	"""
+	violations = audit()
+	if not violations:
+		frappe.logger("billing").info("invariant audit clean")
+		return {"violations": 0, "by_check": {}}
+
+	by_check: dict[str, int] = {}
+	for v in violations:
+		by_check[v.check] = by_check.get(v.check, 0) + 1
+		frappe.logger("billing").error(
+			f"INVARIANT {v.check} violated — team={v.team} {v.subject_doctype}={v.subject} "
+			f"expected={v.expected} actual={v.actual}: {v.detail}"
+		)
+	frappe.log_error(
+		title=f"Billing invariant audit: {len(violations)} violation(s)",
+		message=frappe.as_json([asdict(v) for v in violations[:50]], indent=2),
+	)
+	return {"violations": len(violations), "by_check": by_check}

--- a/central/billing/report/billing_invariant_violations/billing_invariant_violations.js
+++ b/central/billing/report/billing_invariant_violations/billing_invariant_violations.js
@@ -1,0 +1,28 @@
+// Copyright (c) 2026, Frappe and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["Billing Invariant Violations"] = {
+	filters: [
+		{
+			fieldname: "check",
+			label: __("Invariant"),
+			fieldtype: "Select",
+			options: [
+				{ value: "", label: __("All") },
+				{ value: "C2", label: __("C2 — Wallet balance equals its ledger") },
+				{ value: "C4", label: __("C4 — Ledger running_balance chain is unbroken") },
+				{ value: "I1", label: __("I1 — Invoice subtotal equals its line items") },
+				{ value: "I5", label: __("I5 — Paid invoice is covered by card + credits") },
+				{ value: "I6", label: __("I6 — One live invoice per team per period") },
+				{ value: "P2", label: __("P2 — Captured payments equal invoice amount_paid") },
+				{ value: "P4", label: __("P4 — No payment attempt left non-terminal") },
+			],
+		},
+		{
+			fieldname: "team",
+			label: __("Team"),
+			fieldtype: "Link",
+			options: "Team",
+		},
+	],
+};

--- a/central/billing/report/billing_invariant_violations/billing_invariant_violations.json
+++ b/central/billing/report/billing_invariant_violations/billing_invariant_violations.json
@@ -1,0 +1,26 @@
+{
+ "add_total_row": 0,
+ "columns": [],
+ "creation": "2026-07-13 00:00:00.000000",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letterhead": null,
+ "modified": "2026-07-13 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Billing",
+ "name": "Billing Invariant Violations",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Invoice",
+ "report_name": "Billing Invariant Violations",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "System Manager"
+  }
+ ]
+}

--- a/central/billing/report/billing_invariant_violations/billing_invariant_violations.py
+++ b/central/billing/report/billing_invariant_violations/billing_invariant_violations.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Billing Invariant Violations — the money facts that no longer add up.
+
+Every row is a place where two independent derivations of the same number disagree:
+a wallet whose balance is not its ledger, an invoice whose subtotal is not its lines,
+a payment we believe we captured with no attempt behind it.
+
+**An empty report is the success case.** This is the one report you want blank.
+
+It recomputes live from `platform.invariants` — the same function the daily audit
+runs, so what the job asserts and what a human reads can never drift apart. Nothing is
+stored, so there is no snapshot to go stale.
+
+Amounts are split per currency: INR and USD never share a column or a total
+(report/_currency.split_currency_columns).
+"""
+
+import frappe
+from frappe import _
+
+from central.billing.platform import invariants
+from central.billing.report._currency import split_currency_columns
+
+
+def execute(filters: dict | None = None):
+	filters = filters or {}
+	violations = invariants.audit(only=filters.get("check") or None)
+
+	if filters.get("team"):
+		violations = [v for v in violations if v.team == filters["team"]]
+
+	rows = [
+		{
+			"check": v.check,
+			"title": invariants.CHECKS[v.check][0],
+			"team": v.team,
+			"subject_doctype": v.subject_doctype,
+			"subject": v.subject,
+			"currency": v.currency,
+			"expected": v.expected,
+			"actual": v.actual,
+			"drift": v.drift,
+			"detail": v.detail,
+		}
+		for v in violations
+	]
+
+	# Splits expected/actual/drift into one column per currency when the run spans more
+	# than one, and drops the standalone currency column. Mutates `rows` in place.
+	columns = split_currency_columns(_columns(), rows, ("expected", "actual", "drift"))
+	return columns, rows, _message(rows), _chart(violations)
+
+
+def _message(rows: list[dict]) -> str:
+	if not rows:
+		return _("✅ Every money invariant holds. This report is meant to be empty.")
+	return _(
+		"⚠️ {0} violation(s). Each is a number the system derives two ways and gets two "
+		"answers for — money has drifted. Worst drift first."
+	).format(len(rows))
+
+
+def _chart(violations: list) -> dict | None:
+	if not violations:
+		return None
+	counts: dict[str, int] = {}
+	for v in violations:
+		counts[v.check] = counts.get(v.check, 0) + 1
+	labels = sorted(counts)
+	return {
+		"data": {
+			"labels": [f"{k} — {invariants.CHECKS[k][0]}" for k in labels],
+			"datasets": [{"name": _("Violations"), "values": [counts[k] for k in labels]}],
+		},
+		"type": "bar",
+	}
+
+
+def _columns() -> list[dict]:
+	return [
+		{"label": _("Check"), "fieldname": "check", "fieldtype": "Data", "width": 70},
+		{"label": _("Invariant"), "fieldname": "title", "fieldtype": "Data", "width": 240},
+		{"label": _("Team"), "fieldname": "team", "fieldtype": "Link", "options": "Team",
+		 "width": 150},
+		{"label": _("Subject"), "fieldname": "subject", "fieldtype": "Dynamic Link",
+		 "options": "subject_doctype", "width": 170},
+		{"label": _("Type"), "fieldname": "subject_doctype", "fieldtype": "Data", "width": 130},
+		# expected / actual / drift are expanded per currency by split_currency_columns,
+		# which drops this column when it does — INR and USD never share a total.
+		{"label": _("Currency"), "fieldname": "currency", "fieldtype": "Link",
+		 "options": "Currency", "width": 90},
+		{"label": _("Expected"), "fieldname": "expected", "fieldtype": "Currency", "width": 120},
+		{"label": _("Actual"), "fieldname": "actual", "fieldtype": "Currency", "width": 120},
+		{"label": _("Drift"), "fieldname": "drift", "fieldtype": "Currency", "width": 120},
+		{"label": _("What broke"), "fieldname": "detail", "fieldtype": "Data", "width": 420},
+	]

--- a/central/billing/tests/test_invariants.py
+++ b/central/billing/tests/test_invariants.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""The money invariants that span tables — rung 4 of ADR 0018.
+
+Each test breaks one invariant deliberately (by raw SQL, since every legitimate code
+path is now blocked from breaking it) and asserts the audit catches it. A check that
+cannot be made to fire is a check nobody should trust.
+"""
+
+import frappe
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+
+from central.billing.platform import invariants
+from central.billing.revenue import credits
+from central.billing.tests.utils import ensure_team
+
+TEAM = "team-invariants"
+
+
+class InvariantTestBase(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		self._purge()
+
+	def tearDown(self):
+		self._purge()
+		frappe.db.commit()
+
+	def _purge(self):
+		frappe.db.delete("Credit Ledger Entry", {"team": TEAM})
+		frappe.db.delete("Credit Wallet", {"team": TEAM})
+		frappe.db.commit()
+
+	def _mine(self, violations, check):
+		"""Only this team's violations — the site carries other teams' data."""
+		return [v for v in violations if v.team == TEAM and v.check == check]
+
+
+class TestWalletMatchesLedger(InvariantTestBase):
+	def test_a_healthy_wallet_reports_nothing(self):
+		credits.purchase(TEAM, 500, "INR")
+		credits.apply_credit(TEAM, 200, "INR", reference_name="INV-1")
+
+		self.assertEqual(self._mine(invariants.audit("C2"), "C2"), [])
+
+	def test_anchor_drifting_from_its_ledger_is_caught(self):
+		credits.purchase(TEAM, 500, "INR")
+		wallet = credits.wallet_name(TEAM, "INR")
+
+		# Raw SQL: every code path is now guarded, so drift can only be simulated by
+		# going around them — which is exactly the scenario the audit exists for.
+		frappe.db.sql(
+			"update `tabCredit Wallet` set balance = 430 where name = %s", (wallet,)
+		)
+
+		found = self._mine(invariants.audit("C2"), "C2")
+		self.assertEqual(len(found), 1)
+		self.assertEqual(found[0].expected, 500)  # what the ledger says
+		self.assertEqual(found[0].actual, 430)  # what the anchor claims
+		self.assertEqual(found[0].drift, -70)
+		self.assertEqual(found[0].currency, "INR")
+
+	def test_ledger_with_no_anchor_is_caught(self):
+		credits.purchase(TEAM, 300, "INR")
+		frappe.db.sql("delete from `tabCredit Wallet` where team = %s", (TEAM,))
+
+		found = self._mine(invariants.audit("C2"), "C2")
+		self.assertEqual(len(found), 1)
+		self.assertIn("no Credit Wallet anchor", found[0].detail)
+
+	def test_drift_is_reported_per_currency(self):
+		credits.purchase(TEAM, 500, "INR")
+		credits.purchase(TEAM, 80, "USD")
+		frappe.db.sql(
+			"update `tabCredit Wallet` set balance = 10 where name = %s",
+			(credits.wallet_name(TEAM, "USD"),),
+		)
+
+		found = self._mine(invariants.audit("C2"), "C2")
+		self.assertEqual([(v.currency, v.expected, v.actual) for v in found], [("USD", 80, 10)])
+
+
+class TestRunningBalanceChain(InvariantTestBase):
+	def test_an_intact_chain_reports_nothing(self):
+		credits.purchase(TEAM, 500, "INR")
+		credits.apply_credit(TEAM, 120, "INR", reference_name="INV-1")
+		credits.purchase(TEAM, 30, "INR")
+
+		self.assertEqual(self._mine(invariants.audit("C4"), "C4"), [])
+
+	def test_a_deleted_ledger_entry_breaks_the_chain(self):
+		credits.purchase(TEAM, 100, "INR")
+		second = credits.purchase(TEAM, 50, "INR")["ledger_entry"]
+		credits.purchase(TEAM, 25, "INR")
+
+		# Excise the middle entry. The final running_balance still *looks* plausible,
+		# which is precisely why the chain — not just the total — has to be checked.
+		frappe.db.sql("delete from `tabCredit Ledger Entry` where name = %s", (second,))
+
+		found = self._mine(invariants.audit("C4"), "C4")
+		self.assertEqual(len(found), 1)
+		self.assertIn("chain breaks here", found[0].detail)
+
+	def test_only_the_first_break_is_reported(self):
+		"""Everything after a break is the same defect, not N defects."""
+		credits.purchase(TEAM, 100, "INR")
+		second = credits.purchase(TEAM, 50, "INR")["ledger_entry"]
+		credits.purchase(TEAM, 25, "INR")
+		credits.purchase(TEAM, 25, "INR")
+		frappe.db.sql("delete from `tabCredit Ledger Entry` where name = %s", (second,))
+
+		self.assertEqual(len(self._mine(invariants.audit("C4"), "C4")), 1)
+
+
+class TestPaidNeverExceedsCaptured(InvariantTestBase):
+	"""P2 — an invoice may not be Paid for more than the gateway ever captured.
+
+	It is an INEQUALITY, and the two silent cases below are why. Both are real histories
+	taken from live data, and both would trip any equality:
+
+	  - a fully-refunded invoice keeps `amount_paid` and stays Paid (a dispute refunds to
+	    source; the invoice is not un-billed), so "captured minus refunds" flags it;
+	  - a charge → refund → re-charge leaves TWO money-taking attempts on one invoice, so
+	    "sum of captured equals amount_paid" flags that one.
+
+	Both were found by running this audit against real data, and both are guarded here so
+	the check can never be "tightened" back into crying wolf.
+	"""
+
+	def _paid_invoice(self, total, amount_paid, attempts):
+		inv = frappe.get_doc({
+			"doctype": "Invoice", "team": TEAM, "status": "Paid", "currency": "INR",
+			"period_start": "2098-03-01", "period_end": "2098-03-31",
+			"subtotal": total, "total": total, "amount_paid": amount_paid,
+		}).insert(ignore_permissions=True)
+		for amount, status in attempts:
+			frappe.get_doc({
+				"doctype": "Payment Attempt", "invoice": inv.name, "team": TEAM,
+				"amount": amount, "currency": "INR", "status": status,
+			}).insert(ignore_permissions=True)
+		return inv.name
+
+	def tearDown(self):
+		frappe.db.delete("Payment Attempt", {"team": TEAM})
+		frappe.db.delete("Invoice", {"team": TEAM})
+		super().tearDown()
+
+	def test_a_captured_attempt_covers_the_invoice(self):
+		self._paid_invoice(500, 500, [(500, "Captured")])
+		self.assertEqual(self._mine(invariants.audit("P2"), "P2"), [])
+
+	def test_a_fully_refunded_invoice_is_not_a_violation(self):
+		# Refunded to source; the invoice stays Paid by design. amount_paid is intact.
+		self._paid_invoice(500, 500, [(500, "Refunded")])
+		self.assertEqual(self._mine(invariants.audit("P2"), "P2"), [])
+
+	def test_charge_refund_recharge_is_not_a_violation(self):
+		# Two money-taking attempts for one invoice — legitimate history, not drift.
+		self._paid_invoice(500, 500, [(500, "Refunded"), (500, "Captured"), (500, "Failed")])
+		self.assertEqual(self._mine(invariants.audit("P2"), "P2"), [])
+
+	def test_paid_with_nothing_captured_behind_it_is_caught(self):
+		"""The defect worth catching: revenue we believe we collected and did not."""
+		self._paid_invoice(500, 500, [(500, "Failed")])
+
+		found = self._mine(invariants.audit("P2"), "P2")
+		self.assertEqual(len(found), 1)
+		self.assertEqual(found[0].expected, 0)  # nothing was ever captured
+		self.assertEqual(found[0].actual, 500)  # but the invoice claims it was paid
+
+	def test_paid_for_more_than_was_captured_is_caught(self):
+		self._paid_invoice(500, 500, [(200, "Captured")])
+
+		found = self._mine(invariants.audit("P2"), "P2")
+		self.assertEqual(len(found), 1)
+		self.assertEqual((found[0].expected, found[0].actual), (200, 500))
+
+
+class TestAuditRunner(InvariantTestBase):
+	def test_every_registered_check_runs_and_returns_a_list(self):
+		for key, (title, fn) in invariants.CHECKS.items():
+			with self.subTest(check=key):
+				self.assertTrue(title)
+				self.assertIsInstance(fn(), list)
+
+	def test_a_broken_check_does_not_blind_the_others(self):
+		"""One raising check must not take the audit down with it."""
+		credits.purchase(TEAM, 500, "INR")
+		frappe.db.sql(
+			"update `tabCredit Wallet` set balance = 1 where name = %s",
+			(credits.wallet_name(TEAM, "INR"),),
+		)
+
+		def explode():
+			raise RuntimeError("check is broken")
+
+		original = invariants.CHECKS["I1"]
+		invariants.CHECKS["I1"] = ("deliberately broken", explode)
+		try:
+			found = invariants.audit()
+		finally:
+			invariants.CHECKS["I1"] = original
+
+		# C2 still reported despite I1 blowing up.
+		self.assertEqual(len(self._mine(found, "C2")), 1)
+
+	def test_run_invariant_audit_summarises_by_check(self):
+		credits.purchase(TEAM, 500, "INR")
+		frappe.db.sql(
+			"update `tabCredit Wallet` set balance = 0 where name = %s",
+			(credits.wallet_name(TEAM, "INR"),),
+		)
+
+		result = invariants.run_invariant_audit()
+
+		self.assertGreaterEqual(result["violations"], 1)
+		self.assertGreaterEqual(result["by_check"].get("C2", 0), 1)

--- a/central/hooks.py
+++ b/central/hooks.py
@@ -194,6 +194,11 @@ scheduler_events = {
 		"central.billing.catalog.subscriptions.backfill_missing_subscriptions",
 		# Services (LLM): refresh the model catalog from the Grove backend.
 		"central.services.llm.sync_models",
+		# Assert the money invariants that no DB constraint can hold (they span
+		# tables): wallet == its ledger, invoice == its lines, captured == amount_paid.
+		# Silence is the success case; a violation is logged with its team and amount.
+		# Read it as the "Billing Invariant Violations" report.
+		"central.billing.platform.invariants.run_invariant_audit",
 	],
 	"hourly": [
 		# Billing: ERPNext sync retries whose backoff window has elapsed.


### PR DESCRIPTION
These return violations: rows with a team and an amount, surfaced by the Billing Invariant Violations report (recomputed live from the same function the daily job runs, so what the job asserts and what a human reads cannot drift apart). An empty report is the success case.

Running it against real data immediately paid for itself by finding two bugs IN THE AUDIT, which is why you never trust a check you haven't fired:

  1. P2 summed only `Captured` attempts, so a REFUNDED attempt vanished and every refunded invoice looked uncollected.
  2. Fixing that surfaced the deeper problem: `amount_paid` has no defined meaning after a refund. A fully-refunded invoice keeps amount_paid and stays Paid (a dispute refunds to source, it is not un-billed) — so "captured minus refunds" flags a healthy invoice. And a charge → refund → re-charge leaves TWO money-taking attempts on one invoice — so "sum of captured == amount_paid" flags that one. NO equality is sound today.

So P2 ships as an inequality — amount_paid <= Σ(money-taking attempts) — which catches the defect worth catching (Paid with nothing behind it) and stays silent on legitimate refund histories. Both real histories are pinned as tests so it can never be "tightened" back into crying wolf. Pinning amount_paid's post-refund semantics is an open design question; the check can tighten once it is settled.

On real demo data (46 invoices, 69 attempts) the audit is now quiet except for one genuine finding: a Payment Attempt Initiated for 8 days, $92.14, its gateway outcome unknown and unreconciled — exactly the ADR 0017 orphan class.

15 new tests, green. Every other module matches its pre-change baseline.