### PR TITLE
fix: Namespace gateway payment id by provider

### DIFF
--- a/central/billing/api/billing_api.py
+++ b/central/billing/api/billing_api.py
@@ -810,7 +810,8 @@ def get_checkout_status(reference: str) -> dict:
 		# (Falls back to the session id only if the gateway hasn't surfaced one yet.)
 		key = payment_id or session_id
 		credits.purchase(target, amount, currency, gateway_payment_id=key,
-						 reference_name=key, note=f"Wallet top-up ({key})")
+						 reference_name=key, note=f"Wallet top-up ({key})",
+						 gateway=gw_doc.adapter_key)
 		return {"status": "paid", "success": True, "message": "Wallet topped up.",
 				"balance": credits.get_balance(target)["balance"]}
 

--- a/central/billing/api/dashboard/invoices.py
+++ b/central/billing/api/dashboard/invoices.py
@@ -536,4 +536,4 @@ def confirm_topup(team: str | None = None, amount: float | None = None, gateway:
 		frappe.throw("Payment confirmation failed.", frappe.ValidationError)
 	return credits.purchase(team, amount, currency,
 		reference_name=reference, note=f"Wallet top-up ({reference})",
-		gateway_payment_id=reference)
+		gateway_payment_id=reference, gateway=gw_doc.adapter_key)

--- a/central/billing/payments/charges.py
+++ b/central/billing/payments/charges.py
@@ -573,6 +573,7 @@ def _extract_topup(adapter_key: str, payload: dict):
 			"team": notes.get("team"),
 			"amount": frappe.utils.flt(minor) / 100 if minor is not None else None,
 			"currency": (entity.get("currency") or "").upper() or None,
+			"gateway": adapter_key,
 		}
 	if adapter_key == "Stripe":
 		obj = ((payload.get("data") or {}).get("object")) or {}
@@ -585,6 +586,7 @@ def _extract_topup(adapter_key: str, payload: dict):
 			"team": notes.get("team"),
 			"amount": frappe.utils.flt(minor) / 100 if minor is not None else None,
 			"currency": (obj.get("currency") or "").upper() or None,
+			"gateway": adapter_key,
 		}
 	return None
 
@@ -648,6 +650,7 @@ def _credit_topup(event, topup: dict) -> dict:
 		reference_name=topup["payment_id"],
 		note=f"Wallet top-up ({topup['payment_id']})",
 		gateway_payment_id=topup["payment_id"],
+		gateway=topup.get("gateway"),
 	)
 	_mark_event(event, "Processed")
 	return {"handled": True, "result": "topup_credited", "team": topup["team"],

--- a/central/billing/revenue/credits.py
+++ b/central/billing/revenue/credits.py
@@ -233,10 +233,25 @@ def _existing_payment_entry(gateway_payment_id: str | None):
 	return entry, frappe.utils.flt(balance)
 
 
+def _namespaced_payment_id(gateway: str | None, payment_id: str | None) -> str | None:
+	"""Prefix a gateway payment id with its provider so the stored key is unique
+	across gateways, not just within one.
+
+	A payment id is only guaranteed unique inside its own gateway — a Stripe id and
+	a Razorpay id can be the same string yet mean two different payments. Storing
+	`{gateway}:{payment_id}` keeps those apart, so the unique key never rejects a
+	real second payment. The confirm callback, the pilot poll and the capture webhook
+	all pass the same provider for a given payment, so they still dedupe to one credit.
+	"""
+	if not payment_id:
+		return None
+	return f"{gateway}:{payment_id}" if gateway else payment_id
+
+
 def purchase(team: str, amount: float, currency: str | None = None,
 			 payment_method: str | None = None,
 			 reference_name: str | None = None, note: str | None = None,
-			 gateway_payment_id: str | None = None) -> dict:
+			 gateway_payment_id: str | None = None, gateway: str | None = None) -> dict:
 	"""Top-up: book a credit entry for purchased credits.
 
 	(The card charge that funds the top-up is the payment flow's concern; this
@@ -245,6 +260,8 @@ def purchase(team: str, amount: float, currency: str | None = None,
 	`gateway_payment_id` dedupes a gateway-order top-up: the synchronous confirm
 	callback and the async `payment.captured` webhook both call this for the same
 	payment, and the unique-key + under-lock guard ensure it books one credit.
+	`gateway` (the provider/adapter key) namespaces that id so ids only unique within
+	a gateway can't collide across gateways — see `_namespaced_payment_id`.
 	"""
 	entry, new_balance = _book_entry(
 		team,
@@ -254,7 +271,7 @@ def purchase(team: str, amount: float, currency: str | None = None,
 		reference_type="Payment Method" if payment_method else "Top-up",
 		reference_name=payment_method or reference_name,
 		note=note or "Credit top-up",
-		gateway_payment_id=gateway_payment_id,
+		gateway_payment_id=_namespaced_payment_id(gateway, gateway_payment_id),
 	)
 	return {"ledger_entry": entry.name, "new_balance": new_balance}
 

--- a/central/billing/tests/test_dashboard.py
+++ b/central/billing/tests/test_dashboard.py
@@ -546,9 +546,10 @@ class TestGatewayTopUp(CustomerDataBase):
 				paypal_order_id="PPORDER1")
 			adapter.capture_order.assert_called_once_with("PPORDER1")
 			self.assertEqual(out["new_balance"], 5000)
