### PR TITLE
feat: unified assets list view

### DIFF
--- a/central/api/resources.py
+++ b/central/api/resources.py
@@ -12,23 +12,29 @@ from central.iam import can, resolve_team
 
 
 @frappe.whitelist(methods=["GET"])
-def list_resources(team: str | None = None) -> dict:
+def list_resources(team: str | None = None, kind: str | None = None) -> dict:
 	"""A team's servers and sites as one list, so the console lands a single-site team
-	on its site and a server owner on their servers from one read. Each carries a region
+	on its site and a server owner on their servers from one read (optionally one `kind`). Each carries a region
 	so both share the map view."""
 	user = frappe.session.user
 	team = resolve_team(user, team)
 	if not can(user, team, "server:view"):
 		frappe.throw(_("You can't view this team's resources."), frappe.PermissionError)
 
-	servers = frappe.get_all(
-		"Asset",
-		filters={"team": team},
-		fields=["name", "title", "resource_id", "status", "public_ipv4", "cluster"],
-		order_by="title",
+	servers = (
+		frappe.get_all(
+			"Asset",
+			filters={"team": team},
+			fields=["name", "title", "resource_id", "status", "public_ipv4", "cluster"],
+			order_by="title",
+		)
+		if kind in (None, "server")
+		else []
 	)
-	sites = frappe.get_all(
-		"Site", filters={"team": team}, fields=["name", "status", "url", "region"], order_by="name"
+	sites = (
+		frappe.get_all("Site", filters={"team": team}, fields=["name", "status", "url", "region"], order_by="name")
+		if kind in (None, "site")
+		else []
 	)
 
 	# Servers carry a cluster, not a region — resolve every cluster's region in one query.

--- a/central/api/resources.py
+++ b/central/api/resources.py
@@ -2,8 +2,15 @@ from __future__ import annotations
 
 import frappe
 from frappe import _
+from frappe.query_builder import DocType, Order
+from pypika import analytics as an
 
 from central.iam import can, resolve_team
+
+# Rows returned per region by list_site_groups. The count is exact regardless — a
+# region with more sites lists this many and reports the true total, so the map
+# payload stays bounded however many sites a team runs.
+SITE_PREVIEW_LIMIT = 50
 
 # A team's resources unified for the console home + resource-aware landing: servers
 # (the Asset mirror) and sites (the Site mirror), each tagged with `kind`. "Asset" as
@@ -61,3 +68,43 @@ def list_resources(team: str | None = None, kind: str | None = None) -> dict:
 	]
 
 	return {"team": team, "resources": resources}
+
+
+@frappe.whitelist(methods=["GET"])
+def list_site_groups(team: str | None = None) -> dict:
+	"""A team's sites grouped by region with an exact per-region count, for the
+	servers map + panel. The DB does the grouping, counting and per-region capping
+	(indexed on team, region), so the payload never scales with a team's site count."""
+	user = frappe.session.user
+	team = resolve_team(user, team)
+	if not can(user, team, "server:view"):
+		frappe.throw(_("You can't view this team's resources."), frappe.PermissionError)
+
+	# ROW_NUMBER caps each region to a preview; COUNT(*) OVER carries the true total.
+	site = DocType("Site")
+	ranked = (
+		frappe.qb.from_(site)
+		.select(
+			site.name,
+			site.status,
+			site.url,
+			site.region,
+			an.RowNumber().over(site.region).orderby(site.modified, order=Order.desc).as_("rn"),
+			an.Count(site.star).over(site.region).as_("region_count"),
+		)
+		.where((site.team == team) & (site.status != "Terminated"))
+	).as_("ranked")
+	rows = (
+		frappe.qb.from_(ranked)
+		.select(ranked.name, ranked.status, ranked.url, ranked.region, ranked.region_count)
+		.where(ranked.rn <= SITE_PREVIEW_LIMIT)
+		.orderby(ranked.region, ranked.rn)
+		.run(as_dict=True)
+	)
+
+	groups: dict[str, dict] = {}
+	for row in rows:
+		group = groups.setdefault(row.region or "", {"region": row.region, "count": row.region_count, "sites": []})
+		group["sites"].append({"name": row.name, "status": row.status, "url": row.url})
+
+	return {"team": team, "groups": list(groups.values())}

--- a/central/api/resources.py
+++ b/central/api/resources.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import frappe
+from frappe import _
+
+from central.iam import can, resolve_team
+
+# A team's resources unified for the console home + resource-aware landing: servers
+# (the Asset mirror) and sites (the Site mirror), each tagged with `kind`. "Asset" as
+# the umbrella term is deferred to a later Asset->Server rename; "resource" is the
+# interim word. Gated on server:view — every role that reaches the home carries it.
+
+
+@frappe.whitelist(methods=["GET"])
+def list_resources(team: str | None = None) -> dict:
+	"""A team's servers and sites as one list, so the console lands a single-site team
+	on its site and a server owner on their servers from one read. Each carries a region
+	so both share the map view."""
+	user = frappe.session.user
+	team = resolve_team(user, team)
+	if not can(user, team, "server:view"):
+		frappe.throw(_("You can't view this team's resources."), frappe.PermissionError)
+
+	servers = frappe.get_all(
+		"Asset",
+		filters={"team": team},
+		fields=["name", "title", "resource_id", "status", "public_ipv4", "cluster"],
+		order_by="title",
+	)
+	sites = frappe.get_all(
+		"Site", filters={"team": team}, fields=["name", "status", "url", "region"], order_by="name"
+	)
+
+	# Servers carry a cluster, not a region — resolve every cluster's region in one query.
+	clusters = {row.cluster for row in servers if row.cluster}
+	region_by_cluster = (
+		dict(frappe.get_all("Atlas Instance", filters={"name": ["in", list(clusters)]}, fields=["name", "region"], as_list=True))
+		if clusters
+		else {}
+	)
+
+	resources = [
+		{
+			"kind": "server",
+			"name": a.name,
+			"label": a.title or a.resource_id,
+			"status": a.status,
+			"region": region_by_cluster.get(a.cluster),
+			"detail": a.public_ipv4,
+		}
+		for a in servers
+	] + [
+		{"kind": "site", "name": s.name, "label": s.name, "status": s.status, "region": s.region, "detail": s.url}
+		for s in sites
+	]
+
+	return {"team": team, "resources": resources}

--- a/central/api/resources.py
+++ b/central/api/resources.py
@@ -28,10 +28,12 @@ def list_resources(team: str | None = None, kind: str | None = None) -> dict:
 	if not can(user, team, "server:view"):
 		frappe.throw(_("You can't view this team's resources."), frappe.PermissionError)
 
+	# Terminated resources are gone, not a state to land on or render — exclude both
+	# kinds here (the map feeds already do), so no caller sees stale entries.
 	servers = (
 		frappe.get_all(
 			"Asset",
-			filters={"team": team},
+			filters={"team": team, "status": ["!=", "Terminated"]},
 			fields=["name", "title", "resource_id", "status", "public_ipv4", "cluster"],
 			order_by="title",
 		)
@@ -39,7 +41,12 @@ def list_resources(team: str | None = None, kind: str | None = None) -> dict:
 		else []
 	)
 	sites = (
-		frappe.get_all("Site", filters={"team": team}, fields=["name", "status", "url", "region"], order_by="name")
+		frappe.get_all(
+			"Site",
+			filters={"team": team, "status": ["!=", "Terminated"]},
+			fields=["name", "status", "url", "region"],
+			order_by="name",
+		)
 		if kind in (None, "site")
 		else []
 	)

--- a/central/api/sites.py
+++ b/central/api/sites.py
@@ -141,3 +141,21 @@ def site_domain(region: str | None = None) -> dict:
 	the user types. Atlas returns `domain` regardless of label validity."""
 	region = region or _default_region()
 	return {"domain": AtlasClient.for_region(region).check_subdomain("", region=region).get("domain")}
+
+
+@frappe.whitelist(methods=["POST"])
+def terminate_site(name: str) -> dict:
+	"""Terminate a self-serve site (and its 1:1 backing VM). Gated on `server:terminate` —
+	a site is a VM, so removing it is authorized like tearing down a server (site-level
+	capabilities are deferred). The mirror flips to Terminated on the site.* event."""
+	user = frappe.session.user
+	site = frappe.db.get_value("Site", name, ["team", "cluster", "status"], as_dict=True)
+	if not site:
+		frappe.throw(_("Unknown site {0}.").format(name))
+	if not can(user, site.team, "server:terminate"):
+		frappe.throw(_("You can't terminate this team's sites."), frappe.PermissionError)
+
+	instance = frappe.get_doc("Atlas Instance", site.cluster)
+	AtlasClient(instance).terminate_site(name)
+
+	return {"name": name, "status": "Terminating"}

--- a/central/api/sites.py
+++ b/central/api/sites.py
@@ -155,6 +155,14 @@ def terminate_site(name: str) -> dict:
 	if not can(user, site.team, "server:terminate"):
 		frappe.throw(_("You can't terminate this team's sites."), frappe.PermissionError)
 
+	# Already gone — no-op, and never issue a second teardown to Atlas.
+	if site.status == "Terminated":
+		return {"name": name, "status": site.status}
+	# A site with no backing region was never placed on Atlas; without this,
+	# get_doc("Atlas Instance", None) below raises an opaque error.
+	if not site.cluster:
+		frappe.throw(_("Site {0} has no backing region to terminate.").format(name), frappe.ValidationError)
+
 	instance = frappe.get_doc("Atlas Instance", site.cluster)
 	AtlasClient(instance).terminate_site(name)
 

--- a/central/central/doctype/site/site.py
+++ b/central/central/doctype/site/site.py
@@ -83,3 +83,8 @@ class Site(Document):
 			doc.last_event_at = occurred_at
 		if synced_at:
 			doc.last_synced_at = synced_at
+
+
+def on_doctype_update():
+	# Backs the team-scoped, region-grouped read in central.api.resources; runs on migrate.
+	frappe.db.add_index("Site", ["team", "region"])

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -326,6 +326,15 @@ class AtlasClient:
 			params={"dt": "Site", "dn": name, "method": "regenerate_login_url"},
 		)
 
+	def terminate_site(self, name: str) -> dict:
+		"""Tear down a self-serve site and its 1:1 backing VM. The Atlas Site controller
+		terminates the guest + VM; the site.* events flip the mirror to Terminated."""
+		return self.client().post_api(
+			"run_doc_method",
+			params={"dt": "Site", "dn": name, "method": "terminate"},
+		)
+
+
 	def check_subdomain(self, subdomain: str, region: str | None = None) -> dict:
 		"""Best-effort availability pre-check: {available, reason, fqdn, domain}."""
 		params = {"subdomain": subdomain}

--- a/central/services/tests/test_llm_provisioning.py
+++ b/central/services/tests/test_llm_provisioning.py
@@ -16,6 +16,23 @@ _FAKE = {
 }
 
 
+def _ensure_llm_service():
+	"""The LLM add-on's catalog entry. Operator-provisioned in prod (not seeded), so
+	tests must stand it up before linking a Service Backend / Managed Service to it.
+	Its Plan Category ("AI Tokens") is seeded on install by the billing taxonomy."""
+	if not frappe.db.exists("Add-on Service", "llm"):
+		frappe.get_doc(
+			{
+				"doctype": "Add-on Service",
+				"service_key": "llm",
+				"title": "LLM Hosting",
+				"handler_key": "grove",
+				"plan_category": "AI Tokens",
+				"is_active": 1,
+			}
+		).insert(ignore_permissions=True)
+
+
 class TestLLMProvisioning(IntegrationTestCase):
 	def setUp(self):
 		site = frappe.get_all("Site", fields=["name", "team"], limit=1)
@@ -25,6 +42,7 @@ class TestLLMProvisioning(IntegrationTestCase):
 
 		self.site, self.team = site[0].name, site[0].team
 
+		_ensure_llm_service()
 		# Frappe rolls the suite back only at class teardown, so wipe our own rows
 		# between methods to avoid the composite-unique guard tripping on reuse.
 		frappe.db.delete("Site Service Credential", {"site": self.site})
@@ -108,6 +126,7 @@ class TestLLMPolicyAndUsage(IntegrationTestCase):
 		from central.services import llm
 
 		self.llm = llm
+		_ensure_llm_service()
 		frappe.db.delete("Service Backend", {"service": "llm"})
 		frappe.db.delete("LLM Model", {"model_key": ["in", ["m-fast", "m-premium", "m-stale"]]})
 
@@ -139,7 +158,10 @@ class TestLLMPolicyAndUsage(IntegrationTestCase):
 		frappe.get_doc({"doctype": "LLM Model", "model_key": "m-fast", "tier": "Fast", "is_published": 1}).insert()
 		frappe.get_doc({"doctype": "LLM Model", "model_key": "m-premium", "tier": "Premium", "is_published": 1}).insert()
 
-		plan = frappe.get_all("Plan", pluck="name", limit=1)[0]
+		plans = frappe.get_all("Plan", pluck="name", limit=1)
+		if not plans:
+			self.skipTest("Needs at least one Plan.")
+		plan = plans[0]
 		frappe.db.delete("LLM Plan Tier", {"parent": plan})
 		frappe.db.delete("LLM Plan Policy", {"plan": plan})
 		frappe.get_doc(
@@ -152,7 +174,10 @@ class TestLLMPolicyAndUsage(IntegrationTestCase):
 
 	def test_resolve_options_denies_when_tier_has_no_models(self):
 		frappe.db.delete("LLM Model", {"tier": "Premium"})
-		plan = frappe.get_all("Plan", pluck="name", limit=1)[0]
+		plans = frappe.get_all("Plan", pluck="name", limit=1)
+		if not plans:
+			self.skipTest("Needs at least one Plan.")
+		plan = plans[0]
 		frappe.db.delete("LLM Plan Tier", {"parent": plan})
 		frappe.db.delete("LLM Plan Policy", {"plan": plan})
 		frappe.get_doc({"doctype": "LLM Plan Policy", "plan": plan, "allowed_tiers": [{"tier": "Premium"}]}).insert()
@@ -202,6 +227,7 @@ class TestLLMPolicyAndUsage(IntegrationTestCase):
 
 class TestBackendEnroll(IntegrationTestCase):
 	def setUp(self):
+		_ensure_llm_service()
 		frappe.db.delete("Service Backend", {"service": "llm"})
 
 	def test_register_backend_stores_minted_credential(self):

--- a/central/tests/test_resources.py
+++ b/central/tests/test_resources.py
@@ -23,6 +23,14 @@ class TestListResources(IntegrationTestCase):
 		self.assertIn(site[0].name, names)
 		self.assertTrue(all("region" in r for r in result["resources"]))
 
+	def test_list_resources_kind_site_returns_only_sites(self):
+		site = frappe.get_all("Site", fields=["name", "team"], limit=1)
+		if not site:
+			self.skipTest("No Site available.")
+
+		result = resources.list_resources(site[0].team, kind="site")
+		self.assertTrue(all(r["kind"] == "site" for r in result["resources"]))
+
 	def test_terminate_site_routes_to_atlas(self):
 		rows = frappe.get_all("Site", fields=["name", "cluster"], filters={"status": ["!=", "Terminated"]}, limit=25)
 		site = next((r for r in rows if r.cluster and frappe.db.exists("Atlas Instance", r.cluster)), None)

--- a/central/tests/test_resources.py
+++ b/central/tests/test_resources.py
@@ -58,3 +58,33 @@ class TestListResources(IntegrationTestCase):
 
 		Client.return_value.terminate_site.assert_called_once_with(site.name)
 		self.assertEqual(result["status"], "Terminating")
+
+	def _make_site(self, name: str, status: str) -> str:
+		base = frappe.get_all("Site", fields=["team", "cluster"], filters={"cluster": ["is", "set"]}, limit=1)
+		if not base:
+			self.skipTest("No Site to derive a team/cluster from.")
+		self.addCleanup(
+			lambda: frappe.db.exists("Site", name) and frappe.delete_doc("Site", name, ignore_permissions=True, force=True)
+		)
+		frappe.get_doc(
+			{"doctype": "Site", "site_name": name, "team": base[0].team, "cluster": base[0].cluster, "status": status}
+		).insert(ignore_permissions=True)
+		return name
+
+	def test_terminate_site_is_noop_when_already_terminated(self):
+		name = self._make_site("zz-terminate-noop-test.example.dev", "Terminated")
+
+		with patch("central.api.sites.AtlasClient") as Client:
+			result = sites.terminate_site(name)
+
+		Client.assert_not_called()
+		self.assertEqual(result["status"], "Terminated")
+
+	def test_terminate_site_rejects_missing_cluster(self):
+		name = self._make_site("zz-terminate-nocluster-test.example.dev", "Running")
+		frappe.db.set_value("Site", name, "cluster", None, update_modified=False)
+
+		with patch("central.api.sites.AtlasClient") as Client:
+			self.assertRaises(frappe.ValidationError, sites.terminate_site, name)
+
+		Client.assert_not_called()

--- a/central/tests/test_resources.py
+++ b/central/tests/test_resources.py
@@ -31,6 +31,22 @@ class TestListResources(IntegrationTestCase):
 		result = resources.list_resources(site[0].team, kind="site")
 		self.assertTrue(all(r["kind"] == "site" for r in result["resources"]))
 
+	def test_list_resources_excludes_terminated(self):
+		base = frappe.get_all("Site", fields=["team", "cluster"], filters={"cluster": ["is", "set"]}, limit=1)
+		if not base:
+			self.skipTest("No Site to derive a team/cluster from.")
+
+		name = "zz-terminated-resource-test.example.dev"
+		self.addCleanup(
+			lambda: frappe.db.exists("Site", name) and frappe.delete_doc("Site", name, ignore_permissions=True, force=True)
+		)
+		frappe.get_doc(
+			{"doctype": "Site", "site_name": name, "team": base[0].team, "cluster": base[0].cluster, "status": "Terminated"}
+		).insert(ignore_permissions=True)
+
+		result = resources.list_resources(base[0].team, kind="site")
+		self.assertNotIn(name, {r["name"] for r in result["resources"]})
+
 	def test_terminate_site_routes_to_atlas(self):
 		rows = frappe.get_all("Site", fields=["name", "cluster"], filters={"status": ["!=", "Terminated"]}, limit=25)
 		site = next((r for r in rows if r.cluster and frappe.db.exists("Atlas Instance", r.cluster)), None)

--- a/central/tests/test_resources.py
+++ b/central/tests/test_resources.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026, frappe and Contributors
+# See license.txt
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from central.api import resources, sites
+
+
+class TestListResources(IntegrationTestCase):
+	def test_list_resources_includes_sites_with_region(self):
+		site = frappe.get_all("Site", fields=["name", "team"], limit=1)
+		if not site:
+			self.skipTest("No Site available to union.")
+
+		result = resources.list_resources(site[0].team)
+		kinds = {r["kind"] for r in result["resources"]}
+		names = {r["name"] for r in result["resources"]}
+
+		self.assertIn("site", kinds)
+		self.assertIn(site[0].name, names)
+		self.assertTrue(all("region" in r for r in result["resources"]))
+
+	def test_terminate_site_routes_to_atlas(self):
+		rows = frappe.get_all("Site", fields=["name", "cluster"], filters={"status": ["!=", "Terminated"]}, limit=25)
+		site = next((r for r in rows if r.cluster and frappe.db.exists("Atlas Instance", r.cluster)), None)
+		if not site:
+			self.skipTest("No site with a known cluster to terminate.")
+
+		with patch("central.api.sites.AtlasClient") as Client:
+			result = sites.terminate_site(site.name)
+
+		Client.return_value.terminate_site.assert_called_once_with(site.name)
+		self.assertEqual(result["status"], "Terminating")

--- a/dashboard/src/api/methods.ts
+++ b/dashboard/src/api/methods.ts
@@ -43,6 +43,7 @@ export const API = {
 	stopServer: 'central.api.servers.stop_server',
 	terminateServer: 'central.api.servers.terminate_server',
 	listResources: 'central.api.resources.list_resources',
+	listSiteGroups: 'central.api.resources.list_site_groups',
 
 	// ── Auth / SMB signup (central.api.auth) ──
 	signUp: 'central.api.auth.sign_up',

--- a/dashboard/src/api/methods.ts
+++ b/dashboard/src/api/methods.ts
@@ -42,6 +42,7 @@ export const API = {
 	startServer: 'central.api.servers.start_server',
 	stopServer: 'central.api.servers.stop_server',
 	terminateServer: 'central.api.servers.terminate_server',
+	listResources: 'central.api.resources.list_resources',
 
 	// ── Auth / SMB signup (central.api.auth) ──
 	signUp: 'central.api.auth.sign_up',
@@ -53,6 +54,7 @@ export const API = {
 	siteDomain: 'central.api.sites.site_domain',
 	createSite: 'central.api.sites.create_site',
 	getSite: 'central.api.sites.get_site',
+	terminateSite: 'central.api.sites.terminate_site',
 
 	// ── SSO open-in-bench (central.api.sso) ──
 	getBenchLink: 'central.api.sso.get_bench_link',

--- a/dashboard/src/components/navigation/Sidebar.vue
+++ b/dashboard/src/components/navigation/Sidebar.vue
@@ -231,9 +231,9 @@ const onEdgeMove = (event: MouseEvent): void => {
 </template>
 
 <style scoped>
-/* frappe-ui Sidebar's built-in bottom Collapse/Expand item — replaced by the
-   edge strip above. (Selector tracks Sidebar.vue's footer container.) */
-.sb-wrap :deep(.mt-auto > [data-slot="sidebar-item"]:last-child) {
+/* frappe-ui Sidebar's built-in bottom Collapse/Expand item is the last child of
+   the footer container (`.mt-auto`) — hide it; the edge strip above replaces it. */
+.sb-wrap :deep(.mt-auto > :last-child) {
 	display: none;
 }
 

--- a/dashboard/src/components/servers/MapHealthStrips.vue
+++ b/dashboard/src/components/servers/MapHealthStrips.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+// Top-center strips over the map: stale-mirror warning first, then a load error
+// with retry. Presentational — the page owns the data and the retry action.
+defineProps<{ stale: string[]; error: string | null; hasRows: boolean }>()
+defineEmits<{ retry: [] }>()
+</script>
+
+<template>
+	<div class="pointer-events-none absolute inset-x-0 top-4 flex justify-center px-4">
+		<p
+			v-if="stale.length"
+			class="pointer-events-auto rounded-md bg-surface-amber-1 px-3 py-2 text-p-sm text-ink-amber-3 shadow-sm"
+		>
+			Showing last-known data — couldn't reach: {{ stale.join(', ') }}
+		</p>
+		<p
+			v-else-if="error && hasRows"
+			class="pointer-events-auto rounded-md bg-surface-red-1 px-3 py-2 text-p-sm text-ink-red-3 shadow-sm"
+		>
+			{{ error }}
+			<button class="ml-1 font-medium underline" @click="$emit('retry')">Retry</button>
+		</p>
+	</div>
+</template>

--- a/dashboard/src/components/servers/ServerFilters.vue
+++ b/dashboard/src/components/servers/ServerFilters.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { Select } from 'frappe-ui'
+import type { ServerVisual } from '@/lib/serverMap'
+
+// The top-right status + region filters over the map. Both scope the map pins
+// and the panel rows; the page owns the option lists and the resolved filters.
+defineProps<{
+	statusOptions: { label: string; value: string }[]
+	statusDot: string
+	regionOptions: { label: string; value: string }[]
+}>()
+
+const statusFilter = defineModel<ServerVisual['key'] | ''>('statusFilter', { required: true })
+const regionSelection = defineModel<string>('regionSelection', { required: true })
+</script>
+
+<template>
+	<div class="absolute right-4 top-4 flex items-center gap-2">
+		<Select v-model="statusFilter" variant="outline" size="md" :options="statusOptions">
+			<template #prefix>
+				<span
+					class="size-2 shrink-0 rounded-full transition-colors"
+					:style="{ background: statusDot }"
+				/>
+			</template>
+		</Select>
+		<Select v-model="regionSelection" variant="outline" size="md" :options="regionOptions" />
+	</div>
+</template>

--- a/dashboard/src/components/servers/ServerListPanel.vue
+++ b/dashboard/src/components/servers/ServerListPanel.vue
@@ -7,7 +7,7 @@ import type { AssetRow } from '@/composables/useServers'
 import type { ServerVisual } from '@/lib/serverMap'
 import type { Region } from '@/types/Central/Region'
 
-// The "Your assets" floating card: the pill IS the panel, collapsed. Opening
+// The "Your servers" floating card: the pill IS the panel, collapsed. Opening
 // morphs it in place (see <style>). Renders both kinds — a site is a 1:1-backed
 // VM, so servers and sites list side by side, distinguished by their content
 // (a site shows its domain, a server its hostname), not a badge. Presentational.
@@ -60,7 +60,7 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 		class="sp-float absolute left-4 top-4 z-30 overflow-hidden rounded-lg border border-outline-gray-2 bg-surface-elevation-1"
 		:class="open && 'sp-float-open'"
 		role="region"
-		aria-label="Your assets"
+		aria-label="Your servers"
 		@keydown.esc="open = false"
 	>
 		<button class="sp-float-pill text-base" :inert="open" @click="open = true">
@@ -164,10 +164,10 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 				<div v-if="!rows.length" class="m-4 flex flex-col items-center gap-1 py-8 text-center">
 					<span :class="hasRows ? 'lucide-search' : 'lucide-server'" class="mb-2 size-6 text-ink-gray-4" />
 					<p class="text-base font-medium text-ink-gray-8">
-						{{ hasRows ? 'No assets match' : 'No assets yet' }}
+						{{ hasRows ? 'No servers match' : 'No servers yet' }}
 					</p>
 					<p class="text-sm text-ink-gray-5">
-						{{ hasRows ? 'Try a different search or clear the filters.' : 'Create a server or site to get started.' }}
+						{{ hasRows ? 'Try a different search or clear the filters.' : 'Create your first server to host your sites.' }}
 					</p>
 				</div>
 			</div>
@@ -176,7 +176,7 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 </template>
 
 <style scoped>
-/* "Your assets" morph: one floating card whose size change carries the whole
+/* "Your servers" morph: one floating card whose size change carries the whole
    story — the pill grows into the panel in place. The two faces crossfade inside. */
 .sp-float {
 	--sp-ease: cubic-bezier(0.23, 1, 0.32, 1);

--- a/dashboard/src/components/servers/ServerListPanel.vue
+++ b/dashboard/src/components/servers/ServerListPanel.vue
@@ -2,28 +2,33 @@
 import { Badge, Button, FormControl } from 'frappe-ui'
 import ProviderAvatar from '@/components/servers/ProviderAvatar.vue'
 import ServerRowActions from '@/components/servers/ServerRowActions.vue'
+import SiteRowActions from '@/components/servers/SiteRowActions.vue'
 import type { AssetRow } from '@/composables/useServers'
 import type { ServerVisual } from '@/lib/serverMap'
 import type { Region } from '@/types/Central/Region'
 
-// The "Your servers" floating card: the pill IS the panel, collapsed. Opening
-// morphs it in place (see <style>). Presentational — the page owns the rows,
-// filters, and lifecycle commands; this forwards clicks and hover.
-export interface ServerRow {
+// The "Your assets" floating card: the pill IS the panel, collapsed. Opening
+// morphs it in place (see <style>). Renders both kinds — a site is a 1:1-backed
+// VM, so servers and sites list side by side, distinguished by their content
+// (a site shows its domain, a server its hostname), not a badge. Presentational.
+export interface ResourceRow {
+	kind: 'server' | 'site'
 	id: string
 	name: string
-	asset: AssetRow
 	visual: ServerVisual
 	specs: string
+	cluster: string
 	region: Region | undefined
 	regionLabel: string
 	flag: string
 	provider: string | null
+	asset?: AssetRow
+	site?: { name: string; url: string | null }
 }
 
 defineProps<{
 	pillLabel: string
-	rows: ServerRow[]
+	rows: ResourceRow[]
 	hasRows: boolean
 	locationFilter: { ids: string[]; label: string } | null
 	canOpen: boolean
@@ -34,13 +39,15 @@ defineProps<{
 }>()
 
 defineEmits<{
-	focusRow: [row: ServerRow]
+	focusRow: [row: ResourceRow]
 	clearLocation: []
 	open: [server: AssetRow]
 	start: [server: AssetRow]
 	stop: [server: AssetRow]
 	resize: [server: AssetRow]
 	terminate: [server: AssetRow]
+	openSite: [url: string]
+	terminateSite: [name: string]
 }>()
 
 const open = defineModel<boolean>('open', { required: true })
@@ -53,7 +60,7 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 		class="sp-float absolute left-4 top-4 z-30 overflow-hidden rounded-lg border border-outline-gray-2 bg-surface-elevation-1"
 		:class="open && 'sp-float-open'"
 		role="region"
-		aria-label="Your servers"
+		aria-label="Your assets"
 		@keydown.esc="open = false"
 	>
 		<button class="sp-float-pill text-base" :inert="open" @click="open = true">
@@ -102,7 +109,13 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 					@mouseleave="hoverId = null"
 				>
 					<span class="relative shrink-0">
-						<ProviderAvatar :provider="row.provider" :size="32" />
+						<ProviderAvatar v-if="row.kind === 'server'" :provider="row.provider" :size="32" />
+						<span
+							v-else
+							class="grid size-8 place-items-center rounded-full bg-surface-gray-2 text-ink-gray-6"
+						>
+							<span class="lucide-globe size-4" />
+						</span>
 						<span
 							class="absolute -bottom-px -right-px size-2.5 rounded-full border-2 border-[var(--surface-elevation-1)]"
 							:style="{ background: row.visual.dot }"
@@ -123,6 +136,7 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 					</span>
 					<span @click.stop>
 						<ServerRowActions
+							v-if="row.kind === 'server' && row.asset"
 							:server="row.asset"
 							:can-open="canOpen"
 							:can-power="canPower"
@@ -135,16 +149,25 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 							@resize="$emit('resize', $event)"
 							@terminate="$emit('terminate', $event)"
 						/>
+						<SiteRowActions
+							v-else-if="row.site"
+							:site="row.site"
+							:can-open="canOpen"
+							:can-terminate="canTerminate"
+							:busy="busy === row.id"
+							@open="$emit('openSite', $event)"
+							@terminate="$emit('terminateSite', $event)"
+						/>
 					</span>
 				</div>
 
 				<div v-if="!rows.length" class="m-4 flex flex-col items-center gap-1 py-8 text-center">
 					<span :class="hasRows ? 'lucide-search' : 'lucide-server'" class="mb-2 size-6 text-ink-gray-4" />
 					<p class="text-base font-medium text-ink-gray-8">
-						{{ hasRows ? 'No servers match' : 'No servers yet' }}
+						{{ hasRows ? 'No assets match' : 'No assets yet' }}
 					</p>
 					<p class="text-sm text-ink-gray-5">
-						{{ hasRows ? 'Try a different search or clear the filters.' : 'Create your first server to host your sites.' }}
+						{{ hasRows ? 'Try a different search or clear the filters.' : 'Create a server or site to get started.' }}
 					</p>
 				</div>
 			</div>
@@ -153,7 +176,7 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 </template>
 
 <style scoped>
-/* "Your servers" morph: one floating card whose size change carries the whole
+/* "Your assets" morph: one floating card whose size change carries the whole
    story — the pill grows into the panel in place. The two faces crossfade inside. */
 .sp-float {
 	--sp-ease: cubic-bezier(0.23, 1, 0.32, 1);

--- a/dashboard/src/components/servers/ServerListPanel.vue
+++ b/dashboard/src/components/servers/ServerListPanel.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { Badge, Button, FormControl } from 'frappe-ui'
 import ProviderAvatar from '@/components/servers/ProviderAvatar.vue'
 import ServerRowActions from '@/components/servers/ServerRowActions.vue'
@@ -26,7 +27,7 @@ export interface ResourceRow {
 	site?: { name: string; url: string | null }
 }
 
-defineProps<{
+const props = defineProps<{
 	pillLabel: string
 	rows: ResourceRow[]
 	hasRows: boolean
@@ -37,6 +38,13 @@ defineProps<{
 	busy: string | null
 	opening: string | null
 }>()
+
+// Servers list flat; sites collect into one "Sites" group below them. Rows arrive
+// servers-first, so a lone header before the first site row splits the two.
+const siteCount = computed(() => props.rows.filter((row) => row.kind === 'site').length)
+function isFirstSite(index: number): boolean {
+	return props.rows[index].kind === 'site' && (index === 0 || props.rows[index - 1].kind === 'server')
+}
 
 defineEmits<{
 	focusRow: [row: ResourceRow]
@@ -99,15 +107,20 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 			<div
 				class="min-h-0 flex-1 divide-y divide-outline-alpha-gray-1 overflow-y-auto border-t border-outline-alpha-gray-1 px-2 pb-2"
 			>
-				<div
-					v-for="(row, i) in rows"
-					:key="row.id"
-					class="sp-row group flex cursor-pointer items-center gap-3 rounded-lg px-2.5 py-2.5 transition-colors hover:bg-surface-gray-2"
-					:style="{ animationDelay: `${Math.min(i * 25, 200)}ms` }"
-					@click="$emit('focusRow', row)"
-					@mouseenter="hoverId = row.id"
-					@mouseleave="hoverId = null"
-				>
+				<template v-for="(row, i) in rows" :key="row.id">
+					<div
+						v-if="isFirstSite(i)"
+						class="px-2.5 pb-1 pt-3 text-xs font-medium text-ink-gray-5"
+					>
+						Sites · {{ siteCount }}
+					</div>
+					<div
+						class="sp-row group flex cursor-pointer items-center gap-3 rounded-lg px-2.5 py-2.5 transition-colors hover:bg-surface-gray-2"
+						:style="{ animationDelay: `${Math.min(i * 25, 200)}ms` }"
+						@click="$emit('focusRow', row)"
+						@mouseenter="hoverId = row.id"
+						@mouseleave="hoverId = null"
+					>
 					<span class="relative shrink-0">
 						<ProviderAvatar v-if="row.kind === 'server'" :provider="row.provider" :size="32" />
 						<span
@@ -160,6 +173,8 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 						/>
 					</span>
 				</div>
+
+				</template>
 
 				<div v-if="!rows.length" class="m-4 flex flex-col items-center gap-1 py-8 text-center">
 					<span :class="hasRows ? 'lucide-search' : 'lucide-server'" class="mb-2 size-6 text-ink-gray-4" />

--- a/dashboard/src/components/servers/ServerListPanel.vue
+++ b/dashboard/src/components/servers/ServerListPanel.vue
@@ -1,0 +1,239 @@
+<script setup lang="ts">
+import { Badge, Button, FormControl } from 'frappe-ui'
+import ProviderAvatar from '@/components/servers/ProviderAvatar.vue'
+import ServerRowActions from '@/components/servers/ServerRowActions.vue'
+import type { AssetRow } from '@/composables/useServers'
+import type { ServerVisual } from '@/lib/serverMap'
+import type { Region } from '@/types/Central/Region'
+
+// The "Your servers" floating card: the pill IS the panel, collapsed. Opening
+// morphs it in place (see <style>). Presentational — the page owns the rows,
+// filters, and lifecycle commands; this forwards clicks and hover.
+export interface ServerRow {
+	id: string
+	name: string
+	asset: AssetRow
+	visual: ServerVisual
+	specs: string
+	region: Region | undefined
+	regionLabel: string
+	flag: string
+	provider: string | null
+}
+
+defineProps<{
+	pillLabel: string
+	rows: ServerRow[]
+	hasRows: boolean
+	locationFilter: { ids: string[]; label: string } | null
+	canOpen: boolean
+	canPower: boolean
+	canTerminate: boolean
+	busy: string | null
+	opening: string | null
+}>()
+
+defineEmits<{
+	focusRow: [row: ServerRow]
+	clearLocation: []
+	open: [server: AssetRow]
+	start: [server: AssetRow]
+	stop: [server: AssetRow]
+	resize: [server: AssetRow]
+	terminate: [server: AssetRow]
+}>()
+
+const open = defineModel<boolean>('open', { required: true })
+const query = defineModel<string>('query', { required: true })
+const hoverId = defineModel<string | null>('hoverId', { required: true })
+</script>
+
+<template>
+	<section
+		class="sp-float absolute left-4 top-4 z-30 overflow-hidden rounded-lg border border-outline-gray-2 bg-surface-elevation-1"
+		:class="open && 'sp-float-open'"
+		role="region"
+		aria-label="Your servers"
+		@keydown.esc="open = false"
+	>
+		<button class="sp-float-pill text-base" :inert="open" @click="open = true">
+			<span class="truncate">{{ pillLabel }}</span>
+			<span class="lucide-maximize-2 size-3.5 shrink-0 text-ink-gray-6" />
+		</button>
+
+		<div class="sp-float-panel flex h-full min-h-0 flex-col" :inert="!open" :aria-hidden="!open">
+			<div class="flex shrink-0 items-center justify-between gap-2 px-4 pb-2 pt-3">
+				<h2 class="truncate text-base font-semibold text-ink-gray-9">{{ pillLabel }}</h2>
+				<Button variant="ghost" icon="lucide-minimize-2" aria-label="Collapse list" @click="open = false" />
+			</div>
+			<div class="shrink-0 px-4 pb-3">
+				<FormControl v-model="query" type="text" placeholder="Search" autocomplete="off" class="[&_input]:w-full">
+					<template #prefix><span class="lucide-search size-4 text-ink-gray-5" /></template>
+				</FormControl>
+			</div>
+
+			<div
+				v-if="locationFilter"
+				class="flex shrink-0 items-center justify-between gap-3 px-4 pb-2.5"
+			>
+				<span class="min-w-0 truncate text-sm text-ink-gray-5">
+					Filtering for
+					<span class="font-medium text-ink-gray-8">{{ locationFilter.label }}</span>
+				</span>
+				<button
+					class="flex shrink-0 items-center gap-1.5 text-sm text-ink-gray-6 transition-colors hover:text-ink-gray-8"
+					@click="$emit('clearLocation')"
+				>
+					<span class="lucide-filter size-3.5" />
+					Clear
+				</button>
+			</div>
+
+			<div
+				class="min-h-0 flex-1 divide-y divide-outline-alpha-gray-1 overflow-y-auto border-t border-outline-alpha-gray-1 px-2 pb-2"
+			>
+				<div
+					v-for="(row, i) in rows"
+					:key="row.id"
+					class="sp-row group flex cursor-pointer items-center gap-3 rounded-lg px-2.5 py-2.5 transition-colors hover:bg-surface-gray-2"
+					:style="{ animationDelay: `${Math.min(i * 25, 200)}ms` }"
+					@click="$emit('focusRow', row)"
+					@mouseenter="hoverId = row.id"
+					@mouseleave="hoverId = null"
+				>
+					<span class="relative shrink-0">
+						<ProviderAvatar :provider="row.provider" :size="32" />
+						<span
+							class="absolute -bottom-px -right-px size-2.5 rounded-full border-2 border-[var(--surface-elevation-1)]"
+							:style="{ background: row.visual.dot }"
+						/>
+					</span>
+					<span class="min-w-0 flex-1">
+						<span class="flex items-center gap-1.5">
+							<span class="truncate text-sm font-medium text-ink-gray-9">{{ row.name }}</span>
+							<Badge
+								v-if="row.visual.key !== 'active'"
+								:label="row.visual.label"
+								:theme="row.visual.badgeTheme"
+								variant="subtle"
+								size="sm"
+							/>
+						</span>
+						<span class="block truncate text-sm text-ink-gray-5">{{ row.specs || row.regionLabel }}</span>
+					</span>
+					<span @click.stop>
+						<ServerRowActions
+							:server="row.asset"
+							:can-open="canOpen"
+							:can-power="canPower"
+							:can-terminate="canTerminate"
+							:busy="busy === row.id"
+							:opening="opening === row.id"
+							@open="$emit('open', $event)"
+							@start="$emit('start', $event)"
+							@stop="$emit('stop', $event)"
+							@resize="$emit('resize', $event)"
+							@terminate="$emit('terminate', $event)"
+						/>
+					</span>
+				</div>
+
+				<div v-if="!rows.length" class="m-4 flex flex-col items-center gap-1 py-8 text-center">
+					<span :class="hasRows ? 'lucide-search' : 'lucide-server'" class="mb-2 size-6 text-ink-gray-4" />
+					<p class="text-base font-medium text-ink-gray-8">
+						{{ hasRows ? 'No servers match' : 'No servers yet' }}
+					</p>
+					<p class="text-sm text-ink-gray-5">
+						{{ hasRows ? 'Try a different search or clear the filters.' : 'Create your first server to host your sites.' }}
+					</p>
+				</div>
+			</div>
+		</div>
+	</section>
+</template>
+
+<style scoped>
+/* "Your servers" morph: one floating card whose size change carries the whole
+   story — the pill grows into the panel in place. The two faces crossfade inside. */
+.sp-float {
+	--sp-ease: cubic-bezier(0.23, 1, 0.32, 1);
+	width: 10.5rem;
+	height: 2rem;
+	border-radius: 0.5rem;
+	box-shadow: var(--shadow-sm, 0 1px 2px rgb(0 0 0 / 0.05));
+	transition:
+		width 180ms var(--sp-ease),
+		height 180ms var(--sp-ease),
+		border-radius 180ms var(--sp-ease),
+		box-shadow 180ms var(--sp-ease);
+}
+.sp-float-open {
+	width: 24rem;
+	height: calc(100% - 2rem);
+	border-radius: 0.75rem;
+	box-shadow: var(--shadow-xl, 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1));
+	transition-duration: 220ms;
+}
+.sp-float-pill {
+	position: absolute;
+	left: 0;
+	top: 0;
+	display: flex;
+	height: 2rem;
+	width: 10.5rem;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.625rem;
+	padding: 0 0.625rem;
+	font-weight: 420;
+	color: var(--ink-gray-7);
+	transition:
+		opacity 120ms ease-out,
+		background-color 150ms ease;
+}
+.sp-float-pill:hover {
+	background: var(--surface-gray-1);
+}
+.sp-float-open .sp-float-pill {
+	opacity: 0;
+}
+.sp-float-panel {
+	opacity: 0;
+	transform: translateY(4px);
+	transition:
+		opacity 140ms ease-out,
+		transform 220ms var(--sp-ease);
+}
+.sp-float-open .sp-float-panel {
+	opacity: 1;
+	transform: none;
+	transition-delay: 40ms;
+}
+
+/* Rows cascade in as the panel opens — brief, then out of the way. */
+.sp-row {
+	animation: sp-row-in 250ms cubic-bezier(0.23, 1, 0.32, 1) both;
+}
+@keyframes sp-row-in {
+	from {
+		opacity: 0;
+		transform: translateY(6px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.sp-float,
+	.sp-float-pill,
+	.sp-float-panel {
+		transition-duration: 1ms;
+		transition-delay: 0ms;
+	}
+	.sp-row {
+		animation: none;
+	}
+}
+</style>

--- a/dashboard/src/components/servers/ServerListPanel.vue
+++ b/dashboard/src/components/servers/ServerListPanel.vue
@@ -115,7 +115,7 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 						Sites · {{ siteCount }}
 					</div>
 					<div
-						class="sp-row group flex cursor-pointer items-center gap-3 rounded-lg px-2.5 py-2.5 transition-colors hover:bg-surface-gray-2"
+						class="sp-row group flex cursor-pointer items-center gap-3 rounded-lg px-2.5 py-2.5 transition-colors"
 						:style="{ animationDelay: `${Math.min(i * 25, 200)}ms` }"
 						@click="$emit('focusRow', row)"
 						@mouseenter="hoverId = row.id"
@@ -147,7 +147,11 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 						</span>
 						<span class="block truncate text-sm text-ink-gray-5">{{ row.specs || row.regionLabel }}</span>
 					</span>
-					<span @click.stop>
+					<span
+						class="sp-row-actions"
+						:class="{ 'sp-row-actions-active': busy === row.id || opening === row.id }"
+						@click.stop
+					>
 						<ServerRowActions
 							v-if="row.kind === 'server' && row.asset"
 							:server="row.asset"
@@ -252,6 +256,24 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 .sp-row {
 	animation: sp-row-in 250ms cubic-bezier(0.23, 1, 0.32, 1) both;
 }
+.sp-row:hover:not(:has(.sp-row-actions:hover)),
+.sp-row:focus-within:not(:has(.sp-row-actions:focus-within)) {
+	background: var(--surface-gray-2);
+}
+.sp-row-actions {
+	display: flex;
+	align-self: stretch;
+	align-items: center;
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 120ms ease-out;
+}
+.sp-row:hover .sp-row-actions,
+.sp-row:focus-within .sp-row-actions,
+.sp-row-actions-active {
+	opacity: 1;
+	pointer-events: auto;
+}
 @keyframes sp-row-in {
 	from {
 		opacity: 0;
@@ -272,6 +294,13 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 	}
 	.sp-row {
 		animation: none;
+	}
+}
+
+@media (hover: none), (pointer: coarse) {
+	.sp-row-actions {
+		opacity: 1;
+		pointer-events: auto;
 	}
 }
 </style>

--- a/dashboard/src/components/servers/ServerListPanel.vue
+++ b/dashboard/src/components/servers/ServerListPanel.vue
@@ -105,12 +105,12 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 			</div>
 
 			<div
-				class="min-h-0 flex-1 divide-y divide-outline-alpha-gray-1 overflow-y-auto border-t border-outline-alpha-gray-1 px-2 pb-2"
+				class="min-h-0 flex-1 overflow-y-auto border-t border-outline-alpha-gray-1 px-2 pb-2 pt-1"
 			>
 				<template v-for="(row, i) in rows" :key="row.id">
 					<div
 						v-if="isFirstSite(i)"
-						class="px-2.5 pb-1 pt-3 text-xs font-medium text-ink-gray-5"
+						class="mt-1 border-t border-outline-alpha-gray-1 px-2.5 pb-1 pt-2.5 text-xs font-medium text-ink-gray-5"
 					>
 						Sites · {{ siteCount }}
 					</div>

--- a/dashboard/src/components/servers/ServerMap.vue
+++ b/dashboard/src/components/servers/ServerMap.vue
@@ -19,6 +19,7 @@ import {
 	ZOOM_STEP,
 	type MapNode,
 	type MapPin,
+	type MapSite,
 	type MapSpot,
 } from '@/lib/serverMap'
 
@@ -30,6 +31,8 @@ const props = withDefaults(
 	defineProps<{
 		pins?: MapPin[]
 		spots?: MapSpot[]
+		/** Sites keyed by region code — surfaced in that region's hover card. */
+		sitesByRegion?: Record<string, MapSite[]>
 		/** Region-picker mode: render these as selectable dots instead of pins/spots. */
 		markers?: MapSpot[]
 		/** The picked marker — drawn as the provider-logo pin. */
@@ -48,6 +51,7 @@ const props = withDefaults(
 	{
 		pins: () => [],
 		spots: () => [],
+		sitesByRegion: () => ({}),
 		markers: () => [],
 		selectedId: null,
 		highlightId: null,
@@ -63,6 +67,8 @@ const emit = defineEmits<{
 	open: [id: string]
 	/** A cluster-card row's external-link action was chosen. */
 	'open-server': [server: MapPin['server']]
+	/** A site listed in a region's hover card opened its live site. */
+	'open-site': [url: string]
 	/** A + spot was chosen — the Atlas Instance region to create in. */
 	'new-server': [region: string]
 	/** A cluster was clicked; the page may narrow its list to these servers. */
@@ -386,6 +392,16 @@ function cancelHide(): void {
 function canOpenBench(server: MapPin['server']): boolean {
 	return props.allowOpen && server.status === 'Running' && !!server.gateway_url
 }
+
+// Sites don't pin; they surface in the hover card of the region they sit in. A
+// single pin shows its own region's sites; a cluster unions its members' regions.
+function sitesForPin(pin: MapPin): MapSite[] {
+	return props.sitesByRegion[pin.cluster] ?? []
+}
+function sitesForCluster(members: MapPin[]): MapSite[] {
+	const regions = new Set(members.map((m) => m.cluster))
+	return [...regions].flatMap((region) => props.sitesByRegion[region] ?? [])
+}
 function hideCard(): void {
 	window.clearTimeout(showT)
 	window.clearTimeout(hideT)
@@ -679,6 +695,35 @@ function clickNode(n: MapNode): void {
 							>{{ card.node.pin.frappeVersion }}</span
 						>
 					</div>
+					<div
+						v-if="sitesForPin(card.node.pin).length"
+						class="mt-3 border-t border-outline-alpha-gray-1 pt-2"
+					>
+						<div class="px-0.5 pb-1 text-xs font-medium text-ink-gray-5">
+							Sites in this region
+						</div>
+						<button
+							v-for="site in sitesForPin(card.node.pin)"
+							:key="site.name"
+							class="group flex w-full items-center gap-2 rounded-lg p-1.5 text-left transition-colors hover:bg-surface-gray-2 disabled:cursor-default"
+							:disabled="!allowOpen || !site.url"
+							@click.stop="site.url && emit('open-site', site.url)"
+						>
+							<span
+								class="relative grid size-6 shrink-0 place-items-center rounded-full bg-surface-gray-2 text-ink-gray-6"
+							>
+								<span class="lucide-globe size-3.5" />
+								<span
+									class="absolute -bottom-px -right-px size-2 rounded-full border-2 border-[var(--surface-elevation-1)]"
+									:style="{ background: site.visual.dot }"
+								/>
+							</span>
+							<span class="min-w-0 flex-1 truncate text-sm text-ink-gray-8">{{ site.name }}</span>
+							<span
+								class="lucide-arrow-up-right size-3.5 shrink-0 text-ink-gray-5 opacity-0 transition-opacity group-hover:opacity-100 group-disabled:opacity-0"
+							/>
+						</button>
+					</div>
 				</template>
 
 				<!-- Cluster: the servers at this spot -->
@@ -733,6 +778,34 @@ function clickNode(n: MapNode): void {
 							@click.stop="emit('open-server', m.server)"
 						>
 							<span class="lucide-arrow-up-right size-3.5" />
+						</button>
+					</div>
+					<!-- Sites at this spot's regions — discoverable, opened in place. -->
+					<div
+						v-if="sitesForCluster(card.node.members).length"
+						class="mt-1 border-t border-outline-alpha-gray-1 pt-1"
+					>
+						<div class="px-1.5 pb-1 pt-1 text-xs font-medium text-ink-gray-5">Sites</div>
+						<button
+							v-for="site in sitesForCluster(card.node.members)"
+							:key="site.name"
+							class="group flex w-full items-center gap-2.5 rounded-lg p-1.5 text-left transition-colors hover:bg-surface-gray-2 disabled:cursor-default"
+							:disabled="!allowOpen || !site.url"
+							@click.stop="site.url && emit('open-site', site.url)"
+						>
+							<span class="relative shrink-0">
+								<span class="grid size-7 place-items-center rounded-full bg-surface-gray-2 text-ink-gray-6">
+									<span class="lucide-globe size-3.5" />
+								</span>
+								<span
+									class="absolute -bottom-px -right-px size-2.5 rounded-full border-2 border-[var(--surface-elevation-1)]"
+									:style="{ background: site.visual.dot }"
+								/>
+							</span>
+							<span class="min-w-0 flex-1 truncate text-sm font-medium text-ink-gray-8">{{ site.name }}</span>
+							<span
+								class="lucide-arrow-up-right size-3.5 shrink-0 text-ink-gray-5 opacity-0 transition-opacity group-hover:opacity-100 group-disabled:opacity-0"
+							/>
 						</button>
 					</div>
 				</template>

--- a/dashboard/src/components/servers/ServerMap.vue
+++ b/dashboard/src/components/servers/ServerMap.vue
@@ -31,8 +31,9 @@ const props = withDefaults(
 	defineProps<{
 		pins?: MapPin[]
 		spots?: MapSpot[]
-		/** Sites keyed by region code — surfaced in that region's hover card. */
-		sitesByRegion?: Record<string, MapSite[]>
+		/** Sites keyed by region code — surfaced in that region's hover card. `count`
+		 *  is the exact total; `sites` may be a capped preview of it. */
+		sitesByRegion?: Record<string, { count: number; sites: MapSite[] }>
 		/** Region-picker mode: render these as selectable dots instead of pins/spots. */
 		markers?: MapSpot[]
 		/** The picked marker — drawn as the provider-logo pin. */
@@ -395,12 +396,22 @@ function canOpenBench(server: MapPin['server']): boolean {
 
 // Sites don't pin; they surface in the hover card of the region they sit in. A
 // single pin shows its own region's sites; a cluster unions its members' regions.
-function sitesForPin(pin: MapPin): MapSite[] {
-	return props.sitesByRegion[pin.cluster] ?? []
+// The card lists a few and reports the true total (which may exceed the preview).
+const CARD_SITE_LIMIT = 5
+function sitesForPin(pin: MapPin): { count: number; sites: MapSite[] } {
+	return props.sitesByRegion[pin.cluster] ?? { count: 0, sites: [] }
 }
-function sitesForCluster(members: MapPin[]): MapSite[] {
+function sitesForCluster(members: MapPin[]): { count: number; sites: MapSite[] } {
 	const regions = new Set(members.map((m) => m.cluster))
-	return [...regions].flatMap((region) => props.sitesByRegion[region] ?? [])
+	let count = 0
+	const sites: MapSite[] = []
+	for (const region of regions) {
+		const group = props.sitesByRegion[region]
+		if (!group) continue
+		count += group.count
+		sites.push(...group.sites)
+	}
+	return { count, sites }
 }
 function hideCard(): void {
 	window.clearTimeout(showT)
@@ -470,6 +481,15 @@ const card = computed<CardPlacement | null>(() => {
 			'--smc-dx': side === 'right' ? '-6px' : '6px',
 		} as CSSProperties,
 	}
+})
+
+// The hovered region's sites (pin's own region, or a cluster's union) — resolved
+// once for the card templates.
+const cardSites = computed<{ count: number; sites: MapSite[] }>(() => {
+	const node = card.value?.node
+	if (node?.type === 'server') return sitesForPin(node.pin)
+	if (node?.type === 'cluster') return sitesForCluster(node.members)
+	return { count: 0, sites: [] }
 })
 
 // Let the page focus the map from the side panel: glide to the node that
@@ -696,14 +716,14 @@ function clickNode(n: MapNode): void {
 						>
 					</div>
 					<div
-						v-if="sitesForPin(card.node.pin).length"
+						v-if="cardSites.count"
 						class="mt-3 border-t border-outline-alpha-gray-1 pt-2"
 					>
 						<div class="px-0.5 pb-1 text-xs font-medium text-ink-gray-5">
-							Sites in this region
+							Sites in this region · {{ cardSites.count }}
 						</div>
 						<button
-							v-for="site in sitesForPin(card.node.pin)"
+							v-for="site in cardSites.sites.slice(0, CARD_SITE_LIMIT)"
 							:key="site.name"
 							class="group flex w-full items-center gap-2 rounded-lg p-1.5 text-left transition-colors hover:bg-surface-gray-2 disabled:cursor-default"
 							:disabled="!allowOpen || !site.url"
@@ -723,6 +743,12 @@ function clickNode(n: MapNode): void {
 								class="lucide-arrow-up-right size-3.5 shrink-0 text-ink-gray-5 opacity-0 transition-opacity group-hover:opacity-100 group-disabled:opacity-0"
 							/>
 						</button>
+						<div
+							v-if="cardSites.count > CARD_SITE_LIMIT"
+							class="px-1.5 pt-1 text-xs text-ink-gray-5"
+						>
+							+{{ cardSites.count - CARD_SITE_LIMIT }} more
+						</div>
 					</div>
 				</template>
 
@@ -780,14 +806,16 @@ function clickNode(n: MapNode): void {
 							<span class="lucide-arrow-up-right size-3.5" />
 						</button>
 					</div>
-					<!-- Sites at this spot's regions — discoverable, opened in place. -->
+					<!-- Sites across this spot's regions — discoverable, opened in place. -->
 					<div
-						v-if="sitesForCluster(card.node.members).length"
+						v-if="cardSites.count"
 						class="mt-1 border-t border-outline-alpha-gray-1 pt-1"
 					>
-						<div class="px-1.5 pb-1 pt-1 text-xs font-medium text-ink-gray-5">Sites</div>
+						<div class="px-1.5 pb-1 pt-1 text-xs font-medium text-ink-gray-5">
+							Sites · {{ cardSites.count }}
+						</div>
 						<button
-							v-for="site in sitesForCluster(card.node.members)"
+							v-for="site in cardSites.sites.slice(0, CARD_SITE_LIMIT)"
 							:key="site.name"
 							class="group flex w-full items-center gap-2.5 rounded-lg p-1.5 text-left transition-colors hover:bg-surface-gray-2 disabled:cursor-default"
 							:disabled="!allowOpen || !site.url"
@@ -807,6 +835,12 @@ function clickNode(n: MapNode): void {
 								class="lucide-arrow-up-right size-3.5 shrink-0 text-ink-gray-5 opacity-0 transition-opacity group-hover:opacity-100 group-disabled:opacity-0"
 							/>
 						</button>
+						<div
+							v-if="cardSites.count > CARD_SITE_LIMIT"
+							class="px-1.5 pt-1 text-xs text-ink-gray-5"
+						>
+							+{{ cardSites.count - CARD_SITE_LIMIT }} more
+						</div>
 					</div>
 				</template>
 

--- a/dashboard/src/components/servers/SiteRowActions.vue
+++ b/dashboard/src/components/servers/SiteRowActions.vue
@@ -29,6 +29,6 @@ const options = computed(() => {
 
 <template>
 	<Dropdown v-if="options.length" :options="options" placement="right">
-		<Button variant="ghost" icon="lucide-more-horizontal" :loading="busy" aria-label="Site actions" />
+		<Button variant="ghost" icon="lucide-ellipsis-vertical" :loading="busy" aria-label="Site actions" />
 	</Dropdown>
 </template>

--- a/dashboard/src/components/servers/SiteRowActions.vue
+++ b/dashboard/src/components/servers/SiteRowActions.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Button, Dropdown } from 'frappe-ui'
+
+// The actions menu for one site row in the unified assets list. A site is a
+// 1:1-backed VM, so it reuses the server capabilities (site-level caps are
+// deferred). Presentational — it emits the verb; the page owns the calls.
+const props = defineProps<{
+	site: { name: string; url: string | null }
+	canOpen: boolean
+	canTerminate: boolean
+	busy?: boolean
+}>()
+
+const emit = defineEmits<{
+	open: [url: string]
+	terminate: [name: string]
+}>()
+
+const options = computed(() => {
+	const items = []
+	if (props.canOpen && props.site.url)
+		items.push({ label: 'Open site', icon: 'lucide-external-link', onClick: () => emit('open', props.site.url!) })
+	if (props.canTerminate)
+		items.push({ label: 'Terminate', icon: 'lucide-trash-2', theme: 'red' as const, onClick: () => emit('terminate', props.site.name) })
+	return items
+})
+</script>
+
+<template>
+	<Dropdown v-if="options.length" :options="options" placement="right">
+		<Button variant="ghost" icon="lucide-more-horizontal" :loading="busy" aria-label="Site actions" />
+	</Dropdown>
+</template>

--- a/dashboard/src/components/servers/TerminateDialog.vue
+++ b/dashboard/src/components/servers/TerminateDialog.vue
@@ -3,8 +3,6 @@ import { computed } from 'vue'
 import { Dialog } from 'frappe-ui'
 import type { AssetRow } from '@/composables/useServers'
 
-// Destructive, irreversible confirm for terminating a server. Controlled by the
-// page: pass the pending server (or null) via v-model:server.
 const props = defineProps<{
 	server: AssetRow | null
 	loading?: boolean
@@ -22,16 +20,11 @@ const open = computed({
 	},
 })
 
-const name = computed(
-	() => props.server?.title || props.server?.resource_id || '',
-)
-
+const name = computed(() => props.server?.title || props.server?.resource_id || '')
 const dialogOptions = computed(() => ({
-	title: 'Terminate server',
-	message: `Permanently destroy ${name.value}? This can't be undone.`,
 	actions: [
 		{
-			label: 'Terminate',
+			label: 'Yes, terminate',
 			variant: 'solid' as const,
 			theme: 'red' as const,
 			loading: props.loading,
@@ -44,10 +37,9 @@ const dialogOptions = computed(() => ({
 </script>
 
 <template>
-	<Dialog
-		v-model="open"
-		:title="dialogOptions.title"
-		:message="dialogOptions.message"
-		:actions="dialogOptions.actions"
-	/>
+	<Dialog v-model="open" title="Terminate server" size="sm" :actions="dialogOptions.actions">
+		<p class="text-p-base text-ink-gray-7">
+			Permanently destroy <span class="font-semibold text-ink-gray-9">{{ name }}</span>? This can't be undone.
+		</p>
+	</Dialog>
 </template>

--- a/dashboard/src/composables/useSites.ts
+++ b/dashboard/src/composables/useSites.ts
@@ -1,0 +1,51 @@
+import { computed } from 'vue'
+import { useCall } from 'frappe-ui'
+import { API, method } from '@/api/methods'
+import { teamParams, whenTeamReady } from '@/composables/useTeamScope'
+import { useFrappeListInvalidation } from '@/composables/common/useFrappeRealtime'
+import { getErrorMessage } from '@/lib/toast'
+
+// The team's sites for the unified assets view. Reuses central.api.resources.list_resources
+// (server:view gated, team-scoped) filtered to kind=site, so servers aren't refetched here —
+// the rich server feed stays in useServerMapData. The Site mirror is kept fresh by Atlas's
+// site.* event push; the realtime invalidation below reloads on any Site change.
+export interface SiteResource {
+	kind: 'site'
+	name: string
+	label: string
+	status: string
+	region: string | null
+	detail: string | null
+}
+
+type ResourcesResponse = { team: string; resources: SiteResource[] }
+
+const feed = useCall<ResourcesResponse, { team: string; kind: string }>({
+	url: method(API.listResources),
+	params: () => ({ ...teamParams(), kind: 'site' }),
+	refetch: true,
+	immediate: false,
+})
+
+whenTeamReady(() => feed.reload())
+
+let reloadTimer: number | undefined
+function reloadOnce(): void {
+	window.clearTimeout(reloadTimer)
+	reloadTimer = window.setTimeout(() => feed.reload(), 150)
+}
+
+export function useSites() {
+	useFrappeListInvalidation('Site', reloadOnce, { debounceMs: 0 })
+
+	return {
+		sites: computed<SiteResource[]>(() =>
+			(feed.data?.resources ?? []).filter((site) => site.status !== 'Terminated'),
+		),
+		loading: computed(() => feed.loading),
+		error: computed(() =>
+			feed.error ? getErrorMessage(feed.error, "Couldn't load sites.") : null,
+		),
+		reload: () => feed.reload(),
+	}
+}

--- a/dashboard/src/composables/useSites.ts
+++ b/dashboard/src/composables/useSites.ts
@@ -5,10 +5,11 @@ import { teamParams, whenTeamReady } from '@/composables/useTeamScope'
 import { useFrappeListInvalidation } from '@/composables/common/useFrappeRealtime'
 import { getErrorMessage } from '@/lib/toast'
 
-// The team's sites for the unified assets view. Reuses central.api.resources.list_resources
-// (server:view gated, team-scoped) filtered to kind=site, so servers aren't refetched here —
-// the rich server feed stays in useServerMapData. The Site mirror is kept fresh by Atlas's
-// site.* event push; the realtime invalidation below reloads on any Site change.
+// The team's sites for the unified servers view, from central.api.resources.list_site_groups
+// (server:view gated, team-scoped). The DB groups by region, counts, and caps each region to
+// a preview, so the payload never scales with a team's site count — `count` is the exact total,
+// `sites` the (possibly capped) rows to list. The Site mirror is kept fresh by Atlas's site.*
+// event push; the realtime invalidation below reloads on any Site change.
 export interface SiteResource {
 	kind: 'site'
 	name: string
@@ -18,11 +19,17 @@ export interface SiteResource {
 	detail: string | null
 }
 
-type ResourcesResponse = { team: string; resources: SiteResource[] }
+interface SiteGroup {
+	region: string | null
+	count: number
+	sites: { name: string; status: string; url: string | null }[]
+}
 
-const feed = useCall<ResourcesResponse, { team: string; kind: string }>({
-	url: method(API.listResources),
-	params: () => ({ ...teamParams(), kind: 'site' }),
+type SiteGroupsResponse = { team: string; groups: SiteGroup[] }
+
+const feed = useCall<SiteGroupsResponse, { team: string }>({
+	url: method(API.listSiteGroups),
+	params: () => teamParams(),
 	refetch: true,
 	immediate: false,
 })
@@ -38,9 +45,25 @@ function reloadOnce(): void {
 export function useSites() {
 	useFrappeListInvalidation('Site', reloadOnce, { debounceMs: 0 })
 
+	const groups = computed<SiteGroup[]>(() => feed.data?.groups ?? [])
+
 	return {
+		// Flat rows for the searchable panel; each group's preview, region-tagged.
 		sites: computed<SiteResource[]>(() =>
-			(feed.data?.resources ?? []).filter((site) => site.status !== 'Terminated'),
+			groups.value.flatMap((group) =>
+				group.sites.map((site) => ({
+					kind: 'site' as const,
+					name: site.name,
+					label: site.name,
+					status: site.status,
+					region: group.region,
+					detail: site.url,
+				})),
+			),
+		),
+		// Exact per-region totals from the DB (may exceed the previewed rows).
+		siteCountByRegion: computed<Record<string, number>>(() =>
+			Object.fromEntries(groups.value.map((group) => [group.region ?? '', group.count])),
 		),
 		loading: computed(() => feed.loading),
 		error: computed(() =>

--- a/dashboard/src/lib/serverMap.ts
+++ b/dashboard/src/lib/serverMap.ts
@@ -155,6 +155,9 @@ export interface MapPin {
 	lng: number
 	provider: string | null
 	visual: ServerVisual
+	/** Region code — the region a cluster's "new server" routes to, and the key a
+	 *  region's sites are looked up under for the hover card. */
+	cluster: string
 	/** Clean "Mumbai, India" — cluster titles derive the country from it. */
 	regionLabel: string
 	/** Flag emoji for the hover card's region line ('' when unknown). */
@@ -165,6 +168,15 @@ export interface MapPin {
 	frappeVersion: string | null
 	/** The raw row, for the actions menu the page wires in. */
 	server: AssetRow
+}
+
+/** A site surfaced inside a region's hover card. Sites don't pin (they'd clutter
+ *  the map, and a server can host many); they're discovered through the region
+ *  they sit in and listed flat in the side panel's "Sites" group. */
+export interface MapSite {
+	name: string
+	url: string | null
+	visual: ServerVisual
 }
 
 /** An empty Active region — a "+" affordance on the map. */
@@ -410,8 +422,8 @@ export function computeNodes({
 // assets list (and its status filter) can treat a site like the VM it is.
 export function siteVisual(status: string): ServerVisual {
 	if (status === 'Running')
-		return { key: 'active', label: 'Running', badgeTheme: 'green', dot: 'var(--ink-green-7)' }
+		return { key: 'active', label: 'Running', badgeTheme: 'green', dot: 'var(--ink-green-7)', pulse: false }
 	if (status === 'Failed')
-		return { key: 'broken', label: 'Failed', badgeTheme: 'red', dot: 'var(--ink-red-7)' }
-	return { key: 'settingUp', label: status, badgeTheme: 'orange', dot: 'var(--ink-amber-7)' }
+		return { key: 'broken', label: 'Failed', badgeTheme: 'red', dot: 'var(--ink-red-7)', pulse: true }
+	return { key: 'settingUp', label: status, badgeTheme: 'orange', dot: 'var(--ink-amber-7)', pulse: false }
 }

--- a/dashboard/src/lib/serverMap.ts
+++ b/dashboard/src/lib/serverMap.ts
@@ -405,3 +405,13 @@ export function computeNodes({
 	}
 	return out
 }
+
+// A site's status mapped onto the shared server visual vocabulary, so the unified
+// assets list (and its status filter) can treat a site like the VM it is.
+export function siteVisual(status: string): ServerVisual {
+	if (status === 'Running')
+		return { key: 'active', label: 'Running', badgeTheme: 'green', dot: 'var(--ink-green-7)' }
+	if (status === 'Failed')
+		return { key: 'broken', label: 'Failed', badgeTheme: 'red', dot: 'var(--ink-red-7)' }
+	return { key: 'settingUp', label: status, badgeTheme: 'orange', dot: 'var(--ink-amber-7)' }
+}

--- a/dashboard/src/pages/servers/ServersPage.vue
+++ b/dashboard/src/pages/servers/ServersPage.vue
@@ -37,7 +37,7 @@ import type { AssetRow } from '@/composables/useServers'
 import type { Region } from '@/types/Central/Region'
 import type { ResourceRow } from '@/components/servers/ServerListPanel.vue'
 
-// The assets page: the world map is the list (FC V2). Servers (the Asset mirror)
+// The servers page: the world map is the list (FC V2). Servers (the Asset mirror)
 // and sites (the Site mirror — each a 1:1-backed VM) list together; a slide-in
 // panel carries the searchable rows. Lifecycle actions reuse useServers /
 // useSites so the map, panel, and ⋯ menus share one command path.
@@ -233,8 +233,8 @@ const panelRows = computed(() => {
 
 const pillLabel = computed(() =>
 	statusFilter.value || regionFilter.value.provider || regionFilter.value.region
-		? `Assets (${filtered.value.length})`
-		: `All assets (${filtered.value.length})`,
+		? `Servers (${filtered.value.length})`
+		: `All servers (${filtered.value.length})`,
 )
 
 // — Map data. Only servers pin today (a site's pin/hover card is a follow-up);
@@ -349,7 +349,7 @@ async function confirmSiteTerminate(): Promise<void> {
 
 <template>
 	<div class="flex h-full flex-col">
-		<PageHeader title="Assets">
+		<PageHeader title="Servers">
 			<template #actions>
 				<Button
 					v-if="activeTeam"
@@ -471,7 +471,7 @@ async function confirmSiteTerminate(): Promise<void> {
 				v-else-if="error && !rows.length"
 				icon="lucide-circle-alert"
 				icon-class="text-ink-red-5"
-				title="Couldn't load your assets"
+				title="Couldn't load your servers"
 				:description="error"
 			>
 				<template #action>

--- a/dashboard/src/pages/servers/ServersPage.vue
+++ b/dashboard/src/pages/servers/ServersPage.vue
@@ -46,7 +46,7 @@ import type { ResourceRow } from '@/components/servers/ServerListPanel.vue'
 const router = useRouter()
 
 const { assets, loading, error, reload } = useServerMapData()
-const { sites, reload: reloadSites } = useSites()
+const { sites, siteCountByRegion, reload: reloadSites } = useSites()
 const { regions } = useRegions()
 const { canPowerServer, canTerminateServer, canOpenServer, canCreateServer } =
 	useCapabilities()
@@ -263,18 +263,15 @@ const pins = computed<MapPin[]>(() =>
 		})),
 )
 
-// Sites grouped by region code for the map's hover cards. Grouped client-side —
-// the sites feed is already loaded and small; move the grouping/count into a SQL
-// aggregation in list_resources if a team's site count ever grows large.
-const sitesByRegion = computed<Record<string, MapSite[]>>(() => {
-	const grouped: Record<string, MapSite[]> = {}
-	for (const row of filtered.value) {
-		if (row.kind !== 'site' || !row.site) continue
-		;(grouped[row.cluster] ??= []).push({
-			name: row.site.name,
-			url: row.site.url,
-			visual: row.visual,
-		})
+// Sites grouped by region for the map's hover cards. The DB does the grouping,
+// counting and per-region capping (useSites → list_site_groups); `count` is the
+// exact total, `sites` the previewed rows the card lists.
+const sitesByRegion = computed<Record<string, { count: number; sites: MapSite[] }>>(() => {
+	const grouped: Record<string, { count: number; sites: MapSite[] }> = {}
+	for (const site of sites.value) {
+		const region = site.region ?? ''
+		const entry = (grouped[region] ??= { count: siteCountByRegion.value[region] ?? 0, sites: [] })
+		entry.sites.push({ name: site.name, url: site.detail, visual: siteVisual(site.status) })
 	}
 	return grouped
 })

--- a/dashboard/src/pages/servers/ServersPage.vue
+++ b/dashboard/src/pages/servers/ServersPage.vue
@@ -1,17 +1,19 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { Badge, Button, FormControl, Select, Spinner } from 'frappe-ui'
+import { Button, Spinner } from 'frappe-ui'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
 import CreateTeamDialog from '@/components/team/CreateTeamDialog.vue'
 import MapMessageCard from '@/components/servers/MapMessageCard.vue'
 import ServerOnboarding from '@/components/servers/ServerOnboarding.vue'
-import ProviderAvatar from '@/components/servers/ProviderAvatar.vue'
 import ResizeServerDialog from '@/components/servers/ResizeServerDialog.vue'
 import ServerMap from '@/components/servers/ServerMap.vue'
 import ServerRowActions from '@/components/servers/ServerRowActions.vue'
 import TerminateDialog from '@/components/servers/TerminateDialog.vue'
+import MapHealthStrips from '@/components/servers/MapHealthStrips.vue'
+import ServerFilters from '@/components/servers/ServerFilters.vue'
+import ServerListPanel from '@/components/servers/ServerListPanel.vue'
 import { useCapabilities } from '@/composables/useCapabilities'
 import { useRegions } from '@/composables/useRegions'
 import { useServerMapData } from '@/composables/useServerMapData'
@@ -30,6 +32,7 @@ import {
 } from '@/lib/serverMap'
 import type { AssetRow } from '@/composables/useServers'
 import type { Region } from '@/types/Central/Region'
+import type { ServerRow } from '@/components/servers/ServerListPanel.vue'
 
 // The servers page: the world map is the list (FC V2). The Asset mirror feeds
 // pins; Active Atlas Instances feed empty-region + spots; a slide-in panel
@@ -89,19 +92,8 @@ const mapRef = ref<InstanceType<typeof ServerMap> | null>(null)
 
 // — Rows: every non-terminated server, decorated for display. A server whose
 //   region is unlisted (Draining/Disabled instance) or unplaced (no coords)
-//   still rows here — it just can't pin on the map.
-interface ServerRow {
-	id: string
-	name: string
-	asset: AssetRow
-	visual: ServerVisual
-	specs: string
-	region: Region | undefined
-	regionLabel: string
-	flag: string
-	provider: string | null
-}
-
+//   still rows here — it just can't pin on the map. (ServerRow type lives with
+//   the panel that renders it.)
 const regionsByName = computed(
 	() => new Map(regions.value.map((r) => [r.region, r])),
 )
@@ -390,192 +382,42 @@ const pendingResize = ref<AssetRow | null>(null)
 				</template>
 			</ServerMap>
 
-			<!-- Mirror-health strips (top center): reachability first, then load errors. -->
-			<div
-				class="pointer-events-none absolute inset-x-0 top-4 flex justify-center px-4"
-			>
-				<p
-					v-if="stale.length"
-					class="pointer-events-auto rounded-md bg-surface-amber-1 px-3 py-2 text-p-sm text-ink-amber-3 shadow-sm"
-				>
-					Showing last-known data — couldn't reach: {{ stale.join(', ') }}
-				</p>
-				<p
-					v-else-if="error && rows.length"
-					class="pointer-events-auto rounded-md bg-surface-red-1 px-3 py-2 text-p-sm text-ink-red-3 shadow-sm"
-				>
-					{{ error }}
-					<button class="ml-1 font-medium underline" @click="reloadAll">
-						Retry
-					</button>
-				</p>
-			</div>
+			<MapHealthStrips
+				:stale="stale"
+				:error="error"
+				:has-rows="rows.length > 0"
+				@retry="reloadAll"
+			/>
 
-			<!-- Filters (top right) -->
-			<div class="absolute right-4 top-4 flex items-center gap-2">
-				<Select
-					v-model="statusFilter"
-					variant="outline"
-					size="md"
-					:options="statusOptions"
-				>
-					<template #prefix>
-						<span
-							class="size-2 shrink-0 rounded-full transition-colors"
-							:style="{ background: statusDot }"
-						/>
-					</template>
-				</Select>
-				<Select
-					v-model="regionSelection"
-					variant="outline"
-					size="md"
-					:options="regionOptions"
-				/>
-			</div>
+			<ServerFilters
+				v-model:status-filter="statusFilter"
+				v-model:region-selection="regionSelection"
+				:status-options="statusOptions"
+				:status-dot="statusDot"
+				:region-options="regionOptions"
+			/>
 
-			<!-- Your servers (top left): a floating card — the pill IS the panel,
-           collapsed. Opening expands it in place; content crossfades. -->
-			<section
-				class="sp-float absolute left-4 top-4 z-30 overflow-hidden rounded-lg border border-outline-gray-2 bg-surface-elevation-1"
-				:class="panelOpen && 'sp-float-open'"
-				role="region"
-				aria-label="Your servers"
-				@keydown.esc="panelOpen = false"
-			>
-				<button
-					class="sp-float-pill text-base"
-					:inert="panelOpen"
-					@click="panelOpen = true"
-				>
-					<span class="truncate">{{ pillLabel }}</span>
-					<span class="lucide-maximize-2 size-3.5 shrink-0 text-ink-gray-6" />
-				</button>
-
-				<div
-					class="sp-float-panel flex h-full min-h-0 flex-col"
-					:inert="!panelOpen"
-					:aria-hidden="!panelOpen"
-				>
-					<!-- Same label as the pill so the card reads as the pill expanding. -->
-					<div
-						class="flex shrink-0 items-center justify-between gap-2 px-4 pb-2 pt-3"
-					>
-						<h2 class="truncate text-base font-semibold text-ink-gray-9">
-							{{ pillLabel }}
-						</h2>
-						<Button
-							variant="ghost"
-							icon="lucide-minimize-2"
-							aria-label="Collapse list"
-							@click="panelOpen = false"
-						/>
-					</div>
-					<div class="shrink-0 px-4 pb-3">
-						<FormControl
-							v-model="q"
-							type="text"
-							placeholder="Search"
-							autocomplete="off"
-							class="[&_input]:w-full"
-						>
-							<template #prefix
-								><span class="lucide-search size-4 text-ink-gray-5" /></template
-							>
-						</FormControl>
-					</div>
-
-					<!-- Set by clicking a cluster on the map — the rows narrow to that spot. -->
-					<div
-						v-if="locationFilter"
-						class="flex shrink-0 items-center justify-between gap-3 px-4 pb-2.5"
-					>
-						<span class="min-w-0 truncate text-sm text-ink-gray-5">
-							Filtering for
-							<span class="font-medium text-ink-gray-8"
-								>{{ locationFilter.label }}</span
-							>
-						</span>
-						<button
-							class="flex shrink-0 items-center gap-1.5 text-sm text-ink-gray-6 transition-colors hover:text-ink-gray-8"
-							@click="locationFilter = null"
-						>
-							<span class="lucide-filter size-3.5" />
-							Clear
-						</button>
-					</div>
-
-					<div
-						class="min-h-0 flex-1 divide-y divide-outline-alpha-gray-1 overflow-y-auto border-t border-outline-alpha-gray-1 px-2 pb-2"
-					>
-						<div
-							v-for="(row, i) in panelRows"
-							:key="row.id"
-							class="sp-row group flex cursor-pointer items-center gap-3 rounded-lg px-2.5 py-2.5 transition-colors hover:bg-surface-gray-2"
-							:style="{ animationDelay: `${Math.min(i * 25, 200)}ms` }"
-							@click="focusRow(row)"
-							@mouseenter="hoverId = row.id"
-							@mouseleave="hoverId = null"
-						>
-							<span class="relative shrink-0">
-								<ProviderAvatar :provider="row.provider" :size="32" />
-								<span
-									class="absolute -bottom-px -right-px size-2.5 rounded-full border-2 border-[var(--surface-elevation-1)]"
-									:style="{ background: row.visual.dot }"
-								/>
-							</span>
-							<span class="min-w-0 flex-1">
-								<span class="flex items-center gap-1.5">
-									<span class="truncate text-sm font-medium text-ink-gray-9"
-										>{{ row.name }}</span
-									>
-									<Badge
-										v-if="row.visual.key !== 'active'"
-										:label="row.visual.label"
-										:theme="row.visual.badgeTheme"
-										variant="subtle"
-										size="sm"
-									/>
-								</span>
-								<span class="block truncate text-sm text-ink-gray-5"
-									>{{ row.specs || row.regionLabel }}</span
-								>
-							</span>
-							<span @click.stop>
-								<ServerRowActions
-									:server="row.asset"
-									:can-open="canOpenServer"
-									:can-power="canPowerServer"
-									:can-terminate="canTerminateServer"
-									:busy="busy === row.id"
-									:opening="opening === row.id"
-									@open="open"
-									@start="doStart"
-									@stop="doStop"
-									@resize="pendingResize = $event"
-									@terminate="pendingTerminate = $event"
-								/>
-							</span>
-						</div>
-
-						<div
-							v-if="!panelRows.length"
-							class="m-4 flex flex-col items-center gap-1 py-8 text-center"
-						>
-							<span
-								:class="rows.length ? 'lucide-search' : 'lucide-server'"
-								class="mb-2 size-6 text-ink-gray-4"
-							/>
-							<p class="text-base font-medium text-ink-gray-8">
-								{{ rows.length ? 'No servers match' : 'No servers yet' }}
-							</p>
-							<p class="text-sm text-ink-gray-5">
-								{{ rows.length ? 'Try a different search or clear the filters.' : 'Create your first server to host your sites.' }}
-							</p>
-						</div>
-					</div>
-				</div>
-			</section>
+			<ServerListPanel
+				v-model:open="panelOpen"
+				v-model:query="q"
+				v-model:hover-id="hoverId"
+				:pill-label="pillLabel"
+				:rows="panelRows"
+				:has-rows="rows.length > 0"
+				:location-filter="locationFilter"
+				:can-open="canOpenServer"
+				:can-power="canPowerServer"
+				:can-terminate="canTerminateServer"
+				:busy="busy"
+				:opening="opening"
+				@focus-row="focusRow"
+				@clear-location="locationFilter = null"
+				@open="open"
+				@start="doStart"
+				@stop="doStop"
+				@resize="pendingResize = $event"
+				@terminate="pendingTerminate = $event"
+			/>
 
 			<!-- Initial load / hard failure / first run — centered over the map -->
 			<div
@@ -614,96 +456,3 @@ const pendingResize = ref<AssetRow | null>(null)
 		<CreateTeamDialog v-model:open="createTeamOpen" />
 	</div>
 </template>
-
-<style scoped>
-/* "Your servers" morph: one floating card whose size change carries the whole
-   story — the pill grows into the panel in place. Faster on close than open,
-   one strong ease-out; the two faces just crossfade inside it. Collapsed, the
-   pill matches the Select (outline / md) filters across the map: 2rem tall,
-   same radius, px-2.5, text-base. */
-.sp-float {
-	--sp-ease: cubic-bezier(0.23, 1, 0.32, 1);
-	width: 10.5rem;
-	height: 2rem;
-	border-radius: 0.5rem;
-	box-shadow: var(--shadow-sm, 0 1px 2px rgb(0 0 0 / 0.05));
-	transition:
-		width 180ms var(--sp-ease),
-		height 180ms var(--sp-ease),
-		border-radius 180ms var(--sp-ease),
-		box-shadow 180ms var(--sp-ease);
-}
-.sp-float-open {
-	width: 24rem;
-	height: calc(100% - 2rem);
-	border-radius: 0.75rem;
-	box-shadow: var(
-		--shadow-xl,
-		0 20px 25px -5px rgb(0 0 0 / 0.1),
-		0 8px 10px -6px rgb(0 0 0 / 0.1)
-	);
-	transition-duration: 220ms;
-}
-.sp-float-pill {
-	position: absolute;
-	left: 0;
-	top: 0;
-	display: flex;
-	height: 2rem;
-	width: 10.5rem;
-	align-items: center;
-	justify-content: space-between;
-	gap: 0.625rem;
-	padding: 0 0.625rem;
-	font-weight: 420;
-	color: var(--ink-gray-7);
-	transition:
-		opacity 120ms ease-out,
-		background-color 150ms ease;
-}
-.sp-float-pill:hover {
-	background: var(--surface-gray-1);
-}
-.sp-float-open .sp-float-pill {
-	opacity: 0;
-}
-.sp-float-panel {
-	opacity: 0;
-	transform: translateY(4px);
-	transition:
-		opacity 140ms ease-out,
-		transform 220ms var(--sp-ease);
-}
-.sp-float-open .sp-float-panel {
-	opacity: 1;
-	transform: none;
-	transition-delay: 40ms;
-}
-
-/* Rows cascade in as the panel opens — brief, then out of the way. */
-.sp-row {
-	animation: sp-row-in 250ms cubic-bezier(0.23, 1, 0.32, 1) both;
-}
-@keyframes sp-row-in {
-	from {
-		opacity: 0;
-		transform: translateY(6px);
-	}
-	to {
-		opacity: 1;
-		transform: translateY(0);
-	}
-}
-
-@media (prefers-reduced-motion: reduce) {
-	.sp-float,
-	.sp-float-pill,
-	.sp-float-panel {
-		transition-duration: 1ms;
-		transition-delay: 0ms;
-	}
-	.sp-row {
-		animation: none;
-	}
-}
-</style>

--- a/dashboard/src/pages/servers/ServersPage.vue
+++ b/dashboard/src/pages/servers/ServersPage.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { Button, Spinner } from 'frappe-ui'
+import { Button, Dialog, Spinner, useCall } from 'frappe-ui'
+import { API, method } from '@/api/methods'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
 import CreateTeamDialog from '@/components/team/CreateTeamDialog.vue'
@@ -18,12 +19,14 @@ import { useCapabilities } from '@/composables/useCapabilities'
 import { useRegions } from '@/composables/useRegions'
 import { useServerMapData } from '@/composables/useServerMapData'
 import { useServers } from '@/composables/useServers'
+import { useSites } from '@/composables/useSites'
 import { useSession } from '@/composables/useSession'
 import {
 	STATUS_FILTERS,
 	flagEmoji,
 	hasMapCoords,
 	regionLabel,
+	siteVisual,
 	specLine,
 	statusVisual,
 	type MapPin,
@@ -32,20 +35,21 @@ import {
 } from '@/lib/serverMap'
 import type { AssetRow } from '@/composables/useServers'
 import type { Region } from '@/types/Central/Region'
-import type { ServerRow } from '@/components/servers/ServerListPanel.vue'
+import type { ResourceRow } from '@/components/servers/ServerListPanel.vue'
 
-// The servers page: the world map is the list (FC V2). The Asset mirror feeds
-// pins; Active Atlas Instances feed empty-region + spots; a slide-in panel
-// carries the searchable row list. Lifecycle actions reuse useServers so the
-// map page and the ⋯ menus share one command path.
+// The assets page: the world map is the list (FC V2). Servers (the Asset mirror)
+// and sites (the Site mirror — each a 1:1-backed VM) list together; a slide-in
+// panel carries the searchable rows. Lifecycle actions reuse useServers /
+// useSites so the map, panel, and ⋯ menus share one command path.
 
 const router = useRouter()
 
 const { assets, loading, error, reload } = useServerMapData()
+const { sites, reload: reloadSites } = useSites()
 const { regions } = useRegions()
 const { canPowerServer, canTerminateServer, canOpenServer, canCreateServer } =
 	useCapabilities()
-// Actions only — list reads come from useServerMapData (unpaginated, map-shaped).
+// Actions only — list reads come from useServerMapData / useSites.
 const {
 	refreshing,
 	stale,
@@ -58,13 +62,17 @@ const {
 	open,
 } = useServers()
 
+const terminateSiteCall = useCall<unknown, { name: string }>({
+	url: method(API.terminateSite),
+})
+
 // A user in no team can't own servers/billing/regions — offer team creation
 // instead of the (empty, error-prone) map until a team exists.
 const { activeTeam, loading: sessionLoading } = useSession()
 const createTeamOpen = ref(false)
 const hasNoTeam = computed(() => !sessionLoading.value && !activeTeam.value)
 
-// First-run onboarding nudge — shown until the team has a server or the user
+// First-run onboarding nudge — shown until the team has an asset or the user
 // dismisses it (remembered across visits so it never nags).
 const ONBOARDING_KEY = 'central.console.serverOnboardingDismissed'
 const onboardingDismissed = ref(localStorage.getItem(ONBOARDING_KEY) === '1')
@@ -90,23 +98,23 @@ const hoverId = ref<string | null>(null)
 const panelOpen = ref(false)
 const mapRef = ref<InstanceType<typeof ServerMap> | null>(null)
 
-// — Rows: every non-terminated server, decorated for display. A server whose
-//   region is unlisted (Draining/Disabled instance) or unplaced (no coords)
-//   still rows here — it just can't pin on the map. (ServerRow type lives with
-//   the panel that renders it.)
 const regionsByName = computed(
 	() => new Map(regions.value.map((r) => [r.region, r])),
 )
 
-const rows = computed<ServerRow[]>(() =>
+// — Rows: servers and sites decorated into one shape (ResourceRow). A server or
+//   site whose region is unlisted/unplaced still rows here — it just can't pin.
+const serverRows = computed<ResourceRow[]>(() =>
 	assets.value.map((asset) => {
 		const region = regionsByName.value.get(asset.cluster)
 		return {
+			kind: 'server' as const,
 			id: asset.resource_id,
 			name: asset.title || asset.resource_id,
 			asset,
 			visual: statusVisual(asset),
 			specs: specLine(asset),
+			cluster: asset.cluster,
 			region,
 			regionLabel: region ? regionLabel(region) : asset.cluster,
 			flag: flagEmoji(region?.country_code),
@@ -114,6 +122,30 @@ const rows = computed<ServerRow[]>(() =>
 		}
 	}),
 )
+
+const siteRows = computed<ResourceRow[]>(() =>
+	sites.value.map((site) => {
+		const region = site.region ? regionsByName.value.get(site.region) : undefined
+		return {
+			kind: 'site' as const,
+			id: site.name,
+			name: site.name,
+			visual: siteVisual(site.status),
+			specs: '',
+			cluster: site.region ?? '',
+			region,
+			regionLabel: region ? regionLabel(region) : (site.region ?? ''),
+			flag: flagEmoji(region?.country_code),
+			provider: region?.provider ?? null,
+			site: { name: site.name, url: site.detail },
+		}
+	}),
+)
+
+const rows = computed<ResourceRow[]>(() => [
+	...serverRows.value,
+	...siteRows.value,
+])
 
 // — Filters. Status and region scope the map and the panel; search only
 //   narrows the panel rows.
@@ -127,8 +159,6 @@ const statusDot = computed(
 		'var(--ink-gray-4)',
 )
 
-// Regions grouped by provider for the nested menu. Providerless instances
-// group under "Other" so nothing disappears from the filter.
 const providerGroups = computed(() => {
 	const groups = new Map<string, Region[]>()
 	for (const region of regions.value) {
@@ -142,9 +172,6 @@ const providerGroups = computed(() => {
 	}))
 })
 
-// Flat option list for the Select: "All <provider> regions" rows stand in for
-// the old nested provider menu. Selection is encoded as '' | 'p:<provider>' |
-// 'r:<provider>|<region>' and mapped onto regionFilter.
 const regionOptions = computed(() => [
 	{ label: 'All regions', value: '' },
 	...providerGroups.value.flatMap((group) => [
@@ -180,10 +207,7 @@ const filtered = computed(() =>
 			(row.provider || 'Other') !== regionFilter.value.provider
 		)
 			return false
-		if (
-			regionFilter.value.region &&
-			row.asset.cluster !== regionFilter.value.region
-		)
+		if (regionFilter.value.region && row.cluster !== regionFilter.value.region)
 			return false
 		if (statusFilter.value && row.visual.key !== statusFilter.value)
 			return false
@@ -209,15 +233,15 @@ const panelRows = computed(() => {
 
 const pillLabel = computed(() =>
 	statusFilter.value || regionFilter.value.provider || regionFilter.value.region
-		? `Servers (${filtered.value.length})`
-		: `All servers (${filtered.value.length})`,
+		? `Assets (${filtered.value.length})`
+		: `All assets (${filtered.value.length})`,
 )
 
-// — Map data. Pins carry everything their hover card shows so ServerMap stays
-//   purely presentational. Only placed regions pin (0/0 = unplaced).
+// — Map data. Only servers pin today (a site's pin/hover card is a follow-up);
+//   pins carry everything their hover card shows so ServerMap stays presentational.
 const pins = computed<MapPin[]>(() =>
 	filtered.value
-		.filter((row) => row.region && hasMapCoords(row.region))
+		.filter((row) => row.kind === 'server' && row.asset && row.region && hasMapCoords(row.region))
 		.map((row) => ({
 			id: row.id,
 			name: row.name,
@@ -228,16 +252,14 @@ const pins = computed<MapPin[]>(() =>
 			regionLabel: row.regionLabel,
 			flag: row.flag,
 			specs: row.specs,
-			publicIpv4: row.asset.public_ipv4 ?? null,
-			plan: row.asset.plan ?? null,
-			frappeVersion: row.asset.frappe_version ?? null,
-			server: row.asset,
+			publicIpv4: row.asset!.public_ipv4 ?? null,
+			plan: row.asset!.plan ?? null,
+			frappeVersion: row.asset!.frappe_version ?? null,
+			server: row.asset!,
 		})),
 )
 
 // Regions with no servers show as + spots — everywhere you could deploy next.
-// The status filter doesn't change what "empty" means, but a region filter
-// scopes the offer too. No server:create, no offer.
 const spots = computed<MapSpot[]>(() => {
 	if (!canCreateServer.value) return []
 	const occupied = new Set(assets.value.map((asset) => asset.cluster))
@@ -272,7 +294,7 @@ function onOpen(id: string): void {
 function onClusterOpen(payload: { ids: string[]; label: string }): void {
 	if (panelOpen.value) locationFilter.value = payload
 }
-function focusRow(row: ServerRow): void {
+function focusRow(row: ResourceRow): void {
 	mapRef.value?.focusPin(row.id)
 }
 function goNewServer(region: string): void {
@@ -283,10 +305,10 @@ watch(panelOpen, (isOpen) => {
 	if (!isOpen) locationFilter.value = null
 })
 
-// — Commands. useServers reloads its own (reportview) list after each verb;
-//   the map reads through registry, so reload that too after every action.
+// — Commands. Reload the map (servers) and the sites feed after every action.
 function reloadAll(): void {
 	reload()
+	reloadSites()
 }
 async function withReload(action: Promise<unknown>): Promise<void> {
 	await action
@@ -296,21 +318,38 @@ const doRefresh = (): Promise<void> => withReload(refreshAssets())
 const doStart = (server: AssetRow): Promise<void> => withReload(start(server))
 const doStop = (server: AssetRow): Promise<void> => withReload(stop(server))
 
-// Terminate confirmation — the only destructive, irreversible action.
+// Terminate confirmation — the only destructive, irreversible actions.
 const pendingTerminate = ref<AssetRow | null>(null)
 async function confirmTerminate(server: AssetRow): Promise<void> {
 	pendingTerminate.value = null
 	await withReload(terminate(server))
 }
 
-// Resize a server (preset or custom) — the backend power-cycles the VM as needed, so
-// this is one action with no separate stop step.
 const pendingResize = ref<AssetRow | null>(null)
+
+// — Sites. Open goes to the live site; terminate tears down the backing VM.
+function openSite(url: string): void {
+	window.open(url, '_blank', 'noopener')
+}
+const pendingSiteTerminate = ref<{ name: string } | null>(null)
+const siteTerminateOpen = computed({
+	get: () => !!pendingSiteTerminate.value,
+	set: (isOpen: boolean) => {
+		if (!isOpen) pendingSiteTerminate.value = null
+	},
+})
+async function confirmSiteTerminate(): Promise<void> {
+	const name = pendingSiteTerminate.value?.name
+	pendingSiteTerminate.value = null
+	if (!name) return
+	await terminateSiteCall.submit({ name })
+	reloadSites()
+}
 </script>
 
 <template>
 	<div class="flex h-full flex-col">
-		<PageHeader title="Servers">
+		<PageHeader title="Assets">
 			<template #actions>
 				<Button
 					v-if="activeTeam"
@@ -417,6 +456,8 @@ const pendingResize = ref<AssetRow | null>(null)
 				@stop="doStop"
 				@resize="pendingResize = $event"
 				@terminate="pendingTerminate = $event"
+				@open-site="openSite"
+				@terminate-site="pendingSiteTerminate = { name: $event }"
 			/>
 
 			<!-- Initial load / hard failure / first run — centered over the map -->
@@ -430,15 +471,14 @@ const pendingResize = ref<AssetRow | null>(null)
 				v-else-if="error && !rows.length"
 				icon="lucide-circle-alert"
 				icon-class="text-ink-red-5"
-				title="Couldn't load your servers"
+				title="Couldn't load your assets"
 				:description="error"
 			>
 				<template #action>
 					<Button class="mt-3" label="Retry" @click="reloadAll" />
 				</template>
 			</MapMessageCard>
-			<!-- First-run onboarding: a dismissible nudge toward the one right action.
-           Only while the team has no servers, and stays gone once dismissed. -->
+			<!-- First-run onboarding: a dismissible nudge toward the one right action. -->
 			<ServerOnboarding
 				v-else-if="showOnboarding"
 				@create="$router.push('/servers/new')"
@@ -450,6 +490,24 @@ const pendingResize = ref<AssetRow | null>(null)
 			v-model:server="pendingTerminate"
 			:loading="busy === pendingTerminate?.resource_id"
 			@confirm="confirmTerminate"
+		/>
+
+		<Dialog
+			v-model="siteTerminateOpen"
+			:options="{
+				title: 'Terminate site',
+				message: `Terminate ${pendingSiteTerminate?.name}? This permanently deletes the site and its backing VM. This can't be undone.`,
+				size: 'sm',
+				actions: [
+					{
+						label: 'Terminate site',
+						variant: 'solid',
+						theme: 'red',
+						loading: terminateSiteCall.loading,
+						onClick: confirmSiteTerminate,
+					},
+				],
+			}"
 		/>
 
 		<ResizeServerDialog v-model:server="pendingResize" @resized="reloadAll" />

--- a/dashboard/src/pages/servers/ServersPage.vue
+++ b/dashboard/src/pages/servers/ServersPage.vue
@@ -30,6 +30,7 @@ import {
 	specLine,
 	statusVisual,
 	type MapPin,
+	type MapSite,
 	type MapSpot,
 	type ServerVisual,
 } from '@/lib/serverMap'
@@ -237,8 +238,10 @@ const pillLabel = computed(() =>
 		: `All servers (${filtered.value.length})`,
 )
 
-// — Map data. Only servers pin today (a site's pin/hover card is a follow-up);
-//   pins carry everything their hover card shows so ServerMap stays presentational.
+// — Map data. Only servers pin; sites would clutter the map (a server can host
+//   many), so they surface in the hover card of the region they sit in (see
+//   sitesByRegion) and list flat in the panel's "Sites" group. Pins carry
+//   everything their hover card shows so ServerMap stays presentational.
 const pins = computed<MapPin[]>(() =>
 	filtered.value
 		.filter((row) => row.kind === 'server' && row.asset && row.region && hasMapCoords(row.region))
@@ -249,6 +252,7 @@ const pins = computed<MapPin[]>(() =>
 			lng: row.region!.longitude!,
 			provider: row.provider,
 			visual: row.visual,
+			cluster: row.cluster,
 			regionLabel: row.regionLabel,
 			flag: row.flag,
 			specs: row.specs,
@@ -258,6 +262,22 @@ const pins = computed<MapPin[]>(() =>
 			server: row.asset!,
 		})),
 )
+
+// Sites grouped by region code for the map's hover cards. Grouped client-side —
+// the sites feed is already loaded and small; move the grouping/count into a SQL
+// aggregation in list_resources if a team's site count ever grows large.
+const sitesByRegion = computed<Record<string, MapSite[]>>(() => {
+	const grouped: Record<string, MapSite[]> = {}
+	for (const row of filtered.value) {
+		if (row.kind !== 'site' || !row.site) continue
+		;(grouped[row.cluster] ??= []).push({
+			name: row.site.name,
+			url: row.site.url,
+			visual: row.visual,
+		})
+	}
+	return grouped
+})
 
 // Regions with no servers show as + spots — everywhere you could deploy next.
 const spots = computed<MapSpot[]>(() => {
@@ -396,11 +416,13 @@ async function confirmSiteTerminate(): Promise<void> {
 				class="absolute inset-0"
 				:pins="pins"
 				:spots="spots"
+				:sites-by-region="sitesByRegion"
 				:highlight-id="hoverId"
 				:allow-create="canCreateServer"
 				:allow-open="canOpenServer"
 				@open="onOpen"
 				@open-server="open"
+				@open-site="openSite"
 				@new-server="goNewServer"
 				@cluster-open="onClusterOpen"
 			>

--- a/dashboard/src/pages/servers/ServersPage.vue
+++ b/dashboard/src/pages/servers/ServersPage.vue
@@ -335,7 +335,6 @@ const doRefresh = (): Promise<void> => withReload(refreshAssets())
 const doStart = (server: AssetRow): Promise<void> => withReload(start(server))
 const doStop = (server: AssetRow): Promise<void> => withReload(stop(server))
 
-// Terminate confirmation — the only destructive, irreversible actions.
 const pendingTerminate = ref<AssetRow | null>(null)
 async function confirmTerminate(server: AssetRow): Promise<void> {
 	pendingTerminate.value = null
@@ -513,21 +512,20 @@ async function confirmSiteTerminate(): Promise<void> {
 
 		<Dialog
 			v-model="siteTerminateOpen"
-			:options="{
-				title: 'Terminate site',
-				message: `Terminate ${pendingSiteTerminate?.name}? This permanently deletes the site and its backing VM. This can't be undone.`,
-				size: 'sm',
-				actions: [
-					{
-						label: 'Terminate site',
-						variant: 'solid',
-						theme: 'red',
-						loading: terminateSiteCall.loading,
-						onClick: confirmSiteTerminate,
-					},
-				],
-			}"
-		/>
+title="Terminate site" size="sm" :actions="[
+			{
+		label: 'Yes, terminate',
+		variant: 'solid',
+		theme: 'red',
+		loading: terminateSiteCall.loading,
+		onClick: confirmSiteTerminate,
+	},
+]">
+			<p class="text-p-base text-ink-gray-7">
+				Terminate <span class="font-semibold text-ink-gray-9">{{ pendingSiteTerminate?.name }}</span>?
+				This permanently deletes the site and its backing VM. This can't be undone.
+			</p>
+		</Dialog>
 
 		<ResizeServerDialog v-model:server="pendingResize" @resized="reloadAll" />
 		<CreateTeamDialog v-model:open="createTeamOpen" />


### PR DESCRIPTION
## Unify servers & sites in the console

Servers and sites are both VMs (a site is a 1:1-backed micro-VM), so the console now shows them in one map + list view instead of separate surfaces - a single-site team lands somewhere it can find its site, a server owner sees everything at once.
This is specially designed for the use case where a single site user ends up on Central looking for their site and can't find it.

### What's in it

**Unified view**
- `list_resources(team, kind?)` returns servers (Asset mirror) + sites (Site mirror) as one region-tagged list; the servers map/panel render both.
- Servers pin on the map; sites don't (a server can host many — they'd clutter it). Instead a region's sites surface in its pin/cluster **hover card**, and the panel collects them into a flat **"Sites"** group.
- Sites support **Open** and **Terminate** (`terminate_site` → Atlas); actions reuse `useServers`/`useSites` so map, panel, and ⋯ menus share one path. Realtime-refreshed via the Site `list_update` push.

**Performance**
- Site feed is grouped/counted in an **indexed query-builder aggregation** (`list_site_groups`): `COUNT(*) OVER` for the exact per-region total, `ROW_NUMBER()` to cap each region's preview, backed by a `(team, region)` composite index. Payload never scales with a team's site count.

**Refactor & polish**
- Split the 700-line `ServersPage` into panel/filters/health-strip/map components (Tailwind over bespoke CSS).
- Removed frappe-ui Sidebar's built-in collapse button; tidied the terminate dialog and list dividers.

### Notes
- Site-level capabilities reuse `server:*` for now (deferred).
- Full VM actions on sites (resize / change-plan) are deferred until we plan this with Atlas on whether we are going to provide this.