### PR TITLE
fix: audit authz

### DIFF
--- a/central/billing/api/admin/__init__.py
+++ b/central/billing/api/admin/__init__.py
@@ -32,6 +32,7 @@ from central.billing.api.admin.revenue import (
 	list_all_invoices,
 )
 from central.billing.api.admin.teams import (
+	adjust_team_credits,
 	get_delinquent_teams,
 	get_metrics,
 	get_payment_failures,
@@ -44,7 +45,7 @@ __all__ = [
 	"get_summary", "get_revenue_trend", "get_cluster_breakdown", "get_team_breakdown",
 	"get_payment_analytics", "get_overdue_aging", "get_free_trial_costs", "list_all_invoices",
 	"get_team_billing", "get_retention", "get_metrics", "list_teams", "get_payment_failures",
-	"get_delinquent_teams",
+	"get_delinquent_teams", "adjust_team_credits",
 	"get_catalog", "update_plan_rate", "get_cluster_consumption", "get_plan_consumption",
 	"get_conversion", "get_trial_detail", "get_trial_costs_detail",
 ]

--- a/central/billing/api/admin/__init__.py
+++ b/central/billing/api/admin/__init__.py
@@ -13,6 +13,7 @@ package re-exports the public API so every `billing.api.admin.*` path holds.
 """
 
 from central.billing.api.admin.catalog import (
+	create_configured_plan,
 	get_catalog,
 	get_cluster_consumption,
 	get_conversion,
@@ -46,6 +47,6 @@ __all__ = [
 	"get_payment_analytics", "get_overdue_aging", "get_free_trial_costs", "list_all_invoices",
 	"get_team_billing", "get_retention", "get_metrics", "list_teams", "get_payment_failures",
 	"get_delinquent_teams", "adjust_team_credits",
-	"get_catalog", "update_plan_rate", "get_cluster_consumption", "get_plan_consumption",
+	"get_catalog", "update_plan_rate", "create_configured_plan", "get_cluster_consumption", "get_plan_consumption",
 	"get_conversion", "get_trial_detail", "get_trial_costs_detail",
 ]

--- a/central/billing/api/admin/catalog.py
+++ b/central/billing/api/admin/catalog.py
@@ -40,6 +40,21 @@ def get_catalog() -> dict:
 	return {"plans": plans, "clusters": cluster_rows}
 
 
+@frappe.whitelist(methods=["POST"])
+def create_configured_plan(title: str, vcpu: float, ratio: str = "1:2", disk_gb: float = 0,
+						   memory_gb: float | None = None, billing_cycle: str = "Monthly",
+						   category: str = "VM Plans", sub_category: str | None = None) -> dict:
+	"""Author a bundle Plan from configurator inputs — operator only. The one HTTP
+	door to `plans.create_configured_plan`; the primitive itself is not whitelisted."""
+	require_operator()
+	from central.billing.catalog import plans
+
+	name = plans.create_configured_plan(
+		title, vcpu, ratio=ratio, disk_gb=disk_gb, memory_gb=memory_gb,
+		billing_cycle=billing_cycle, category=category, sub_category=sub_category)
+	return {"plan": name}
+
+
 @frappe.whitelist()
 def update_plan_rate(plan: str, currency: str, rate: int, cluster: str = "") -> dict:
 	"""Price management: change a plan's Catalog Rate. Existing price-locks are

--- a/central/billing/api/admin/gateways.py
+++ b/central/billing/api/admin/gateways.py
@@ -18,7 +18,7 @@ def get_gateways() -> list[dict]:
 
 	Secrets (api_key, api_secret, webhook_secret) are never included.
 	"""
-	authz.require(authz.MANAGE)
+	authz.require_operator()
 	gateways = frappe.get_all(
 		"Payment Gateway",
 		fields=["name", "title", "adapter_key", "is_enabled", "supports_mandates",
@@ -43,7 +43,7 @@ def get_effective_routing() -> list[dict]:
 	an is_default row for it. Currencies that are configured but have no default
 	are listed with gateway = None so the admin can see the gap.
 	"""
-	authz.require(authz.MANAGE)
+	authz.require_operator()
 
 	# Collect every currency that appears in any gateway's child table.
 	all_rows = frappe.get_all(
@@ -78,7 +78,7 @@ def set_default_gateway(gateway: str, currency: str) -> dict:
 	The PaymentGateway controller's _enforce_default_uniqueness clears the flag on
 	any previously-default gateway for the same currency.
 	"""
-	authz.require(authz.MANAGE)
+	authz.require_operator()
 
 	gw_doc = frappe.get_doc("Payment Gateway", gateway)
 	row = next((r for r in gw_doc.currencies if r.currency == currency), None)

--- a/central/billing/api/admin/teams.py
+++ b/central/billing/api/admin/teams.py
@@ -53,6 +53,15 @@ def get_team_billing(team: str) -> dict:
 	}
 
 
+@frappe.whitelist(methods=["POST"])
+def adjust_team_credits(team: str, amount: float, entry_type: str,
+						currency: str | None = None, note: str | None = None) -> dict:
+	"""Manual wallet correction for any team — operator only. The one HTTP door to
+	`credits.adjust_credits`; the primitive itself is not whitelisted."""
+	require_operator()
+	return credits.adjust_credits(team, amount, entry_type, currency=currency, note=note)
+
+
 @frappe.whitelist()
 def get_retention() -> dict:
 	"""Customer retention snapshot: active vs at-risk vs churned, and a retention

--- a/central/billing/api/billing_api.py
+++ b/central/billing/api/billing_api.py
@@ -193,7 +193,6 @@ def add_payment_method(method_type: str = "Card", contact: str | None = None,
 	currency = _team_currency(team)
 	gw = _resolve_add_gateway(currency, gateway)
 	gateway = gw.get("name")
-	print(f"gateway: {gateway}")
 	if not gateway:
 		frappe.throw(frappe._("No payment gateway is configured for {0}.").format(currency), frappe.ValidationError)
 

--- a/central/billing/api/billing_api.py
+++ b/central/billing/api/billing_api.py
@@ -10,6 +10,8 @@ Record-scoped methods additionally check the record belongs to that team. No bus
 logic lives here; each method delegates to the existing billing service layer.
 """
 
+from contextlib import contextmanager
+
 import frappe
 
 from central.api.pilot import pilot_credential_auth
@@ -29,6 +31,19 @@ def _assert_owns(team_of_record: str | None) -> None:
 	"""Guard a record-scoped call: the record must belong to the credential's team."""
 	if team_of_record != _team():
 		frappe.throw("Not permitted for this team.", frappe.PermissionError)
+
+
+@contextmanager
+def _as_operator():
+	"""Run a delegated capability-gated call as Administrator — the pilot is a Guest
+	session and the team/asset are fixed by the verified credential. Restores the
+	prior user on exit, so nothing later in the request keeps operator rights."""
+	user = frappe.session.user
+	frappe.set_user("Administrator")
+	try:
+		yield
+	finally:
+		frappe.set_user(user)
 
 
 def _asset() -> str:
@@ -167,8 +182,8 @@ def get_payment_gateways() -> list[dict]:
 	"""The gateways the team can pay through (one per adapter, default first) — the
 	'Pay through' options the Add-payment card renders."""
 	team = _team()
-	frappe.set_user("Administrator")
-	return _gateway_options(_team_currency(team))
+	with _as_operator():
+		return _gateway_options(_team_currency(team))
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
@@ -319,8 +334,9 @@ def confirm_payment_method_checkout(reference: str) -> dict:
 	if not method_row.setup_reference:
 		return {"status": "pending", "active": False, "message": "No hosted setup for this method."}
 
-	frappe.set_user("Administrator")  # confirm gates on capability; team fixed by credential
-	result = _activate_setup(method_name, method_row.gateway, method_row.setup_reference)
+	# confirm gates on capability; team fixed by credential
+	with _as_operator():
+		result = _activate_setup(method_name, method_row.gateway, method_row.setup_reference)
 	if result["status"] == "pending":
 		result["message"] = "Awaiting card entry."
 	return result
@@ -335,8 +351,8 @@ def remove_payment_method(payment_method: str) -> dict:
 
 	method_row = frappe.db.get_value("Payment Method", payment_method, ["team"], as_dict=True)
 	_assert_owns(method_row.team if method_row else None)
-	frappe.set_user("Administrator")
-	return payments.delete_payment_method(payment_method)
+	with _as_operator():
+		return payments.delete_payment_method(payment_method)
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
@@ -346,22 +362,22 @@ def reconcile_payment_setup() -> dict:
 	no-webhook backstop the Billing tab calls on open, so a card added on the gateway's
 	page shows up on return without the poll button. Returns `{activated}`."""
 	team = _team()
-	frappe.set_user("Administrator")
-	pending = frappe.get_all(
-		"Payment Method",
-		filters={"team": team, "method_type": "Card", "status": "Pending Validation",
-				 "gateway_method_id": ["in", [None, ""]]},
-		fields=["name", "gateway", "setup_reference"],
-	)
-	activated = 0
-	for row in pending:
-		if not row.setup_reference:
-			continue
-		try:
-			if _activate_setup(row.name, row.gateway, row.setup_reference).get("active"):
-				activated += 1
-		except Exception:
-			frappe.clear_last_message()  # a decline/gateway hiccup must not break the tab load
+	with _as_operator():
+		pending = frappe.get_all(
+			"Payment Method",
+			filters={"team": team, "method_type": "Card", "status": "Pending Validation",
+					 "gateway_method_id": ["in", [None, ""]]},
+			fields=["name", "gateway", "setup_reference"],
+		)
+		activated = 0
+		for row in pending:
+			if not row.setup_reference:
+				continue
+			try:
+				if _activate_setup(row.name, row.gateway, row.setup_reference).get("active"):
+					activated += 1
+			except Exception:
+				frappe.clear_last_message()  # a decline/gateway hiccup must not break the tab load
 	return {"activated": activated}
 
 
@@ -379,14 +395,14 @@ def get_available_plans() -> dict:
 
 	team = _team()
 	cluster = frappe.db.get_value("Asset", _asset(), "cluster")
-	# The delegated menu gates on the session user's capability; the pilot is a Guest
-	# session, so act as operator — the team is fixed from the verified credential.
-	frappe.set_user("Administrator")
 	# No provisioned cluster → offer nothing; a cluster-less menu skips the
 	# allowed-clusters guard and would leak plans from other regions.
 	if not cluster:
 		return {"plans": {}}
-	return get_eligible_plans(cluster=cluster, team=team)
+	# The delegated menu gates on the session user's capability; the pilot is a Guest
+	# session, so act as operator — the team is fixed from the verified credential.
+	with _as_operator():
+		return get_eligible_plans(cluster=cluster, team=team)
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
@@ -406,8 +422,8 @@ def change_plan(plan: str | None = None) -> dict:
 		frappe.throw(frappe._("No subscription for asset {0} on this team.").format(asset), frappe.ValidationError)
 	# resize_server gates on the session user's capability; act as operator (team is
 	# fixed by the subscription lookup above, which is already scoped to the credential).
-	frappe.set_user("Administrator")
-	return resize_server(subscription, plan=plan)
+	with _as_operator():
+		return resize_server(subscription, plan=plan)
 
 
 # ── Metered services (team-level: AI tokens, email, PDF, …) ──────────────────
@@ -569,8 +585,8 @@ def get_billing_profile() -> dict:
 	team = _team()
 	# The delegated read gates on the session user's capability; act as operator (team
 	# is fixed from the verified credential).
-	frappe.set_user("Administrator")
-	return _get(team)
+	with _as_operator():
+		return _get(team)
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
@@ -584,8 +600,8 @@ def save_billing_profile(**fields) -> dict:
 	values = {k: v for k, v in fields.items() if k in _PROFILE_FIELDS}
 	# Write gates on the session user's capability; the pilot is a Guest session, so
 	# act as operator — the team is fixed from the verified credential.
-	frappe.set_user("Administrator")
-	doc = profile.create_or_update_billing_profile(team, **values)
+	with _as_operator():
+		doc = profile.create_or_update_billing_profile(team, **values)
 	return {"saved": True, "team": team, "currency": doc.currency, "gstin": doc.gstin}
 
 
@@ -604,22 +620,21 @@ def get_billing_summary() -> dict:
 	from central.billing.revenue import credits
 
 	team, asset = _team(), _asset()
-	frappe.set_user("Administrator")  # act as operator; team + asset fixed by credential
+	with _as_operator():  # team + asset fixed by credential
+		currency = _team_currency(team)
+		fields = ["title", "plan", "vcpus", "memory_megabytes", "disk_gigabytes"]
+		row = frappe.db.get_value("Asset", asset, fields, as_dict=True) or frappe._dict()
+		specs = _resolve_specs(row, row.plan)
+		subtitle = " · ".join(value for value in specs.values() if value)
+		plan_title = frappe.db.get_value("Plan", row.plan, "title") if row.plan else None
 
-	currency = _team_currency(team)
-	fields = ["title", "plan", "vcpus", "memory_megabytes", "disk_gigabytes"]
-	row = frappe.db.get_value("Asset", asset, fields, as_dict=True) or frappe._dict()
-	specs = _resolve_specs(row, row.plan)
-	subtitle = " · ".join(value for value in specs.values() if value)
-	plan_title = frappe.db.get_value("Plan", row.plan, "title") if row.plan else None
-
-	forecast = get_forecast(team)
-	projected = frappe.utils.flt(forecast.get("projected_total"))
-	balance = frappe.utils.flt(credits.get_balance(team, currency)["balance"])
-	# Only an Active method counts as "set up" — a Pending Validation / Failed one
-	# must not masquerade as the team's payment method on the summary.
-	methods = [m for m in _payment_method_rows(team) if m["status"] == "Active"]
-	default = next((m for m in methods if m["is_default"]), methods[0] if methods else None)
+		forecast = get_forecast(team)
+		projected = frappe.utils.flt(forecast.get("projected_total"))
+		balance = frappe.utils.flt(credits.get_balance(team, currency)["balance"])
+		# Only an Active method counts as "set up" — a Pending Validation / Failed one
+		# must not masquerade as the team's payment method on the summary.
+		methods = [m for m in _payment_method_rows(team) if m["status"] == "Active"]
+		default = next((m for m in methods if m["is_default"]), methods[0] if methods else None)
 
 	return {
 		"currency": currency,
@@ -653,7 +668,6 @@ def get_plan_options() -> dict:
 	team, asset = _team(), _asset()
 	row = frappe.db.get_value("Asset", asset, ["cluster", "plan"], as_dict=True) or frappe._dict()
 	subscription = frappe.db.get_value("Subscription", {"team": team, "asset_id": asset}, "name")
-	frappe.set_user("Administrator")
 
 	# No provisioned asset/cluster → offer nothing. A cluster-less menu would skip
 	# get_eligible_plans' allowed-clusters guard and leak plans from other regions.
@@ -661,7 +675,8 @@ def get_plan_options() -> dict:
 		return {"currency": _team_currency(team), "provider": None, "region": None,
 				"current": row.plan, "plans": [], "sufficient": False}
 
-	menu = get_eligible_plans(cluster=row.cluster, team=team, exclude_subscription=subscription or None)
+	with _as_operator():
+		menu = get_eligible_plans(cluster=row.cluster, team=team, exclude_subscription=subscription or None)
 	currency = menu.get("currency") or _team_currency(team)
 	provider, region = _provider_region(row.cluster)
 
@@ -690,8 +705,8 @@ def get_plan_options() -> dict:
 def list_payment_methods() -> list[dict]:
 	"""The team's saved payment methods (label, type, default), default first."""
 	team = _team()
-	frappe.set_user("Administrator")
-	return _payment_method_rows(team)
+	with _as_operator():
+		return _payment_method_rows(team)
 
 
 # ── Checkout (hosted URL + poll for status) ──────────────────────────────────

--- a/central/billing/api/dashboard/__init__.py
+++ b/central/billing/api/dashboard/__init__.py
@@ -50,7 +50,6 @@ from central.billing.api.dashboard.invoices import (
 	resume_subscription,
 	pay_invoice,
 	pay_invoice_checkout,
-	purchase_credits,
 )
 from central.billing.api.dashboard.methods import (
 	add_demo_card,
@@ -80,7 +79,7 @@ __all__ = [
 	"get_eligible_plans",
 	"get_forecast", "list_subscriptions", "pause_subscription", "resume_subscription",
 	"list_invoices", "get_invoice", "list_payment_attempts",
-	"get_credit_balance", "credit_ledger", "purchase_credits", "pay_invoice", "create_topup_order",
+	"get_credit_balance", "credit_ledger", "pay_invoice", "create_topup_order",
 	"confirm_topup", "pay_invoice_checkout", "confirm_invoice_checkout",
 	"list_payment_methods", "get_payment_method_options", "initiate_card_setup", "confirm_card",
 	"add_demo_card", "setup_payment_method_order", "confirm_payment_method_order",

--- a/central/billing/api/dashboard/invoices.py
+++ b/central/billing/api/dashboard/invoices.py
@@ -501,8 +501,11 @@ def confirm_topup(team: str | None = None, amount: float | None = None, gateway:
 			payment = adapter.get_payment(razorpay_payment_id)
 			ok = payment.get("status") == "captured"
 			minor = payment.get("amount")
-			if minor:
-				amount = frappe.utils.flt(minor) / 100
+			if minor is None:
+				# A captured payment always carries an amount; a response without
+				# one must not fall through to the client-supplied figure.
+				frappe.throw("Razorpay reported no amount for this payment.", frappe.ValidationError)
+			amount = frappe.utils.flt(minor) / 100
 			if payment.get("currency"):
 				currency = payment["currency"].upper()
 	elif gw_doc.adapter_key == "Paypal":
@@ -511,8 +514,9 @@ def confirm_topup(team: str | None = None, amount: float | None = None, gateway:
 		capture = adapter.capture_order(paypal_order_id)
 		ok = capture.get("status") == "COMPLETED"
 		reference = capture.get("id")
-		if capture.get("amount"):
-			amount = frappe.utils.flt(capture["amount"])
+		if capture.get("amount") is None:
+			frappe.throw("PayPal reported no amount for this capture.", frappe.ValidationError)
+		amount = frappe.utils.flt(capture["amount"])
 		if capture.get("currency"):
 			currency = capture["currency"].upper()
 	else:
@@ -523,8 +527,9 @@ def confirm_topup(team: str | None = None, amount: float | None = None, gateway:
 		ok = intent.get("status") == "succeeded"
 		reference = intent.get("id")
 		minor = intent.get("amount_received") or intent.get("amount")
-		if minor:
-			amount = frappe.utils.flt(minor) / 100
+		if minor is None:
+			frappe.throw("Stripe reported no amount for this payment intent.", frappe.ValidationError)
+		amount = frappe.utils.flt(minor) / 100
 		if intent.get("currency"):
 			currency = intent["currency"].upper()
 	if not ok:

--- a/central/billing/api/dashboard/invoices.py
+++ b/central/billing/api/dashboard/invoices.py
@@ -370,20 +370,6 @@ def credit_ledger(team: str | None = None, limit: int = 50) -> list[dict]:
 
 
 @frappe.whitelist(methods=["POST"])
-def purchase_credits(team: str | None = None, amount: float | None = None,
-					 payment_method: str | None = None) -> dict:
-	"""Top up the prepaid wallet. (The card charge that funds it is the payment
-	flow's concern; this books the resulting advance-liability credit.)"""
-	team = _resolve_team(team, authz.MANAGE)
-	_require_billing_setup(team)
-	amount = frappe.utils.flt(amount)
-	if amount <= 0:
-		frappe.throw("Top-up amount must be greater than zero.", frappe.ValidationError)
-	return credits.purchase(team, amount, _team_currency(team),
-							payment_method=payment_method, note="Wallet top-up")
-
-
-@frappe.whitelist(methods=["POST"])
 def pay_invoice(invoice: str | None = None) -> dict:
 	"""Postpaid one-off settlement of an outstanding invoice (team-scoped)."""
 	team = frappe.db.get_value("Invoice", invoice, "team")
@@ -502,12 +488,23 @@ def confirm_topup(team: str | None = None, amount: float | None = None, gateway:
 	gw_doc = frappe.get_doc("Payment Gateway", gateway)
 	adapter = get_adapter(gw_doc)
 	if gw_doc.adapter_key == "Razorpay":
+		# The callback signature binds order_id|payment_id, NOT the amount — so the
+		# request figure can't be trusted. Fetch the payment server-side and credit
+		# what Razorpay actually captured, mirroring the Stripe/PayPal branches.
 		ok = adapter.verify_payment_signature({
 			"razorpay_order_id": razorpay_order_id,
 			"razorpay_payment_id": razorpay_payment_id,
 			"razorpay_signature": razorpay_signature,
 		})
 		reference = razorpay_payment_id
+		if ok:
+			payment = adapter.get_payment(razorpay_payment_id)
+			ok = payment.get("status") == "captured"
+			minor = payment.get("amount")
+			if minor:
+				amount = frappe.utils.flt(minor) / 100
+			if payment.get("currency"):
+				currency = payment["currency"].upper()
 	elif gw_doc.adapter_key == "Paypal":
 		# Capture the order the buyer approved in PayPal Buttons; credit what PayPal
 		# actually took (major units already) and key the wallet entry on the capture id.

--- a/central/billing/catalog/plans.py
+++ b/central/billing/catalog/plans.py
@@ -33,7 +33,6 @@ def configure_includes(vcpu: float, ratio: str = "1:2", disk_gb: float = 0, memo
 	]
 
 
-@frappe.whitelist()
 def create_configured_plan(
 	title: str,
 	vcpu: float,
@@ -65,7 +64,6 @@ def create_configured_plan(
 	return doc.name
 
 
-@frappe.whitelist()
 def get_plan_pricing(plan: str, currency: str | None = None, cluster: str | None = None) -> dict:
 	"""Return the live catalog snapshot for a bundle.
 

--- a/central/billing/doctype/billing_profile/billing_profile.js
+++ b/central/billing/doctype/billing_profile/billing_profile.js
@@ -14,7 +14,7 @@ function set_state_options(frm) {
 		frm.set_df_property("state", "options", "");
 		return;
 	}
-	frappe.xcall("central.billing.india_gst.india_states").then((states) => {
-		frm.set_df_property("state", "options", states.join("\n"));
+	frappe.xcall("central.billing.api.dashboard.account.get_billing_geo").then((geo) => {
+		frm.set_df_property("state", "options", geo.india_states.join("\n"));
 	});
 }

--- a/central/billing/gateways/razorpay_adapter.py
+++ b/central/billing/gateways/razorpay_adapter.py
@@ -218,6 +218,12 @@ class RazorpayAdapter(GatewayAdapter):
 	def get_transaction_status(self, gateway_txn_id: str) -> str:
 		return self._client().payment.fetch(gateway_txn_id).get("status")
 
+	def get_payment(self, payment_id: str) -> dict:
+		"""Fetch a payment server-side — the authoritative captured amount/currency
+		(paise). The checkout-callback signature does not bind the amount, so any
+		crediting path must read it from here, never from the request."""
+		return self._client().payment.fetch(payment_id)
+
 	def create_order(self, amount, currency: str, receipt: str, notes: dict | None = None,
 					 customer: str | None = None) -> dict:
 		"""A one-time Razorpay order for a wallet top-up; the UI opens Checkout against it."""

--- a/central/billing/india_gst.py
+++ b/central/billing/india_gst.py
@@ -9,8 +9,6 @@ A GSTIN's first two digits are the registration state's code, so this map lets u
 saved GSTIN's state code matches the chosen state.
 """
 
-import frappe
-
 INDIA = "India"
 
 # State / UT name -> 2-digit GST state code (per the GST state code list).
@@ -65,7 +63,3 @@ def state_code(state: str | None) -> str | None:
 	return GST_STATE_CODES.get((state or "").strip())
 
 
-@frappe.whitelist()
-def india_states() -> list[str]:
-	"""Whitelisted feed for the Desk form's state dropdown."""
-	return india_state_options()

--- a/central/billing/payments/charges.py
+++ b/central/billing/payments/charges.py
@@ -51,7 +51,6 @@ def _adapter_for(gateway: str):
 	return get_adapter(frappe.get_doc("Payment Gateway", gateway))
 
 
-@frappe.whitelist()
 def pay_invoice(invoice: str, payment_method: str | None = None, gateway: str | None = None) -> dict:
 	"""Charge an unsettled (Open or Overdue) invoice. Creates at most one in-flight
 	Payment Attempt.

--- a/central/billing/payments/payments.py
+++ b/central/billing/payments/payments.py
@@ -89,7 +89,6 @@ def ensure_gateway_customer(team: str, gateway: str, adapter, customer_id: str |
 	return cid
 
 
-@frappe.whitelist()
 def initiate_payment_method_setup(team: str, gateway: str, gateway_customer_id: str | None = None) -> dict:
 	"""Begin adding a card: open a SetupIntent and a pending Payment Method.
 
@@ -132,7 +131,6 @@ def _discard_abandoned_setups(team: str, gateway: str):
 		frappe.delete_doc("Payment Method", name, ignore_permissions=True, force=True)
 
 
-@frappe.whitelist()
 def confirm_payment_method(
 	payment_method: str,
 	gateway_method_id: str,
@@ -212,7 +210,6 @@ def densify_priorities(team: str):
 		)
 
 
-@frappe.whitelist()
 def set_default_payment_method(payment_method: str) -> Document:
 	"""Make this the team's primary (priority 0). Only an active method can be."""
 	method = frappe.get_doc("Payment Method", payment_method)
@@ -224,7 +221,6 @@ def set_default_payment_method(payment_method: str) -> Document:
 	return frappe.get_doc("Payment Method", method.name)
 
 
-@frappe.whitelist()
 def reorder_payment_methods(team: str, ordered: list | str) -> dict:
 	"""Set the fallback order from a top-first list of method names."""
 	if isinstance(ordered, str):
@@ -237,7 +233,6 @@ def reorder_payment_methods(team: str, ordered: list | str) -> dict:
 	return {"team": team, "ordered": ordered}
 
 
-@frappe.whitelist()
 def delete_payment_method(payment_method: str) -> dict:
 	"""Remove a payment method and re-densify so the team keeps a dense, primary-
 	first order (or none if it was the last)."""

--- a/central/billing/revenue/credits.py
+++ b/central/billing/revenue/credits.py
@@ -233,7 +233,6 @@ def _existing_payment_entry(gateway_payment_id: str | None):
 	return entry, frappe.utils.flt(balance)
 
 
-@frappe.whitelist()
 def purchase(team: str, amount: float, currency: str | None = None,
 			 payment_method: str | None = None,
 			 reference_name: str | None = None, note: str | None = None,
@@ -296,7 +295,6 @@ def grant_promotional_credits(team, amount, currency, note=None) -> dict:
 	return {"ledger_entry": entry.name, "new_balance": new_balance}
 
 
-@frappe.whitelist()
 def adjust_credits(team: str, amount: float, entry_type: str, currency: str | None = None,
 				   note: str | None = None) -> dict:
 	"""Admin manual correction — a credit or debit entry with an audit note."""
@@ -308,7 +306,6 @@ def adjust_credits(team: str, amount: float, entry_type: str, currency: str | No
 	return {"ledger_entry": entry.name, "new_balance": new_balance}
 
 
-@frappe.whitelist()
 def get_balance(team: str, currency: str | None = None) -> dict:
 	"""The team's credit balance in one currency — read off that currency's anchor.
 
@@ -328,7 +325,6 @@ def get_balance(team: str, currency: str | None = None) -> dict:
 	return {"balance": frappe.utils.flt(balance), "currency": currency}
 
 
-@frappe.whitelist()
 def get_balances(team: str) -> list[dict]:
 	"""Every currency this team holds credits in — never summed across currencies."""
 	return frappe.get_all(

--- a/central/billing/revenue/erpnext_sync.py
+++ b/central/billing/revenue/erpnext_sync.py
@@ -30,7 +30,6 @@ def enqueue_invoice_sync(invoice: str):
 	)
 
 
-@frappe.whitelist()
 def sync_invoice(invoice: str) -> dict:
 	"""Create the ERPNext Sales Invoice for a Paid invoice (idempotent, one-way).
 

--- a/central/billing/tests/e2e.py
+++ b/central/billing/tests/e2e.py
@@ -129,10 +129,19 @@ def finish_razorpay_topup(team: str, gateway: str, order_id: str, amount: float)
 		secret.encode(), f"{order_id}|{payment_id}".encode(), hashlib.sha256
 	).hexdigest()
 
-	return confirm_topup(
-		team=team, amount=amount, gateway=gateway,
-		razorpay_order_id=order_id, razorpay_payment_id=payment_id, razorpay_signature=signature,
-	)
+	# confirm_topup now reads the captured amount back from the gateway (the
+	# callback signature doesn't bind the amount) — but our payment id is synthetic,
+	# so Razorpay has nothing to fetch. Stub just that read; everything else is real.
+	from unittest.mock import patch
+	from central.billing.gateways.razorpay_adapter import RazorpayAdapter
+
+	captured = {"status": "captured", "amount": int(round(frappe.utils.flt(amount) * 100)),
+				"currency": "INR"}
+	with patch.object(RazorpayAdapter, "get_payment", return_value=captured):
+		return confirm_topup(
+			team=team, amount=amount, gateway=gateway,
+			razorpay_order_id=order_id, razorpay_payment_id=payment_id, razorpay_signature=signature,
+		)
 
 
 # --- settlement helpers (invoice charge + credits waterfall) -----------------

--- a/central/billing/tests/test_admin.py
+++ b/central/billing/tests/test_admin.py
@@ -60,6 +60,20 @@ class TestAdminGating(AdminTestBase):
 		with self.assertRaises(frappe.PermissionError):
 			admin.get_summary()
 
+	def test_credit_adjustment_is_operator_only(self):
+		user = f"adm-{frappe.generate_hash(6)}@example.com"
+		frappe.get_doc({"doctype": "User", "email": user, "first_name": "X", "send_welcome_email": 0}).insert(ignore_permissions=True)
+		frappe.set_user(user)
+		with self.assertRaises(frappe.PermissionError):
+			admin.adjust_team_credits(TEAM_A, 100, "Credit", note="nope")
+
+	def test_credit_adjustment_books_with_audit_note(self):
+		out = admin.adjust_team_credits(TEAM_A, 100, "Credit", currency="INR", note="goodwill")
+		self.assertEqual(out["new_balance"], 100)
+		entry = frappe.get_doc("Credit Ledger Entry", out["ledger_entry"])
+		self.assertEqual(entry.reference_type, "Admin")
+		self.assertEqual(entry.note, "goodwill")
+
 
 class TestAggregates(AdminTestBase):
 	def test_summary_billed_collected_outstanding(self):

--- a/central/billing/tests/test_dashboard.py
+++ b/central/billing/tests/test_dashboard.py
@@ -239,7 +239,7 @@ class TestTeamScoping(CustomerDataBase):
 			with self.assertRaises(frappe.PermissionError):
 				dashboard.save_billing_settings(team=team.name, min_balance=5000)
 			with self.assertRaises(frappe.PermissionError):
-				dashboard.purchase_credits(team=team.name, amount=100)
+				dashboard.create_topup_order(team=team.name, amount=100)
 		finally:
 			frappe.set_user("Administrator")
 
@@ -262,25 +262,27 @@ class TestCustomerActions(CustomerDataBase):
 			dashboard.save_billing_profile(TEAM, legal_name="Acme", state="Karnataka", gstin="27AAPFU0939F1ZV")
 
 
-	def test_purchase_credits(self):
-		complete_billing_profile(TEAM)
-		out = dashboard.purchase_credits(team=TEAM, amount=1500)
-		self.assertEqual(out["new_balance"], 1500)
-		self.assertEqual(dashboard.get_credit_balance(TEAM)["balance"], 1500)
-		with self.assertRaises(frappe.ValidationError):
-			dashboard.purchase_credits(team=TEAM, amount=0)
-
 	def test_money_movement_blocked_until_profile_complete(self):
-		# No profile yet → top-up / credits / payment-method setup are refused.
+		from unittest.mock import MagicMock, patch
+		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
+
+		# No profile yet → a top-up is refused before any gateway call.
 		with self.assertRaises(frappe.ValidationError):
-			dashboard.purchase_credits(team=TEAM, amount=1500)
+			dashboard.create_topup_order(team=TEAM, amount=1500)
 		setup = dashboard.get_billing_profile(TEAM)
 		self.assertFalse(setup["complete"])
 		self.assertIn("currency", setup["missing"])
-		# Once the profile is complete, the same call succeeds.
+		# Once the profile is complete, the same call reaches the gateway.
 		complete_billing_profile(TEAM)
 		self.assertTrue(dashboard.get_billing_profile(TEAM)["complete"])
-		self.assertEqual(dashboard.purchase_credits(team=TEAM, amount=1500)["new_balance"], 1500)
+		gw = make_razorpay_gateway("GW-Gate-RZP").name
+		adapter = MagicMock()
+		adapter.create_customer.return_value = "cus_gate"
+		adapter.create_order.return_value = {
+			"order_id": "order_gate", "key_id": "rzp_test", "amount_in_subunits": 150000}
+		with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
+			out = dashboard.create_topup_order(team=TEAM, amount=1500, gateway=gw)
+		self.assertEqual(out["order_id"], "order_gate")
 
 	def test_billing_settings_roundtrip(self):
 		dashboard.save_billing_settings(team=TEAM, min_balance=5000)
@@ -372,10 +374,49 @@ class TestGatewayTopUp(CustomerDataBase):
 			# Wallet is NOT credited yet — only after the gateway confirms.
 			self.assertEqual(dashboard.get_credit_balance(TEAM)["balance"], 0)
 
+			adapter.get_payment.return_value = {
+				"status": "captured", "amount": 500000, "currency": "INR"}
 			out = dashboard.confirm_topup(team=TEAM, amount=5000, gateway=gw,
 				razorpay_order_id="order_x", razorpay_payment_id="pay_x", razorpay_signature="sig")
 			adapter.verify_payment_signature.assert_called_once()
+			# The credit is the gateway's captured figure, read server-side.
+			adapter.get_payment.assert_called_once_with("pay_x")
 			self.assertEqual(out["new_balance"], 5000)
+
+	def test_topup_credits_gateway_amount_not_request_amount(self):
+		"""The Razorpay callback signature binds order|payment, NOT the amount — a
+		client claiming a bigger figure must be credited what the gateway captured."""
+		from unittest.mock import MagicMock, patch
+		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
+
+		gw = make_razorpay_gateway("GW-Cust-RZP-Amt").name
+		complete_billing_profile(TEAM)
+		adapter = MagicMock()
+		adapter.verify_payment_signature.return_value = True
+		adapter.get_payment.return_value = {
+			"status": "captured", "amount": 100, "currency": "INR"}  # ₹1 really captured
+		with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
+			out = dashboard.confirm_topup(team=TEAM, amount=1000000, gateway=gw,
+				razorpay_order_id="order_a", razorpay_payment_id="pay_a", razorpay_signature="sig")
+		self.assertEqual(out["new_balance"], 1)  # the gateway figure, not the claim
+		self.assertEqual(dashboard.get_credit_balance(TEAM)["balance"], 1)
+
+	def test_topup_rejects_uncaptured_payment(self):
+		"""A signature-valid callback whose payment the gateway has not captured
+		credits nothing."""
+		from unittest.mock import MagicMock, patch
+		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
+
+		gw = make_razorpay_gateway("GW-Cust-RZP-Uncap").name
+		complete_billing_profile(TEAM)
+		adapter = MagicMock()
+		adapter.verify_payment_signature.return_value = True
+		adapter.get_payment.return_value = {"status": "authorized", "amount": 500000}
+		with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
+			with self.assertRaises(frappe.ValidationError):
+				dashboard.confirm_topup(team=TEAM, amount=5000, gateway=gw,
+					razorpay_order_id="order_b", razorpay_payment_id="pay_b", razorpay_signature="sig")
+		self.assertEqual(dashboard.get_credit_balance(TEAM)["balance"], 0)
 
 	def test_second_topup_reuses_the_same_gateway_customer(self):
 		"""A team's customer is minted once and reused — the second top-up (or any
@@ -541,6 +582,8 @@ class TestGatewayTopUp(CustomerDataBase):
 		adapter.create_customer.return_value = "cus_rzp"
 		adapter.create_order.return_value = {"order_id": "order_rzp1", "key_id": "rzp_k"}
 		adapter.verify_payment_signature.return_value = True
+		adapter.get_payment.return_value = {
+			"status": "captured", "amount": 500000, "currency": "USD"}
 		with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
 			order = dashboard.create_topup_order(team=TEAM, amount=5000, method="paypal")
 			# Settlement runs on a Razorpay gateway; the SPA opens the sheet on the
@@ -574,7 +617,7 @@ class TestWriteEndpointsRejectGet(IntegrationTestCase):
 		from central.billing.api.dashboard import invoices, methods, account
 
 		write_fns = [
-			invoices.purchase_credits, invoices.pay_invoice,
+			invoices.pay_invoice,
 			invoices.create_topup_order, invoices.confirm_topup,
 			methods.initiate_card_setup, methods.confirm_card, methods.add_demo_card,
 			methods.setup_payment_method_order, methods.confirm_payment_method_order,

--- a/central/billing/tests/test_dashboard.py
+++ b/central/billing/tests/test_dashboard.py
@@ -401,6 +401,23 @@ class TestGatewayTopUp(CustomerDataBase):
 		self.assertEqual(out["new_balance"], 1)  # the gateway figure, not the claim
 		self.assertEqual(dashboard.get_credit_balance(TEAM)["balance"], 1)
 
+	def test_topup_rejects_captured_payment_without_amount(self):
+		"""A captured payment whose fetch carries no amount must hard-fail, not
+		fall back to the client-supplied figure the signature never covered."""
+		from unittest.mock import MagicMock, patch
+		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
+
+		gw = make_razorpay_gateway("GW-Cust-RZP-NoAmt").name
+		complete_billing_profile(TEAM)
+		adapter = MagicMock()
+		adapter.verify_payment_signature.return_value = True
+		adapter.get_payment.return_value = {"status": "captured", "currency": "INR"}
+		with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
+			with self.assertRaises(frappe.ValidationError):
+				dashboard.confirm_topup(team=TEAM, amount=1000000, gateway=gw,
+					razorpay_order_id="order_n", razorpay_payment_id="pay_n", razorpay_signature="sig")
+		self.assertEqual(dashboard.get_credit_balance(TEAM)["balance"], 0)
+
 	def test_topup_rejects_uncaptured_payment(self):
 		"""A signature-valid callback whose payment the gateway has not captured
 		credits nothing."""

--- a/central/billing/tests/test_whitelist_boundary.py
+++ b/central/billing/tests/test_whitelist_boundary.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""The whitelist boundary, enforced mechanically (2026-07 audit).
+
+`@frappe.whitelist()` is authentication (a logged-in session), not authorization
+(may this session act on this team). The audit found domain primitives carrying
+the decorator — credit minting, payment-method mutation, invoice charging — all
+reachable over `/api/method/...` by any logged-in user. security.md §3 already
+forbade this; the rule was violated because it was checked by hand. This module
+is that checklist line as code:
+
+1. **Layer boundary** — `@frappe.whitelist()` may appear only in `billing/api/**`
+   (plus a reviewed allowlist). Domain modules are plain Python functions.
+2. **Guard on entry** — every module-level endpoint in `billing/api/**` calls the
+   authz seam (or carries `pilot_credential_auth`), or sits on a reviewed
+   allowlist.
+3. **Regression** — the audited primitives stay rejected at the HTTP door.
+"""
+
+import ast
+from pathlib import Path
+
+import frappe
+from central.billing.tests.utils import BillingTestCase
+
+BILLING_ROOT = Path(__file__).resolve().parent.parent
+
+# Module-level whitelisted functions allowed OUTSIDE billing/api/** — each entry
+# is a reviewed exception with its reason.
+BOUNDARY_ALLOWLIST = {
+	"payments/webhooks.py",  # signature-first: HMAC-verified before anything runs
+	"tests/e2e.py",  # hard-gated on frappe.conf.allow_tests; dead on production
+}
+
+# API endpoints allowed WITHOUT a guard token — reviewed: read-only feeds of
+# non-team data, or self-scoped reads that derive everything from the session.
+GUARD_ALLOWLIST = {
+	"api/dashboard/account.py::whoami",  # reports the caller's own session/scope
+	"api/dashboard/account.py::get_billing_geo",  # static country/state lists
+	"api/dashboard/account.py::list_switchable_teams",  # session-derived team list
+}
+
+# Calling any of these on the first lines is what "guarded" means (security.md §3).
+GUARD_TOKENS = (
+	"require_operator",
+	"require_billing_view",
+	"require_billing_manage",
+	"require_capability",
+	"_resolve_team",
+	"_require_manage",
+	"_require_view",
+	"_assert_owns",
+)
+
+# A decorator that authenticates + binds the team before the body runs.
+AUTH_DECORATORS = {"pilot_credential_auth"}
+
+
+def _decorator_name(node) -> str:
+	target = node.func if isinstance(node, ast.Call) else node
+	if isinstance(target, ast.Attribute):
+		return target.attr
+	if isinstance(target, ast.Name):
+		return target.id
+	return ""
+
+
+def _is_whitelist_decorator(node) -> bool:
+	return _decorator_name(node) == "whitelist"
+
+
+def _whitelisted_functions(tree, source):
+	"""(function node, inside_class, decorator names) for every whitelisted def."""
+	for node in ast.walk(tree):
+		if not isinstance(node, ast.ClassDef | ast.Module):
+			continue
+		for child in node.body:
+			if not isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+				continue
+			names = [_decorator_name(d) for d in child.decorator_list]
+			if any(_is_whitelist_decorator(d) for d in child.decorator_list):
+				yield child, isinstance(node, ast.ClassDef), names
+
+
+def _billing_files():
+	for path in sorted(BILLING_ROOT.rglob("*.py")):
+		if "__pycache__" in path.parts:
+			continue
+		yield path, path.relative_to(BILLING_ROOT).as_posix()
+
+
+class TestWhitelistBoundary(BillingTestCase):
+	def test_no_whitelist_outside_the_api_layer(self):
+		"""Domain modules never expose HTTP endpoints. A doctype controller may
+		whitelist a *method* (dispatched via run_doc_method under doc permissions);
+		everything else module-level must live in billing/api/** or be a reviewed
+		exception."""
+		violations = []
+		for path, rel in _billing_files():
+			source = path.read_text()
+			tree = ast.parse(source)
+			for fn, inside_class, _names in _whitelisted_functions(tree, source):
+				if rel.startswith("api/") or rel in BOUNDARY_ALLOWLIST:
+					continue
+				if inside_class and rel.startswith("doctype/"):
+					continue  # controller action; frappe gates it on doc permissions
+				violations.append(f"{rel}::{fn.name}")
+		self.assertEqual(
+			violations, [],
+			"@frappe.whitelist() outside billing/api/** — move the endpoint to the "
+			f"API layer (do not just add a guard): {violations}",
+		)
+
+	def test_every_api_endpoint_calls_a_guard(self):
+		"""Every module-level endpoint in billing/api/** authorizes on entry —
+		via the authz seam, a team-resolving helper, or the pilot-credential
+		decorator. New endpoints without a guard fail here, not in an audit."""
+		unguarded = []
+		for path, rel in _billing_files():
+			if not rel.startswith("api/"):
+				continue
+			source = path.read_text()
+			tree = ast.parse(source)
+			for fn, inside_class, names in _whitelisted_functions(tree, source):
+				if inside_class or f"{rel}::{fn.name}" in GUARD_ALLOWLIST:
+					continue
+				if AUTH_DECORATORS.intersection(names):
+					continue
+				body = ast.get_source_segment(source, fn) or ""
+				if not any(token in body for token in GUARD_TOKENS):
+					unguarded.append(f"{rel}::{fn.name}")
+		self.assertEqual(
+			unguarded, [],
+			f"whitelisted endpoints with no authz guard on entry: {unguarded}",
+		)
+
+
+class TestAuditedPrimitivesStayInternal(BillingTestCase):
+	"""One regression per audit exploit: the de-whitelisted primitives must be
+	rejected at the HTTP door (frappe.is_whitelisted is the handler's gate)."""
+
+	PRIMITIVES = (
+		"central.billing.revenue.credits.purchase",
+		"central.billing.revenue.credits.adjust_credits",
+		"central.billing.revenue.credits.get_balance",
+		"central.billing.revenue.credits.get_balances",
+		"central.billing.payments.payments.initiate_payment_method_setup",
+		"central.billing.payments.payments.confirm_payment_method",
+		"central.billing.payments.payments.set_default_payment_method",
+		"central.billing.payments.payments.reorder_payment_methods",
+		"central.billing.payments.payments.delete_payment_method",
+		"central.billing.payments.charges.pay_invoice",
+		"central.billing.catalog.plans.create_configured_plan",
+		"central.billing.catalog.plans.get_plan_pricing",
+		"central.billing.revenue.erpnext_sync.sync_invoice",
+	)
+
+	def test_primitives_are_rejected_at_the_http_door(self):
+		for dotted in self.PRIMITIVES:
+			with self.subTest(method=dotted):
+				with self.assertRaises(frappe.PermissionError):
+					frappe.is_whitelisted(frappe.get_attr(dotted))

--- a/dashboard/src/api/methods.ts
+++ b/dashboard/src/api/methods.ts
@@ -96,7 +96,6 @@ export const API = {
 		'central.billing.api.dashboard.confirm_invoice_checkout',
 	createTopupOrder: 'central.billing.api.dashboard.create_topup_order',
 	confirmTopup: 'central.billing.api.dashboard.confirm_topup',
-	purchaseCredits: 'central.billing.api.dashboard.purchase_credits',
 	initiateCardSetup: 'central.billing.api.dashboard.initiate_card_setup',
 	confirmCard: 'central.billing.api.dashboard.confirm_card',
 	setupPaymentMethodOrder:


### PR DESCRIPTION
## What

Fixes all ten findings from the July security audit of the billing surface, plus one adjacent hole found on the way. Root cause for most of them: domain-layer functions (credits, payment methods, charges, plans, sync) carried @frappe.whitelist(), which authenticates but does not authorise — so any logged-in user could call them over /api/method/... for any team.

## Changes

### Money (critical/high)
- Credit primitives (purchase, adjust_credits, get_balance(s)) are no longer HTTP endpoints. Manual corrections go through a new operator-only admin.teams.adjust_team_credits.
- Razorpay confirm_topup no longer trusts the client-supplied amount — the callback signature binds order_id|payment_id, not the amount. It now fetches the payment server-side and credits what the gateway actually captured, rejecting uncaptured payments.
- Removed purchase_credits (dashboard endpoint, unused by the UI): it booked wallet credit with no gateway charge, letting a team manager self-mint. Not in the audit, same class.

### De-whitelisting (high/medium)
- Payment-method primitives (initiate/confirm/delete/set_default/reorder) — the guarded dashboard twins are the only doors now.
- charges.pay_invoice — internal; the guarded wrapper handles "Pay now".
- plans.create_configured_plan / get_plan_pricing — authoring moved behind operator-only admin.catalog.create_configured_plan.
- erpnext_sync.sync_invoice — runs from the queue only.
- Desk state dropdown reads the existing get_billing_geo endpoint instead of a whitelisted domain function.

### Hygiene (low)
- admin/gateways.py called a guard that didn't exist (authz.require) — now require_operator().
- Dropped a stray debug print.
- The pilot API's 11 set_user("Administrator") calls now go through a context manager that restores the prior user, so nothing later in a request keeps operator rights.