-			# Wallet entry references the PayPal capture id (the reconcilable handle).
+			# Wallet entry references the PayPal capture id (the reconcilable handle),
+			# namespaced by provider.
 			self.assertTrue(frappe.db.exists(
-				"Credit Ledger Entry", {"team": TEAM, "gateway_payment_id": "CAP123"}))
+				"Credit Ledger Entry", {"team": TEAM, "gateway_payment_id": "Paypal:CAP123"}))
 
 	def test_topup_paypal_via_razorpay_delegates_to_razorpay(self):
 		"""A PayPal gateway in 'Via Razorpay' mode holds no PayPal merchant account: the
@@ -613,9 +614,10 @@ class TestGatewayTopUp(CustomerDataBase):
 				razorpay_order_id="order_rzp1", razorpay_payment_id="pay_rzp1",
 				razorpay_signature="sig")
 			self.assertEqual(out["new_balance"], 5000)
-			# Reference is the razorpay_payment_id (no PayPal capture id exists here).
+			# Reference is the razorpay_payment_id (no PayPal capture id exists here),
+			# namespaced by provider.
 			self.assertTrue(frappe.db.exists(
-				"Credit Ledger Entry", {"team": TEAM, "gateway_payment_id": "pay_rzp1"}))
+				"Credit Ledger Entry", {"team": TEAM, "gateway_payment_id": "Razorpay:pay_rzp1"}))
 
 
 class TestWriteEndpointsRejectGet(IntegrationTestCase):

--- a/central/billing/tests/test_webhooks.py
+++ b/central/billing/tests/test_webhooks.py
@@ -173,9 +173,11 @@ class TestWalletTopupWebhookBackstop(IntegrationTestCase):
 		}).insert(ignore_permissions=True)
 
 	def _credits_for(self, payment_id):
+		# Stored keys are namespaced by provider; these fixtures are all Razorpay.
 		return frappe.get_all(
 			"Credit Ledger Entry",
-			filters={"gateway_payment_id": payment_id}, fields=["name", "amount", "entry_type"],
+			filters={"gateway_payment_id": f"Razorpay:{payment_id}"},
+			fields=["name", "amount", "entry_type"],
 		)
 
 	def test_captured_topup_webhook_books_one_credit(self):
@@ -194,8 +196,10 @@ class TestWalletTopupWebhookBackstop(IntegrationTestCase):
 
 	def test_confirm_then_webhook_does_not_double_credit(self):
 		pid = "pay_backstop_2"
-		# Browser confirm landed first (what confirm_topup does).
-		credits.purchase(TOPUP_TEAM, 1000, "INR", reference_name=pid, gateway_payment_id=pid)
+		# Browser confirm landed first (what confirm_topup does) — same provider, so
+		# the webhook backstop dedupes to the same namespaced key.
+		credits.purchase(TOPUP_TEAM, 1000, "INR", reference_name=pid,
+						 gateway_payment_id=pid, gateway="Razorpay")
 		# Backstop webhook arrives for the same payment.
 		out = charges.apply_webhook(self._store_event(pid).name)
 

--- a/central/patches.txt
+++ b/central/patches.txt
@@ -124,3 +124,6 @@ central.patches.v0_0.billing_hot_indexes
 # Drop the duplicate non-unique index on Credit Ledger Entry.gateway_payment_id
 # (the unique constraint already indexes it).
 central.patches.v0_0.drop_dup_credit_ledger_index
+# Namespace existing Credit Ledger Entry gateway_payment_ids by provider so a
+# webhook pending across the deploy can't miss the bare row and double-credit.
+central.patches.v0_0.namespace_gateway_payment_ids

--- a/central/patches/v0_0/namespace_gateway_payment_ids.py
+++ b/central/patches/v0_0/namespace_gateway_payment_ids.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Namespace existing Credit Ledger Entry gateway_payment_ids by provider.
+
+Top-up credits now store `{provider}:{payment_id}` so ids only unique within a
+gateway can't collide across gateways. Existing rows hold the bare id. Without
+this, a capture webhook still pending across the deploy would compose the new
+`{provider}:{id}` key, miss the bare pre-deploy row, and double-credit.
+
+Provider is read off the id's prefix — reliable for the gateways that actually
+have a confirm-vs-webhook race (Razorpay `pay_`/`order_`, Stripe `pi_`/`ch_`).
+PayPal capture ids have no such prefix, but PayPal top-ups are confirm-only (no
+webhook race), so leaving those bare is safe. Idempotent: an already-namespaced
+row (one containing ':') is skipped.
+"""
+
+import frappe
+
+
+def _provider_for(payment_id: str) -> str | None:
+	if payment_id.startswith(("pay_", "order_")):
+		return "Razorpay"
+	if payment_id.startswith(("pi_", "ch_")):
+		return "Stripe"
+	return None
+
+
+def execute():
+	rows = frappe.get_all(
+		"Credit Ledger Entry",
+		filters={"gateway_payment_id": ["is", "set"]},
+		fields=["name", "gateway_payment_id"],
+	)
+	for row in rows:
+		pid = row.gateway_payment_id
+		if ":" in pid:  # already namespaced
+			continue
+		provider = _provider_for(pid)
+		if not provider:
+			continue
+		frappe.db.set_value(
+			"Credit Ledger Entry", row.name,
+			"gateway_payment_id", f"{provider}:{pid}", update_modified=False,
+		)


### PR DESCRIPTION
## What

`Credit Ledger Entry.gateway_payment_id` is unique — one gateway payment books
exactly one wallet credit, which is what stops a top-up being double-credited
when the synchronous confirm and the async capture webhook race. But a payment
id is only unique *within* a gateway. With multiple gateways (Stripe, Razorpay,
PayPal…), a Stripe id and a Razorpay id could be the same string yet mean two
different payments, and the global unique key would wrongly reject the second.

This scopes the uniqueness per provider by storing `{provider}:{payment_id}`
instead of the bare id, keeping the double-credit backstop while removing the
cross-gateway collision risk.

## How

- Composition is centralised in `credits.purchase(gateway=…)` via a new
  `_namespaced_payment_id` helper. The three paths that can race for the same
  payment — the synchronous confirm (`api/dashboard/invoices.py`), the pilot
  poll (`api/billing_api.py`), and the capture webhook (`payments/charges.py`)
  — all pass the provider and get an identical key, so they still dedupe to one
  credit. Doing it in one place (not at each call site) is what guarantees the
  three keys can't drift apart.
- The webhook path carries the provider through the `_extract_topup` dict.
- Backfill patch rewrites existing bare rows to the namespaced form, closing the
  deploy-window gap where a webhook still pending across the deploy would compose
  the new key, miss the old bare row, and double-credit. Provider is read from
  the id prefix — reliable for the gateways that actually have a webhook race
  (Razorpay `pay_`/`order_`, Stripe `pi_`/`ch_`); PayPal is confirm-only, so
  leaving those bare is safe. Idempotent (already-namespaced rows are skipped).
- No schema/index change: the single-column unique constraint stays as-is.