### PR TITLE
perf(billing): fan the monthly run out to per-team worker jobs

### DIFF
--- a/central/billing/ARCHITECTURE.md
+++ b/central/billing/ARCHITECTURE.md
@@ -174,8 +174,8 @@ flowchart LR
     D1 --> BF["backfill_missing_subscriptions"]
     H1 --> RF["retry_failed_syncs (ERPNext)"]
     M1 --> EX["expire_payment_methods"]
-    C1 --> DMI["draft_monthly_invoices → 1 job/team"]
-    C2 --> CMI["collect_monthly_invoices → 1 job/invoice"]
+    C1 --> DMI["draft_monthly_invoices → page jobs"]
+    C2 --> CMI["collect_monthly_invoices → page jobs"]
 
     subgraph MANUAL["manual/demo only"]
         RMB["run_monthly_billing (inline, both phases)"]
@@ -200,15 +200,45 @@ flowchart LR
 | daily | `catalog.subscriptions.backfill_missing_subscriptions` | Subscription for any Running Asset missing one |
 | hourly | `revenue.erpnext_sync.retry_failed_syncs` | retry Sales Invoice push (backoff window elapsed) |
 | monthly | `payments.payments.expire_payment_methods` | flip cards past their printed month |
-| cron `0 1 1 * *` | `revenue.invoicing.draft_monthly_invoices` | phase 1 — fan one draft job out per team |
-| cron `0 6 1 * *` | `revenue.invoicing.collect_monthly_invoices` | phase 2 — fan one collect job out per invoice |
+| cron `0 1 1 * *` | `revenue.invoicing.draft_monthly_invoices` | phase 1 — hand the month's teams out as page jobs |
+| cron `0 6 1 * *` | `revenue.invoicing.collect_monthly_invoices` | phase 2 — hand the period's drafts out as page jobs |
 
 **The monthly run is two ticks, and neither of them does the work.** Each is an
-orchestrator: it pages its subjects and enqueues one job per team (drafting) or per
-invoice (collection) on the **long** queue, deduplicated on (period, team) /
-(invoice). One job = one team = one transaction = one commit, and a job that fails
-is contained — logged as `Billing Run Failure`, rolled back to its own savepoint,
-and re-attempted by the next tick, since both phases are idempotent.
+orchestrator: it keyset-pages its subjects and enqueues a **page job** per slice —
+`draft_team_page(after, until)` / `settle_draft_page(period_end, after, until)` —
+deduplicated on the slice's upper bound. A page job re-derives its slice from the
+bounds and works it in order, committing after **each team / each invoice**: the page
+is the unit of *scheduling*, the team is still the unit of *work*, so a job killed
+at team 300 of 500 keeps the 299 it finished.
+
+Not a job per team, deliberately. At a million teams that is a million redis
+round-trips in one scheduler tick — a cron job runs on a **300-second** timeout
+(`get_queue_name()` gives cron jobs the `default` queue), so it would be killed
+around 150k teams having never handed out the rest, and a million queued jobs is
+gigabytes of redis. Two thousand page jobs cost seconds and megabytes.
+
+**The billing queue is the throughput knob and the rate-limit cap, at once.** The run
+uses its own queue, not `long`, configured in `common_site_config.json`:
+
+```json
+"workers": {"billing": {"timeout": 3000, "background_workers": 8}}
+```
+
+Because a page job works its invoices *sequentially*, the number of billing workers
+is exactly the number of gateway charges in flight. That is the only thing standing
+between a million-invoice month and a wall of 429s — there is no token bucket yet, so
+**this number is the rate limit**. Set it against the gateway's documented ceiling
+(Stripe ≈ 100 req/s; a charge is ~2s, so W workers ≈ W/2 req/s). Raising it is how
+you go faster; there is no other dial. `billing_queue()` falls back to `long` with a
+warning if the bench hasn't declared the queue — enqueuing to a queue nobody consumes
+would mean the month silently never gets billed.
+
+A unit that fails is contained: logged to the billing log file *and* as a
+`Billing Run Failure` Error Log row, rolled back to its own savepoint, and re-attempted
+by the next tick since both phases are idempotent. If the savepoint itself is gone —
+the database restarted, the connection dropped — the failure is **re-raised** instead:
+that is the machinery breaking, not a bad team, and containing it would turn one
+outage into a silent run in which nobody was billed.
 
 Why both ticks land on the 1st rather than the documented 28th/1st: a calendar month
 billed in arrears is not closed until it ends, so drafting on the 28th would bill days
@@ -221,10 +251,21 @@ achieved (drafted / pending / collected / failures), derived from the tables rat
 than from a counter — read it before deciding to re-fire a tick.
 
 **Worker math.** One collected invoice ≈ 2s (rating is ~100ms; the rest is the gateway
-round-trip). Sequentially that is 50k × 2s ≈ 28h — longer than the billing day. Fanned
-out over N long-queue workers it is 50k × 2s / N: **20 workers ≈ 1.4h**, 40 ≈ 42min.
-Drafting is cheaper (~0.3s/team) and finishes well inside the five-hour gap before the
-collect tick. Size the queue to the team count, not to the invoice amount.
+round-trip). Sequentially, a million invoices is ≈ 23 days. Over W billing workers it is
+1M × 2s / W: **8 workers ≈ 69h, 32 ≈ 17h, 64 ≈ 9h** — and 64 workers is ~32 charges/s,
+still inside a 100 req/s gateway ceiling. Drafting is cheaper (~0.3s/team): 1M teams
+over 32 workers ≈ 2.6h, which does *not* fit the five-hour gap with much room to spare
+at that scale — widen the gap or the pool before you get there. Size the pool from the
+team count, never from the invoice amount.
+
+**A late run never costs the customer grace.** `due_date` and `dunning_starts_on` are
+both set from the day the invoice is actually *opened*, so a run three days behind
+bills three days later rather than three days overdue. Beyond that, any collection
+failure on our side — a 429, a dead worker, a contained run error — calls
+`dunning.defer_dunning`, which pushes `dunning_starts_on` (never `due_date`, which is
+an accounting fact AR aging depends on) forward to today + the standard window. It is
+monotonic and self-limiting: a successful ask stops pushing, so a broken gateway defers
+*escalation*, not collection.
 
 ### Lifecycle / install hooks
 - `after_install` / `after_migrate` / `before_tests` → `catalog.taxonomy_setup.ensure_catalog_masters` (idempotent seed of catalog masters — ADR 0007).
@@ -272,7 +313,7 @@ Resize: `resize_composed_config → resize_composed_subscription` → new Subscr
 ```mermaid
 flowchart TD
     DRAFTTICK(["1st 01:00 · draft tick"]) --> GDI["draft_monthly_invoices<br/>→ generate_draft_invoices (pages teams)"]
-    GDI --> DTI["draft_team_invoice<br/>(1 job/team, isolated)"]
+    GDI --> DTI["draft_team_page → draft_team_invoice<br/>(per team: isolated, committed)"]
     DTI --> GTI["generate_team_invoice (per team)"]
     GTI --> RS["reconcile_subscription (fix drift)"]
     GTI --> LINES["lines.compute_line_items<br/>day-weighted from Sub Change segments"]
@@ -283,7 +324,7 @@ flowchart TD
 
     COLLECTTICK(["1st 06:00 · collect tick"]) --> OD["collect_monthly_invoices<br/>→ open_drafts (pages drafts)"]
     DRAFT --> OD
-    OD --> OAC["settle_draft → open_and_collect<br/>(1 job/invoice, isolated)"]
+    OD --> OAC["settle_draft_page → settle_draft<br/>(per invoice: isolated, committed)"]
     OAC --> WF{"settlement waterfall"}
     WF -->|credits| CR["settlement.py"]
     WF -->|then card| CARD["charges.pay_invoice"]
@@ -293,8 +334,8 @@ flowchart TD
 ```
 ```
 [1st 01:00]  revenue.invoicing.draft_monthly_invoices
-  → generate_draft_invoices (pages teams, enqueues one job each)
-  → draft_team_invoice (one job = one team = one commit; failure contained + logged)
+  → generate_draft_invoices (pages teams, enqueues one page job per slice)
+  → draft_team_page → draft_team_invoice (one team = one transaction = one commit)
     → generate_team_invoice (per team, aggregates clusters)
       → reconcile_subscription (correct drift if stale)
       → lines.compute_line_items  (day-weighted, from Subscription Change rate-snapshot segments)
@@ -303,8 +344,8 @@ flowchart TD
   → Invoice (Draft)
 
 [1st 06:00]  revenue.invoicing.collect_monthly_invoices
-  → open_drafts (pages the period's drafts, enqueues one job each)
-  → settle_draft → open_and_collect (per invoice)
+  → open_drafts (pages the period's drafts, enqueues one page job per slice)
+  → settle_draft_page → settle_draft → open_and_collect (per invoice)
       → settlement waterfall: credits (settlement.py) → card (charges.pay_invoice)
       → Invoice Draft → Open → (on webhook) Paid
       → on Paid: erpnext_sync.enqueue_invoice_sync
@@ -437,6 +478,9 @@ get_team_caps resolves caps live (no per-team Trust Tier doctype — dropped)
 |---|---|
 | Invoice never generated | `billing_run_status()` — is the team in `pending_draft`? then Error Log `Billing Run Failure` for that team, the long queue for stuck jobs, and `lines.compute_line_items` for empty segments |
 | Half the teams billed, half not | a partial run: read `billing_run_status()`, fix the cause, re-fire `draft_monthly_invoices` — both phases are idempotent and resume |
+| Billing run never starts / jobs pile up | is there a worker on the `billing` queue? (`common_site_config.workers.billing` + `bench worker --queue billing`); the billing log warns and falls back to `long` if the queue is undeclared |
+| Run is far too slow | `background_workers` on the billing queue is the only throughput dial — but it is also the gateway concurrency cap; check for 429s (`Billing Run Failure` Error Logs, `dunning_starts_on` deferrals) before raising it |
+| Customer dunned during a backlog | should be impossible: `dunning_starts_on` is pushed by `dunning.defer_dunning` on every failure of ours. If it happened, find the collection path that failed without calling it |
 | Invoice wrong amount | `lines.compute_line_items` (day-weighting), `metering.metered_line_items`, `commitments` discount, `tax.resolve_tax`; verify Subscription Change `locked_rate` segments |
 | Charge stuck "Open"/unpaid | `payments/webhooks.py` (signature failed? Webhook Event row?), `charges.apply_webhook`, `collection.collect_invoice` fallback chain |
 | Webhook ignored | `webhooks.process_webhook` signature check; gateway `verify_signature`; dedupe against existing Webhook Event |

--- a/central/billing/ARCHITECTURE.md
+++ b/central/billing/ARCHITECTURE.md
@@ -165,7 +165,6 @@ flowchart LR
         H1["hourly"]
         M1["monthly"]
         C1["cron · 1st 01:00"]
-        C2["cron · 1st 06:00"]
     end
     D1 --> RD["run_dunning"]
     D1 --> RR["run_reconciliation"]
@@ -175,7 +174,7 @@ flowchart LR
     H1 --> RF["retry_failed_syncs (ERPNext)"]
     M1 --> EX["expire_payment_methods"]
     C1 --> DMI["draft_monthly_invoices → page jobs"]
-    C2 --> CMI["collect_monthly_invoices → page jobs"]
+    D1 --> CDI["collect_due_invoices → page jobs (daily sweep)"]
 
     subgraph MANUAL["manual/demo only"]
         RMB["run_monthly_billing (inline, both phases)"]
@@ -193,6 +192,7 @@ flowchart LR
 ### Scheduled (`central/hooks.py` → `scheduler_events`)
 | Cadence | Entry point | Purpose |
 |---|---|---|
+| daily | `revenue.invoicing.collect_due_invoices` | phase 2 — sweep every Draft whose month has closed, fan drafts out as page jobs |
 | daily | `revenue.dunning.run_dunning` | Day 1/3/7 retries → past_due → suspend → terminate |
 | daily | `payments.reconciliation.run_reconciliation` | charged-but-never-webhooked gateway scan |
 | daily | `payments.charges.cleanup_payment_logs` | prune Payment Attempt / Webhook Event |
@@ -201,15 +201,23 @@ flowchart LR
 | hourly | `revenue.erpnext_sync.retry_failed_syncs` | retry Sales Invoice push (backoff window elapsed) |
 | monthly | `payments.payments.expire_payment_methods` | flip cards past their printed month |
 | cron `0 1 1 * *` | `revenue.invoicing.draft_monthly_invoices` | phase 1 — hand the month's teams out as page jobs |
-| cron `0 6 1 * *` | `revenue.invoicing.collect_monthly_invoices` | phase 2 — hand the period's drafts out as page jobs |
 
 **The monthly run is two ticks, and neither of them does the work.** Each is an
 orchestrator: it keyset-pages its subjects and enqueues a **page job** per slice —
-`draft_team_page(after, until)` / `settle_draft_page(period_end, after, until)` —
+`draft_team_page(after, until)` / `settle_draft_page(cutoff, after, until)` —
 deduplicated on the slice's upper bound. A page job re-derives its slice from the
 bounds and works it in order, committing after **each team / each invoice**: the page
 is the unit of *scheduling*, the team is still the unit of *work*, so a job killed
 at team 300 of 500 keeps the 299 it finished.
+
+Drafting fires once, on the 1st; collection is a **daily** sweep, not a single tick a
+fixed few hours later. At scale drafting can still be running when a one-shot collect
+would fire, and that scan would collect only the drafts that existed at that instant
+and orphan the rest — with no later pass to catch them. `collect_due_invoices` instead
+opens every Draft whose month has closed (`period_end <= the just-closed month`) and
+re-runs daily until nothing is owed, so a late draft, or one a settle page left behind
+(this month's or an older run's), is swept up rather than stranded. A settled draft
+drops out of the scan, so once the run has drained the sweep is a cheap indexed no-op.
 
 Not a job per team, deliberately. At a million teams that is a million redis
 round-trips in one scheduler tick — a cron job runs on a **300-second** timeout
@@ -350,7 +358,7 @@ flowchart TD
     GTI --> TAX["+ tax.resolve_tax<br/>GST / SEZ / TDS"]
     LINES & MET & DISC & TAX --> DRAFT[["Invoice: Draft"]]
 
-    COLLECTTICK(["1st 06:00 · collect tick"]) --> OD["collect_monthly_invoices<br/>→ open_drafts (pages drafts)"]
+    COLLECTTICK(["daily · collect sweep"]) --> OD["collect_due_invoices<br/>→ open_drafts (pages drafts, period_end ≤ closed month)"]
     DRAFT --> OD
     OD --> OAC["settle_draft_page → settle_draft<br/>(per invoice: isolated, committed)"]
     OAC --> WF{"settlement waterfall"}
@@ -371,8 +379,8 @@ flowchart TD
       → + commitments discount, + tax.resolve_tax (GST additive / SEZ zero / TDS withhold)
   → Invoice (Draft)
 
-[1st 06:00]  revenue.invoicing.collect_monthly_invoices
-  → open_drafts (pages the period's drafts, enqueues one page job per slice)
+[daily]      revenue.invoicing.collect_due_invoices   (sweeps until nothing is owed)
+  → open_drafts (pages every Draft with period_end ≤ the closed month, one page job per slice)
   → settle_draft_page → settle_draft → open_and_collect (per invoice)
       → settlement waterfall: credits (settlement.py) → card (charges.pay_invoice)
       → Invoice Draft → Open → (on webhook) Paid

--- a/central/billing/ARCHITECTURE.md
+++ b/central/billing/ARCHITECTURE.md
@@ -164,6 +164,8 @@ flowchart LR
         D1["daily"]
         H1["hourly"]
         M1["monthly"]
+        C1["cron · 1st 01:00"]
+        C2["cron · 1st 06:00"]
     end
     D1 --> RD["run_dunning"]
     D1 --> RR["run_reconciliation"]
@@ -172,10 +174,11 @@ flowchart LR
     D1 --> BF["backfill_missing_subscriptions"]
     H1 --> RF["retry_failed_syncs (ERPNext)"]
     M1 --> EX["expire_payment_methods"]
+    C1 --> DMI["draft_monthly_invoices → 1 job/team"]
+    C2 --> CMI["collect_monthly_invoices → 1 job/invoice"]
 
-    subgraph MANUAL["⚠️ NOT scheduled — manual/demo"]
-        GDI["generate_draft_invoices (28th)"]
-        OD["open_drafts (1st)"]
+    subgraph MANUAL["manual/demo only"]
+        RMB["run_monthly_billing (inline, both phases)"]
     end
 
     subgraph INSTALL["install/migrate/before_tests"]
@@ -197,11 +200,31 @@ flowchart LR
 | daily | `catalog.subscriptions.backfill_missing_subscriptions` | Subscription for any Running Asset missing one |
 | hourly | `revenue.erpnext_sync.retry_failed_syncs` | retry Sales Invoice push (backoff window elapsed) |
 | monthly | `payments.payments.expire_payment_methods` | flip cards past their printed month |
+| cron `0 1 1 * *` | `revenue.invoicing.draft_monthly_invoices` | phase 1 — fan one draft job out per team |
+| cron `0 6 1 * *` | `revenue.invoicing.collect_monthly_invoices` | phase 2 — fan one collect job out per invoice |
 
-> ⚠️ **Invoice generation is NOT in `scheduler_events`.** The 28th-draft / 1st-open phases
-> (`revenue.invoicing.generate_draft_invoices`, `open_drafts`) are designed for those dates
-> but are currently invoked **manually / by demo scenarios**, not by the scheduler. If
-> invoices "aren't appearing on the 28th", this is why — check who's calling them.
+**The monthly run is two ticks, and neither of them does the work.** Each is an
+orchestrator: it pages its subjects and enqueues one job per team (drafting) or per
+invoice (collection) on the **long** queue, deduplicated on (period, team) /
+(invoice). One job = one team = one transaction = one commit, and a job that fails
+is contained — logged as `Billing Run Failure`, rolled back to its own savepoint,
+and re-attempted by the next tick, since both phases are idempotent.
+
+Why both ticks land on the 1st rather than the documented 28th/1st: a calendar month
+billed in arrears is not closed until it ends, so drafting on the 28th would bill days
+that had not happened. The split that matters is heavy-local (rating) vs slow-external
+(gateway), and that is preserved — five hours apart on the same morning.
+
+`run_monthly_billing` still runs both phases inline for demos, small sites and manual
+re-runs. `billing_run_status()` reports what the current period's run has actually
+achieved (drafted / pending / collected / failures), derived from the tables rather
+than from a counter — read it before deciding to re-fire a tick.
+
+**Worker math.** One collected invoice ≈ 2s (rating is ~100ms; the rest is the gateway
+round-trip). Sequentially that is 50k × 2s ≈ 28h — longer than the billing day. Fanned
+out over N long-queue workers it is 50k × 2s / N: **20 workers ≈ 1.4h**, 40 ≈ 42min.
+Drafting is cheaper (~0.3s/team) and finishes well inside the five-hour gap before the
+collect tick. Size the queue to the team count, not to the invoice amount.
 
 ### Lifecycle / install hooks
 - `after_install` / `after_migrate` / `before_tests` → `catalog.taxonomy_setup.ensure_catalog_masters` (idempotent seed of catalog masters — ADR 0007).
@@ -248,8 +271,9 @@ Resize: `resize_composed_config → resize_composed_subscription` → new Subscr
 ### B. Bill a period (draft → open → collect)
 ```mermaid
 flowchart TD
-    S28(["28th · off-peak"]) --> GDI["generate_draft_invoices"]
-    GDI --> GTI["generate_team_invoice (per team)"]
+    DRAFTTICK(["1st 01:00 · draft tick"]) --> GDI["draft_monthly_invoices<br/>→ generate_draft_invoices (pages teams)"]
+    GDI --> DTI["draft_team_invoice<br/>(1 job/team, isolated)"]
+    DTI --> GTI["generate_team_invoice (per team)"]
     GTI --> RS["reconcile_subscription (fix drift)"]
     GTI --> LINES["lines.compute_line_items<br/>day-weighted from Sub Change segments"]
     GTI --> MET["+ metering.metered_line_items<br/>max(0, qty−allowance)×rate"]
@@ -257,9 +281,9 @@ flowchart TD
     GTI --> TAX["+ tax.resolve_tax<br/>GST / SEZ / TDS"]
     LINES & MET & DISC & TAX --> DRAFT[["Invoice: Draft"]]
 
-    S1(["1st · light/parallel"]) --> OD["open_drafts"]
+    COLLECTTICK(["1st 06:00 · collect tick"]) --> OD["collect_monthly_invoices<br/>→ open_drafts (pages drafts)"]
     DRAFT --> OD
-    OD --> OAC["open_and_collect (enqueued per invoice)"]
+    OD --> OAC["settle_draft → open_and_collect<br/>(1 job/invoice, isolated)"]
     OAC --> WF{"settlement waterfall"}
     WF -->|credits| CR["settlement.py"]
     WF -->|then card| CARD["charges.pay_invoice"]
@@ -268,16 +292,19 @@ flowchart TD
     PAID --> SYNC["erpnext_sync.enqueue_invoice_sync"]
 ```
 ```
-[28th, off-peak]  revenue.invoicing.generate_draft_invoices
-  → generate_team_invoice (per team, aggregates clusters)
+[1st 01:00]  revenue.invoicing.draft_monthly_invoices
+  → generate_draft_invoices (pages teams, enqueues one job each)
+  → draft_team_invoice (one job = one team = one commit; failure contained + logged)
+    → generate_team_invoice (per team, aggregates clusters)
       → reconcile_subscription (correct drift if stale)
       → lines.compute_line_items  (day-weighted, from Subscription Change rate-snapshot segments)
       → + metering.metered_line_items   (max(0, qty−allowance) × rate)
       → + commitments discount, + tax.resolve_tax (GST additive / SEZ zero / TDS withhold)
   → Invoice (Draft)
 
-[1st, light/parallel]  revenue.invoicing.open_drafts
-  → open_and_collect (per invoice; enqueued)
+[1st 06:00]  revenue.invoicing.collect_monthly_invoices
+  → open_drafts (pages the period's drafts, enqueues one job each)
+  → settle_draft → open_and_collect (per invoice)
       → settlement waterfall: credits (settlement.py) → card (charges.pay_invoice)
       → Invoice Draft → Open → (on webhook) Paid
       → on Paid: erpnext_sync.enqueue_invoice_sync
@@ -408,7 +435,8 @@ get_team_caps resolves caps live (no per-team Trust Tier doctype — dropped)
 
 | Symptom | Start at |
 |---|---|
-| Invoice never generated | invoicing not scheduled (§3 ⚠️); check caller of `generate_draft_invoices`; `lines.compute_line_items` for empty segments |
+| Invoice never generated | `billing_run_status()` — is the team in `pending_draft`? then Error Log `Billing Run Failure` for that team, the long queue for stuck jobs, and `lines.compute_line_items` for empty segments |
+| Half the teams billed, half not | a partial run: read `billing_run_status()`, fix the cause, re-fire `draft_monthly_invoices` — both phases are idempotent and resume |
 | Invoice wrong amount | `lines.compute_line_items` (day-weighting), `metering.metered_line_items`, `commitments` discount, `tax.resolve_tax`; verify Subscription Change `locked_rate` segments |
 | Charge stuck "Open"/unpaid | `payments/webhooks.py` (signature failed? Webhook Event row?), `charges.apply_webhook`, `collection.collect_invoice` fallback chain |
 | Webhook ignored | `webhooks.process_webhook` signature check; gateway `verify_signature`; dedupe against existing Webhook Event |

--- a/central/billing/ARCHITECTURE.md
+++ b/central/billing/ARCHITECTURE.md
@@ -258,6 +258,34 @@ over 32 workers ≈ 2.6h, which does *not* fit the five-hour gap with much room 
 at that scale — widen the gap or the pool before you get there. Size the pool from the
 team count, never from the invoice amount.
 
+**What the run actually contends on.** The tables a draft reads — Subscription,
+Subscription Change, Payment Method, Catalog Rate, Usage Rollup — are read with plain
+consistent reads, which under InnoDB MVCC take **no locks at all**, so no number of
+workers can make them block each other. Credit Wallet *is* locked `FOR UPDATE`, but the
+key is (team, currency): a team only ever contends with its own concurrent top-up.
+
+There is exactly one **global** lock in the run, and it is not a data table. Every
+Invoice insert calls `make_autoname("INV-YYYY-MM-.#####")`, which takes the `tabSeries`
+row `FOR UPDATE` and holds it **until the transaction commits** — so every worker in
+the run queues behind one row. Measured on a dev bench: ~6ms held per invoice, i.e. a
+ceiling of **~169 invoices/sec however many workers you add**, or ~1.6h for a million.
+That sits *above* the worker-bound rate until roughly 50 billing workers (at ~0.3s of
+rating per team, W workers deliver W×3.3/sec), so it is a ceiling to know about, not
+one to design around yet. If you ever need past it, shard the series — `INV-YYYY-MM-A-`,
+`-B-`, … per page — which GST permits as long as each series is itself consecutive.
+
+Two things keep that lock short, and both are load-bearing:
+
+- **One team = one transaction = one commit**, inline and fanned out alike. A page job
+  that committed once at the end would hold the series row for 500 teams — minutes —
+  and every other worker would hit `innodb_lock_wait_timeout` (50s by default). The
+  commit inside the page loop is what makes the critical section milliseconds.
+- **Contention is retried, not contained.** A lock-wait timeout (1205) or deadlock
+  (1213) means the team lost a race, not that its data is bad. `draft_team_invoice`
+  retries it with jittered backoff (`CONTENTION_RETRIES`), because the draft tick comes
+  round once a *month* — a contained loser would go unbilled until someone noticed.
+  Only after the budget is exhausted is it recorded as a `Billing Run Failure`.
+
 **A late run never costs the customer grace.** `due_date` and `dunning_starts_on` are
 both set from the day the invoice is actually *opened*, so a run three days behind
 bills three days later rather than three days overdue. Beyond that, any collection
@@ -479,6 +507,7 @@ get_team_caps resolves caps live (no per-team Trust Tier doctype — dropped)
 | Invoice never generated | `billing_run_status()` — is the team in `pending_draft`? then Error Log `Billing Run Failure` for that team, the long queue for stuck jobs, and `lines.compute_line_items` for empty segments |
 | Half the teams billed, half not | a partial run: read `billing_run_status()`, fix the cause, re-fire `draft_monthly_invoices` — both phases are idempotent and resume |
 | Billing run never starts / jobs pile up | is there a worker on the `billing` queue? (`common_site_config.workers.billing` + `bench worker --queue billing`); the billing log warns and falls back to `long` if the queue is undeclared |
+| Lock wait timeouts during the run | check the per-unit `frappe.db.commit()` in `draft_team_page`/`settle_draft_page` is still there — without it the `tabSeries` lock is held for a whole page; then check nothing new writes a shared row inside the unit |
 | Run is far too slow | `background_workers` on the billing queue is the only throughput dial — but it is also the gateway concurrency cap; check for 429s (`Billing Run Failure` Error Logs, `dunning_starts_on` deferrals) before raising it |
 | Customer dunned during a backlog | should be impossible: `dunning_starts_on` is pushed by `dunning.defer_dunning` on every failure of ours. If it happened, find the collection path that failed without calling it |
 | Invoice wrong amount | `lines.compute_line_items` (day-weighting), `metering.metered_line_items`, `commitments` discount, `tax.resolve_tax`; verify Subscription Change `locked_rate` segments |

--- a/central/billing/SETUP-AND-DEMO.md
+++ b/central/billing/SETUP-AND-DEMO.md
@@ -157,13 +157,14 @@ Creates the **Subscription** (intent) + first **Subscription Change** row carryi
 `api/dashboard/catalog.provision_composed_config`.
 
 ### Step 7 · Generate the invoice
-> ⚠️ Invoice generation is **not on the scheduler** (see `ARCHITECTURE.md` §3) — drive it
-> by hand for a demo.
+> Invoice generation runs on the scheduler as two ticks on the 1st (see
+> `ARCHITECTURE.md` §3), each fanning work out to workers. For a demo, drive it by hand —
+> the calls below are the same work without the queue.
 ```bash
 # One team, one period (in arrears):
 bench --site central.local execute central.billing.revenue.invoicing.generate_team_invoice \
   --kwargs '{"team":"<TEAM>","period_start":"2026-06-01","period_end":"2026-06-30"}'
-# …or all teams for the period (the 28th "draft" phase):
+# …or all teams for the period (the draft phase, inline):
 bench --site central.local execute central.billing.revenue.invoicing.generate_draft_invoices \
   --kwargs '{"period_start":"2026-06-01","period_end":"2026-06-30"}'
 ```
@@ -172,7 +173,7 @@ segments) + metered overage + commitment discount + tax. Result: **Invoice (Draf
 
 ### Step 8 · Open & collect (settle)
 ```bash
-# The 1st "open" phase — runs the credits→card waterfall per draft:
+# The collect phase — runs the credits→card waterfall per draft:
 bench --site central.local execute central.billing.revenue.invoicing.open_drafts \
   --kwargs '{"period_end":"2026-06-30"}'
 ```
@@ -215,5 +216,5 @@ For e2e isolation, each Playwright spec seeds + tears down its own sandbox via
 | Plans + rates | — | ✅ Plan Configurator |
 | Trust tiers / Tax profiles | — | ✅ reference data |
 | Billing Profile (per team) | — | ✅ wizard (gates money) |
-| Invoice generation | ❌ **not scheduled** | ✅ run `generate_*` / `open_drafts` |
+| Invoice generation | ✅ two cron ticks on the 1st (draft, then collect) | ✅ `run_monthly_billing` / `generate_*` / `open_drafts` |
 | Dunning / reconciliation / e-mandate / card expiry | ✅ scheduled | — |

--- a/central/billing/doctype/invoice/invoice.json
+++ b/central/billing/doctype/invoice/invoice.json
@@ -16,6 +16,7 @@
   "period_start",
   "period_end",
   "due_date",
+  "dunning_starts_on",
   "period_key",
   "section_break_items",
   "items",
@@ -98,6 +99,13 @@
    "fieldname": "due_date",
    "fieldtype": "Date",
    "label": "Due Date"
+  },
+  {
+   "fieldname": "dunning_starts_on",
+   "fieldtype": "Date",
+   "label": "Dunning Starts On",
+   "read_only": 1,
+   "description": "When the retry ladder may begin. Starts at the due date, and is pushed forward whenever a collection attempt fails on our side — so a billing-run backlog never costs the customer their grace period."
   },
   {
    "fieldname": "period_key",

--- a/central/billing/payments/charges.py
+++ b/central/billing/payments/charges.py
@@ -174,6 +174,11 @@ def _charge_claimed_attempt(attempt_name: str) -> dict:
 		# Transient: leave the attempt initiated so a retry reuses the same key.
 		attempt.failure_reason = str(e)[:140]
 		attempt.save(ignore_permissions=True)
+		# We never reached the customer — a rate limit or a network fault is ours, not
+		# theirs — so their retry ladder must not start ticking on it.
+		from central.billing.revenue.dunning import defer_dunning
+
+		defer_dunning(attempt.invoice, f"gateway unreachable: {str(e)[:80]}")
 		_persist()
 		return {"charged": False, "reason": "timeout", "attempt": attempt.name}
 

--- a/central/billing/revenue/dunning.py
+++ b/central/billing/revenue/dunning.py
@@ -28,6 +28,44 @@ SUSPEND_AFTER_DAYS = 14
 TERMINATE_AFTER_DAYS = 44
 
 
+def defer_dunning(invoice: str, reason: str) -> bool:
+	"""Push an invoice's dunning clock forward — we failed to ask, so they aren't late.
+
+	Every stage below is counted from a date the customer is entitled to assume we
+	honoured: that we tried to collect when we said we would. When the attempt fails
+	on *our* side — the gateway rate-limited us, the run backed up, a worker died
+	mid-charge — the customer did nothing wrong, and starting their retry ladder,
+	their Overdue notice and their suspension countdown on that date would be
+	charging them for our outage.
+
+	So the clock restarts at today plus the same window a freshly opened invoice
+	gets. Monotonic (it only ever moves forward) and self-limiting (a successful
+	ask stops pushing it), so a permanently broken gateway cannot defer collection
+	forever — it defers *escalation*, while reconciliation and the next run keep
+	trying. `due_date` is untouched: what the customer owes and when they owed it is
+	an accounting fact, and AR aging must keep telling the truth.
+	"""
+	from central.billing.revenue.invoicing import DEFAULT_DUE_DAYS
+
+	fair_start = frappe.utils.add_days(frappe.utils.nowdate(), DEFAULT_DUE_DAYS)
+	current = frappe.db.get_value("Invoice", invoice, "dunning_starts_on")
+	if current and frappe.utils.getdate(current) >= frappe.utils.getdate(fair_start):
+		return False
+	frappe.db.set_value("Invoice", invoice, "dunning_starts_on", fair_start)
+	frappe.logger("billing").info(f"dunning for {invoice} deferred to {fair_start}: {reason}")
+	return True
+
+
+def dunning_clock_start(invoice_doc):
+	"""The date this invoice's retry ladder counts from.
+
+	`dunning_starts_on` is absent on invoices raised before it existed, and on any
+	invoice whose collection went to plan — in both cases the due date is the
+	honest answer.
+	"""
+	return invoice_doc.get("dunning_starts_on") or invoice_doc.due_date
+
+
 def _notify(invoice, message: str):
 	invoice.add_comment("Info", message)
 
@@ -104,7 +142,7 @@ def process_invoice_dunning(invoice_name: str, now=None) -> dict:
 	if not inv.due_date:
 		return {"invoice": invoice_name, "skipped": "no_due_date"}
 
-	days = (frappe.utils.getdate(now) - frappe.utils.getdate(inv.due_date)).days
+	days = (frappe.utils.getdate(now) - frappe.utils.getdate(dunning_clock_start(inv))).days
 	if days < RETRY_DAYS[0]:
 		return {"invoice": invoice_name, "days_overdue": days, "action": "none"}
 

--- a/central/billing/revenue/invoicing/__init__.py
+++ b/central/billing/revenue/invoicing/__init__.py
@@ -18,13 +18,12 @@ Subscription Change already encodes both the time windows (effective_at per
 row) and the rate snapshot, so billing reads only Central — no live Agent call
 in the common (push-primary) case.
 
-Split into modules (lines / generate / lifecycle); this package re-exports the
-public API so callers and the `billing.revenue.invoicing.*` enqueue paths hold.
+Split into modules (lines / generate / lifecycle / run); this package re-exports
+the public API so callers and the `billing.revenue.invoicing.*` enqueue paths hold.
 """
 
 from central.billing.revenue.invoicing.generate import (
 	generate_draft_invoice,
-	generate_draft_invoices,
 	generate_team_invoice,
 	reconcile_subscription,
 )
@@ -32,11 +31,14 @@ from central.billing.revenue.invoicing.lifecycle import (
 	DEFAULT_DUE_DAYS,
 	cancel_invoice,
 	open_and_collect,
-	open_drafts,
 	reissue_invoice,
-	run_monthly_billing,
 )
 from central.billing.revenue.invoicing.lines import compute_line_items
+from central.billing.revenue.invoicing.run import (
+	generate_draft_invoices,
+	open_drafts,
+	run_monthly_billing,
+)
 
 __all__ = [
 	"compute_line_items",

--- a/central/billing/revenue/invoicing/__init__.py
+++ b/central/billing/revenue/invoicing/__init__.py
@@ -35,6 +35,8 @@ from central.billing.revenue.invoicing.lifecycle import (
 )
 from central.billing.revenue.invoicing.lines import compute_line_items
 from central.billing.revenue.invoicing.run import (
+	collect_monthly_invoices,
+	draft_monthly_invoices,
 	draft_team_invoice,
 	generate_draft_invoices,
 	open_drafts,
@@ -47,5 +49,6 @@ __all__ = [
 	"reconcile_subscription", "generate_draft_invoice", "generate_team_invoice",
 	"generate_draft_invoices", "draft_team_invoice",
 	"open_and_collect", "open_drafts", "cancel_invoice", "reissue_invoice", "DEFAULT_DUE_DAYS",
-	"settle_draft", "run_monthly_billing",
+	"settle_draft",
+	"draft_monthly_invoices", "collect_monthly_invoices", "run_monthly_billing",
 ]

--- a/central/billing/revenue/invoicing/__init__.py
+++ b/central/billing/revenue/invoicing/__init__.py
@@ -35,6 +35,7 @@ from central.billing.revenue.invoicing.lifecycle import (
 )
 from central.billing.revenue.invoicing.lines import compute_line_items
 from central.billing.revenue.invoicing.run import (
+	billing_run_status,
 	collect_monthly_invoices,
 	draft_monthly_invoices,
 	draft_team_invoice,
@@ -51,4 +52,5 @@ __all__ = [
 	"open_and_collect", "open_drafts", "cancel_invoice", "reissue_invoice", "DEFAULT_DUE_DAYS",
 	"settle_draft",
 	"draft_monthly_invoices", "collect_monthly_invoices", "run_monthly_billing",
+	"billing_run_status",
 ]

--- a/central/billing/revenue/invoicing/__init__.py
+++ b/central/billing/revenue/invoicing/__init__.py
@@ -35,15 +35,17 @@ from central.billing.revenue.invoicing.lifecycle import (
 )
 from central.billing.revenue.invoicing.lines import compute_line_items
 from central.billing.revenue.invoicing.run import (
+	draft_team_invoice,
 	generate_draft_invoices,
 	open_drafts,
 	run_monthly_billing,
+	settle_draft,
 )
 
 __all__ = [
 	"compute_line_items",
 	"reconcile_subscription", "generate_draft_invoice", "generate_team_invoice",
-	"generate_draft_invoices",
+	"generate_draft_invoices", "draft_team_invoice",
 	"open_and_collect", "open_drafts", "cancel_invoice", "reissue_invoice", "DEFAULT_DUE_DAYS",
-	"run_monthly_billing",
+	"settle_draft", "run_monthly_billing",
 ]

--- a/central/billing/revenue/invoicing/__init__.py
+++ b/central/billing/revenue/invoicing/__init__.py
@@ -36,7 +36,7 @@ from central.billing.revenue.invoicing.lifecycle import (
 from central.billing.revenue.invoicing.lines import compute_line_items
 from central.billing.revenue.invoicing.run import (
 	billing_run_status,
-	collect_monthly_invoices,
+	collect_due_invoices,
 	draft_monthly_invoices,
 	draft_team_invoice,
 	draft_team_page,
@@ -53,6 +53,6 @@ __all__ = [
 	"generate_draft_invoices", "draft_team_invoice", "draft_team_page",
 	"open_and_collect", "open_drafts", "cancel_invoice", "reissue_invoice", "DEFAULT_DUE_DAYS",
 	"settle_draft", "settle_draft_page",
-	"draft_monthly_invoices", "collect_monthly_invoices", "run_monthly_billing",
+	"draft_monthly_invoices", "collect_due_invoices", "run_monthly_billing",
 	"billing_run_status",
 ]

--- a/central/billing/revenue/invoicing/__init__.py
+++ b/central/billing/revenue/invoicing/__init__.py
@@ -39,18 +39,20 @@ from central.billing.revenue.invoicing.run import (
 	collect_monthly_invoices,
 	draft_monthly_invoices,
 	draft_team_invoice,
+	draft_team_page,
 	generate_draft_invoices,
 	open_drafts,
 	run_monthly_billing,
 	settle_draft,
+	settle_draft_page,
 )
 
 __all__ = [
 	"compute_line_items",
 	"reconcile_subscription", "generate_draft_invoice", "generate_team_invoice",
-	"generate_draft_invoices", "draft_team_invoice",
+	"generate_draft_invoices", "draft_team_invoice", "draft_team_page",
 	"open_and_collect", "open_drafts", "cancel_invoice", "reissue_invoice", "DEFAULT_DUE_DAYS",
-	"settle_draft",
+	"settle_draft", "settle_draft_page",
 	"draft_monthly_invoices", "collect_monthly_invoices", "run_monthly_billing",
 	"billing_run_status",
 ]

--- a/central/billing/revenue/invoicing/generate.py
+++ b/central/billing/revenue/invoicing/generate.py
@@ -22,8 +22,13 @@ from central.billing.catalog import commitments
 from central.billing.revenue.invoicing.lines import compute_line_items
 
 
-def _live_invoice(team: str, period_start, period_end) -> str | None:
-	"""The team's existing live (non-cancelled) invoice for the period, if any."""
+def _live_invoice(team: str, period_start, period_end, for_update: bool = False) -> str | None:
+	"""The team's existing live (non-cancelled) invoice for the period, if any.
+
+	`for_update` is how the loser of an insert race finds the winner: a locking read
+	sees the latest committed row, while a plain one is answered from the snapshot
+	this transaction started with — which predates the winner's commit.
+	"""
 	return frappe.db.get_value(
 		"Invoice",
 		{
@@ -33,6 +38,7 @@ def _live_invoice(team: str, period_start, period_end) -> str | None:
 			"status": ["!=", "Cancelled"],
 		},
 		"name",
+		for_update=for_update,
 	)
 
 
@@ -41,6 +47,8 @@ def _live_invoice(team: str, period_start, period_end) -> str | None:
 # Under real concurrency both occur, so both mean the same thing here.
 _ALREADY_BILLED = (frappe.UniqueValidationError, frappe.DuplicateEntryError)
 
+_INSERT_SAVEPOINT = "invoice_insert"
+
 
 def _insert_invoice(payload: dict) -> str:
 	"""Insert the draft, or yield to the worker that got there first.
@@ -48,13 +56,20 @@ def _insert_invoice(payload: dict) -> str:
 	A unique-key conflict here is not an error — it is the index doing its job. Another
 	worker billed this (team, period) between our check and our insert; its invoice is
 	the invoice, and we return it rather than billing the team a second time.
+
+	Clearing the failed insert is a rollback to a savepoint, not a blanket one: the
+	inline run bills many teams in a single transaction, and losing a race on this
+	team must not discard the teams already drafted. The transaction therefore
+	survives — so the read that finds the winner has to lock, or it would be
+	answered from a snapshot taken before the winner committed.
 	"""
+	frappe.db.savepoint(_INSERT_SAVEPOINT)
 	try:
 		return frappe.get_doc(payload).insert(ignore_permissions=True).name
 	except _ALREADY_BILLED:
-		frappe.db.rollback()
+		frappe.db.rollback(save_point=_INSERT_SAVEPOINT)
 		existing = _live_invoice(
-			payload["team"], payload["period_start"], payload["period_end"]
+			payload["team"], payload["period_start"], payload["period_end"], for_update=True
 		)
 		if not existing:
 			raise  # a conflict on some other unique key — don't swallow it

--- a/central/billing/revenue/invoicing/generate.py
+++ b/central/billing/revenue/invoicing/generate.py
@@ -65,6 +65,18 @@ def _insert_invoice(payload: dict) -> str:
 		return existing
 
 
+def primary_subscription(team: str) -> str | None:
+	"""The team's earliest subscription — its payment method funds the auto-charge.
+
+	Oldest-first is the contract the run has always billed under; it lives here so
+	the orchestrator can page bare team names and let each job resolve its own.
+	"""
+	names = frappe.get_all(
+		"Subscription", filters={"team": team}, pluck="name", order_by="creation asc", limit=1
+	)
+	return names[0] if names else None
+
+
 def reconcile_subscription(subscription_doc):
 	"""Refresh the current period's metered figures from the cluster manager if stale.
 
@@ -194,7 +206,7 @@ def generate_team_invoice(team: str, period_start, period_end, subscription: str
 	total = frappe.utils.flt(taxable_base + tax["output_tax_amount"], 2)
 	expected = frappe.utils.flt(total - tax["tds_amount"], 2)
 	if subscription is None:
-		subscription = frappe.db.get_value("Subscription", {"team": team}, "name")
+		subscription = primary_subscription(team)
 
 	name = _insert_invoice(
 		{

--- a/central/billing/revenue/invoicing/generate.py
+++ b/central/billing/revenue/invoicing/generate.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026, Frappe and contributors
 # For license information, please see license.txt
-"""Phase 1 (28th, off-peak): reconcile-if-stale, then draft.
+"""Phase 1 (heavy): reconcile-if-stale, then draft — one team at a time.
 
 Per team/subscription, compute day-weighted fixed lines (from Subscription
 Change rate-snapshot segments) plus metered overage, apply the commitment
@@ -225,30 +225,3 @@ def generate_team_invoice(team: str, period_start, period_end, subscription: str
 	)
 	commitments.mark_breached(commitment)
 	return name
-
-
-def generate_draft_invoices(period_start, period_end, enqueue: bool = False) -> list[str]:
-	"""Phase-1 orchestrator: ONE consolidated draft per team for the period.
-
-	A team that runs instances across several clusters still gets a single
-	invoice (generate_team_invoice aggregates all its clusters). The team's first
-	subscription is the primary (its payment method funds the auto-charge).
-	"""
-	primary = {}
-	for s in frappe.get_all("Subscription", fields=["name", "team"], order_by="creation asc"):
-		primary.setdefault(s.team, s.name)
-	created = []
-	for team, sub in primary.items():
-		if enqueue:
-			frappe.enqueue(
-				"central.billing.revenue.invoicing.generate_team_invoice",
-				team=team,
-				period_start=period_start,
-				period_end=period_end,
-				subscription=sub,
-			)
-			continue
-		name = generate_team_invoice(team, period_start, period_end, subscription=sub)
-		if name:
-			created.append(name)
-	return created

--- a/central/billing/revenue/invoicing/lifecycle.py
+++ b/central/billing/revenue/invoicing/lifecycle.py
@@ -1,17 +1,18 @@
 # Copyright (c) 2026, Frappe and contributors
 # For license information, please see license.txt
-"""Phase 2 (1st, light/parallel) + pre-payment corrections.
+"""Phase 2 (light/parallel) + pre-payment corrections — one invoice at a time.
 
 `open_and_collect` runs the credits-then-card waterfall and claims Draft -> Open
 atomically. `cancel_invoice` / `reissue_invoice` are the pre-payment correction
 path — issued line items are never mutated; a whole invoice is cancelled and
-reissued from current data.
+reissued from current data. Who calls these across a whole period, and on which
+worker, is `run.py`'s business.
 """
 
 import frappe
 
 from central.billing.revenue import credits
-from central.billing.revenue.invoicing.generate import generate_draft_invoice, generate_draft_invoices
+from central.billing.revenue.invoicing.generate import generate_draft_invoice
 
 DEFAULT_DUE_DAYS = 7
 
@@ -94,43 +95,6 @@ def open_and_collect(invoice: str, collect: bool = True) -> dict:
 
 	return {"invoice": invoice, "claimed": True, "credit_applied": applied,
 			"expected_collection": doc.expected_collection, "status": "Open", "charge": charge}
-
-
-def open_drafts(period_end, enqueue: bool = False) -> list[str]:
-	"""Phase-2 orchestrator: open every Draft for the billing month."""
-	drafts = frappe.get_all(
-		"Invoice", filters={"status": "Draft", "period_end": period_end}, pluck="name"
-	)
-	for inv in drafts:
-		if enqueue:
-			frappe.enqueue("central.billing.revenue.invoicing.open_and_collect", invoice=inv)
-		else:
-			open_and_collect(inv)
-	return drafts
-
-
-def run_monthly_billing(today=None) -> dict:
-	"""Scheduled entrypoint (1st of the month): bill the just-closed calendar month
-	end-to-end for every team — the production trigger for the two-phase invoicing
-	(#09/#10) that otherwise only ran from demos and tests.
-
-	Phase 1 drafts one consolidated invoice per team for the previous month; phase 2
-	opens each Draft and runs the credits-then-card waterfall — settling it, or leaving
-	it Open for dunning (#14). Idempotent: drafting is idempotent per (team, period) and
-	open_drafts only touches invoices still in Draft, so a retried tick is safe.
-	"""
-	today = frappe.utils.getdate(today or frappe.utils.nowdate())
-	period_start = frappe.utils.get_first_day(today, d_months=-1)
-	period_end = frappe.utils.get_last_day(period_start)
-
-	drafted = generate_draft_invoices(period_start, period_end)
-	opened = open_drafts(period_end)
-	return {
-		"period_start": str(period_start),
-		"period_end": str(period_end),
-		"drafted": len(drafted),
-		"opened": len(opened),
-	}
 
 
 def cancel_invoice(invoice: str, reason: str | None = None) -> str:

--- a/central/billing/revenue/invoicing/lifecycle.py
+++ b/central/billing/revenue/invoicing/lifecycle.py
@@ -73,7 +73,13 @@ def open_and_collect(invoice: str, collect: bool = True) -> dict:
 	doc.expected_collection = frappe.utils.flt(
 		frappe.utils.flt(doc.total) - frappe.utils.flt(doc.tds_amount) - applied, 2
 	)
+	# Both dates are set from *today*, not from the period end: an invoice the run
+	# opened three days late is due three days later, and its dunning ladder starts
+	# three days later. A backlog delays collection; it never shortens the customer's
+	# window. From here the two diverge — due_date is the accounting fact and stays
+	# put, while dunning_starts_on moves if we fail to ask again (dunning.defer_dunning).
 	doc.due_date = frappe.utils.add_days(frappe.utils.nowdate(), DEFAULT_DUE_DAYS)
+	doc.dunning_starts_on = doc.due_date
 
 	# Credits cover it in full — settled, no card charge needed.
 	if doc.expected_collection <= 0:

--- a/central/billing/revenue/invoicing/run.py
+++ b/central/billing/revenue/invoicing/run.py
@@ -8,6 +8,7 @@ work is spread over workers.
 """
 
 import frappe
+from frappe.query_builder.functions import Count
 
 from central.billing.revenue.invoicing.generate import generate_team_invoice
 from central.billing.revenue.invoicing.lifecycle import open_and_collect
@@ -210,9 +211,55 @@ def collect_monthly_invoices(today=None) -> dict:
 	get collected on time.
 	"""
 	period_start, period_end = billing_period(today)
+	# Logged before fanning out, so the record of what drafting achieved (and what it
+	# missed) exists even if collection then falls over.
+	frappe.logger("billing").info(f"billing run {period_end}: {billing_run_status(today)}")
 	fanned = open_drafts(period_end, enqueue=True)
 	frappe.logger("billing").info(f"billing run {period_end}: collection fanned out for {len(fanned)} invoices")
 	return {"period_start": str(period_start), "period_end": str(period_end), "invoices": len(fanned)}
+
+
+def billing_run_status(today=None) -> dict:
+	"""What the run for the just-closed month has actually achieved so far.
+
+	Derived from the tables, not tracked alongside them: a counter the run keeps is a
+	counter that lies the moment a worker dies mid-job. Teams, invoices and their
+	statuses are the truth, so this reads correctly for a run that only half
+	happened — which is the run you need to read. `pending_draft` and
+	`pending_collection` are what a re-fired tick would pick up.
+
+	`pending_draft` is an upper bound: a team with nothing billable produces no
+	invoice by design, and shows up here as one that was never drafted.
+	"""
+	period_start, period_end = billing_period(today)
+	sub = frappe.qb.DocType("Subscription")
+	teams = (frappe.qb.from_(sub).select(Count(sub.team).distinct())).run()[0][0]
+
+	inv = frappe.qb.DocType("Invoice")
+	counts = {
+		row.status: row.invoices
+		for row in (
+			frappe.qb.from_(inv)
+			.select(inv.status, Count(inv.name).as_("invoices"))
+			.where(inv.period_end == period_end)
+			.groupby(inv.status)
+		).run(as_dict=True)
+	}
+	drafted = sum(n for status, n in counts.items() if status != "Cancelled")
+	pending_collection = counts.get("Draft", 0)
+	return {
+		"period_start": str(period_start),
+		"period_end": str(period_end),
+		"teams": teams,
+		"drafted": drafted,
+		"pending_draft": max(teams - drafted, 0),
+		"pending_collection": pending_collection,
+		"collected": drafted - pending_collection,
+		"by_status": counts,
+		"failures": frappe.db.count(
+			"Error Log", {"method": BILLING_RUN_FAILURE, "creation": [">=", period_end]}
+		),
+	}
 
 
 def run_monthly_billing(today=None) -> dict:

--- a/central/billing/revenue/invoicing/run.py
+++ b/central/billing/revenue/invoicing/run.py
@@ -270,8 +270,14 @@ def generate_draft_invoices(period_start, period_end, enqueue: bool = False) -> 
 	return created
 
 
-def draft_pages(period_end, page_size: int = COLLECT_PAGE_SIZE):
-	"""Yield the period's Draft invoices, one bounded page at a time.
+def draft_pages(cutoff, page_size: int = COLLECT_PAGE_SIZE):
+	"""Yield every still-Draft invoice for a month that closed on or before `cutoff`,
+	one bounded page at a time.
+
+	`<=`, not `==`: collection sweeps every draft whose period has ended, not one exact
+	month. That is what makes the sweep re-runnable — a draft that landed after the last
+	sweep (drafting hadn't caught up), or one a settle page left behind, is found by the
+	next sweep instead of being orphaned until (and then past) the next monthly tick.
 
 	Keyset paging on the name — correct even though settling a draft removes it
 	from the filter as we walk, because the cursor advances by name, not by offset.
@@ -280,7 +286,7 @@ def draft_pages(period_end, page_size: int = COLLECT_PAGE_SIZE):
 	while True:
 		page = frappe.get_all(
 			"Invoice",
-			filters={"status": "Draft", "period_end": period_end, "name": (">", after)},
+			filters={"status": "Draft", "period_end": ("<=", cutoff), "name": (">", after)},
 			pluck="name",
 			order_by="name asc",
 			limit=page_size,
@@ -291,14 +297,15 @@ def draft_pages(period_end, page_size: int = COLLECT_PAGE_SIZE):
 		after = page[-1]
 
 
-def drafts_to_settle(period_end, page_size: int = COLLECT_PAGE_SIZE):
-	"""The period's Draft invoices, page by page, flattened."""
-	for page in draft_pages(period_end, page_size):
+def drafts_to_settle(cutoff, page_size: int = COLLECT_PAGE_SIZE):
+	"""Every settleable Draft on or before `cutoff`, page by page, flattened."""
+	for page in draft_pages(cutoff, page_size):
 		yield from page
 
 
-def drafts_in_range(period_end, after: str, until: str) -> list[str]:
-	"""The still-Draft invoices in one cursor slice `(after, until]`.
+def drafts_in_range(cutoff, after: str, until: str) -> list[str]:
+	"""The still-Draft invoices in one cursor slice `(after, until]`, for any month
+	that closed on or before `cutoff`.
 
 	Re-read at run time, not carried in the job: by the time a page job starts, some
 	of its slice may already be settled (a retried tick, a customer paying
@@ -308,7 +315,7 @@ def drafts_in_range(period_end, after: str, until: str) -> list[str]:
 		"Invoice",
 		filters=[
 			["status", "=", "Draft"],
-			["period_end", "=", period_end],
+			["period_end", "<=", cutoff],
 			["name", ">", after],
 			["name", "<=", until],
 		],
@@ -317,7 +324,7 @@ def drafts_in_range(period_end, after: str, until: str) -> list[str]:
 	)
 
 
-def settle_draft_page(period_end, after: str, until: str) -> dict:
+def settle_draft_page(cutoff, after: str, until: str) -> dict:
 	"""Settle every draft in one cursor slice — the unit a billing worker picks up.
 
 	Sequential within the page, deliberately: the gateway concurrency of the whole
@@ -326,15 +333,15 @@ def settle_draft_page(period_end, after: str, until: str) -> dict:
 	make it faster — it would make it rate-limited.
 	"""
 	settled = 0
-	for invoice in drafts_in_range(period_end, after, until):
+	for invoice in drafts_in_range(cutoff, after, until):
 		if settle_draft(invoice):
 			settled += 1
 		frappe.db.commit()  # nosemgrep: frappe-manual-commit -- one invoice, one transaction
 	return {"after": after, "until": until, "settled": settled}
 
 
-def open_drafts(period_end, enqueue: bool = False) -> list[str]:
-	"""Phase-2 orchestrator: open every Draft for the billing month.
+def open_drafts(cutoff, enqueue: bool = False) -> list[str]:
+	"""Phase-2 orchestrator: open every Draft for a month closed on or before `cutoff`.
 
 	Page jobs, not a job per invoice — same reason as drafting, plus one specific to
 	collection: a job per invoice puts the run's gateway concurrency at the mercy of
@@ -342,19 +349,21 @@ def open_drafts(period_end, enqueue: bool = False) -> list[str]:
 	in order, so in-flight charges never exceed the billing worker count.
 
 	Claiming Draft -> Open under a row lock already makes two workers on one invoice
-	harmless; the deduplicated page job id keeps them from queueing at all.
+	harmless; the deduplicated page job id keeps them from queueing at all. Because a
+	settled draft drops out of the scan, re-running this against the same cutoff only
+	ever picks up what is still owed — which is exactly what the daily sweep relies on.
 	"""
 	drafts = []
 	after = ""
-	for page in draft_pages(period_end):
+	for page in draft_pages(cutoff):
 		until = page[-1]
 		if enqueue:
 			frappe.enqueue(
 				"central.billing.revenue.invoicing.settle_draft_page",
 				queue=billing_queue(),
-				job_id=f"billing-settle::{period_end}::{until}",
+				job_id=f"billing-settle::{cutoff}::{until}",
 				deduplicate=True,
-				period_end=period_end,
+				cutoff=cutoff,
 				after=after,
 				until=until,
 			)
@@ -378,13 +387,15 @@ def billing_period(today=None) -> tuple:
 def draft_monthly_invoices(today=None) -> dict:
 	"""Tick 1 (1st, off-peak): draft the just-closed month, one job per team.
 
-	The two phases are separate scheduler ticks, not one job that does both: rating
-	is heavy and local, collection is slow and external, and a run that interleaves
-	them can only go as fast as its slowest gateway call.
+	Drafting and collection are separate ticks, not one job that does both: rating is
+	heavy and local, collection is slow and external, and a run that interleaves them
+	can only go as fast as its slowest gateway call.
 
-	They are hours apart on the same day rather than the 28th and the 1st, because a
-	calendar month billed in arrears is not closed until it ends — drafting on the
-	28th would bill days that had not happened yet.
+	Drafting fires once, on the 1st — not the 28th — because a month billed in arrears
+	is not closed until it ends; drafting on the 28th would bill days that had not
+	happened yet. Collection does not run a fixed few hours later hoping drafting is
+	done: it is a daily sweep (`collect_due_invoices`) that drains whatever has drafted,
+	so a run that overruns the day is finished by the next sweep, not abandoned.
 	"""
 	period_start, period_end = billing_period(today)
 	fanned = generate_draft_invoices(period_start, period_end, enqueue=True)
@@ -392,20 +403,31 @@ def draft_monthly_invoices(today=None) -> dict:
 	return {"period_start": str(period_start), "period_end": str(period_end), "pages": len(fanned)}
 
 
-def collect_monthly_invoices(today=None) -> dict:
-	"""Tick 2 (1st, once drafting has settled): open + collect, one job per invoice.
+def collect_due_invoices(today=None) -> dict:
+	"""Tick 2 (daily): open + collect every Draft whose month has already closed.
 
-	Whatever tick 1 failed to draft simply isn't here yet; it is picked up by the
-	next run rather than blocking this one, and the invoices that did draft still
-	get collected on time.
+	Daily, not a single tick a fixed few hours after drafting: at a million teams the
+	draft page jobs may still be finishing when collection first fires, and a one-shot
+	scan would collect only the drafts that existed at that instant and orphan every one
+	that landed later. Nor is there a second monthly pass to catch them — the tick comes
+	round once, pinned to one exact period.
+
+	So collection is a daily sweep of `period_end <= the just-closed month`. It re-runs
+	until nothing is owed: drafts that appeared after the previous sweep get collected on
+	the next one, and a draft a settle page left behind — this month's or an older run's
+	— is swept up rather than stranded. Once the run has drained it is a cheap indexed
+	no-op (no Draft for a closed period left to find).
+
+	`open_drafts` skips anything already Open/Paid, so re-firing never double-charges;
+	`settle_draft` defers dunning on failure, so a slow sweep never makes a customer late.
 	"""
-	period_start, period_end = billing_period(today)
-	# Logged before fanning out, so the record of what drafting achieved (and what it
-	# missed) exists even if collection then falls over.
+	_, period_end = billing_period(today)
+	# Logged before fanning out, so the record of what the run has achieved (and what it
+	# still owes) exists even if collection then falls over.
 	frappe.logger("billing").info(f"billing run {period_end}: {billing_run_status(today)}")
 	fanned = open_drafts(period_end, enqueue=True)
-	frappe.logger("billing").info(f"billing run {period_end}: collection handed out as {len(fanned)} pages")
-	return {"period_start": str(period_start), "period_end": str(period_end), "pages": len(fanned)}
+	frappe.logger("billing").info(f"billing collection <= {period_end}: handed out as {len(fanned)} pages")
+	return {"period_end": str(period_end), "pages": len(fanned)}
 
 
 def billing_run_status(today=None) -> dict:

--- a/central/billing/revenue/invoicing/run.py
+++ b/central/billing/revenue/invoicing/run.py
@@ -124,6 +124,11 @@ def settle_draft(invoice: str) -> dict | None:
 		return open_and_collect(invoice)
 	except Exception as error:
 		_contain(f"Settling {invoice}", "Invoice", invoice, error, undo=False)
+		# The run broke down over this invoice; the customer is not late because we
+		# are. Their retry ladder restarts from a date we actually asked on.
+		from central.billing.revenue.dunning import defer_dunning
+
+		defer_dunning(invoice, f"collection failed in the run: {type(error).__name__}")
 		return None
 
 

--- a/central/billing/revenue/invoicing/run.py
+++ b/central/billing/revenue/invoicing/run.py
@@ -13,18 +13,49 @@ from frappe.query_builder.functions import Count
 from central.billing.revenue.invoicing.generate import generate_team_invoice
 from central.billing.revenue.invoicing.lifecycle import open_and_collect
 
-# How many teams / invoices a single orchestrator query pulls back at a time.
+# How many teams / invoices one page job is responsible for.
 PAGE_SIZE = 500
 
-# Billing units are minutes-long and gateway-bound; they belong on the long queue,
-# away from the short jobs a user is waiting on.
-BILLING_QUEUE = "long"
+# Collection pages are smaller than drafting pages: each invoice is a gateway
+# round-trip (~2s) rather than local arithmetic (~0.3s), and a page has to finish
+# inside its queue timeout.
+COLLECT_PAGE_SIZE = 100
+
+# The monthly run gets its own queue, not `long`. It is not a daily job sharing a
+# pool with everything else: its worker count is the throughput knob (how many
+# teams are billed at once) AND the gateway concurrency cap (how many charges are
+# in flight at once). Both need to be tuned for billing alone, and a saturated
+# billing run must not starve the rest of the site. Configure it in
+# common_site_config.json — the worker count is the number that matters:
+#
+#   "workers": {"billing": {"timeout": 3000, "background_workers": 8}}
+#
+# and give the queue a worker (`bench worker --queue billing`).
+BILLING_QUEUE = "billing"
+
 
 # Every unit failure is logged under this one title, so an operator (and
 # `billing_run_status`) can count a run's casualties with a single filter.
 BILLING_RUN_FAILURE = "Billing Run Failure"
 
 _SAVEPOINT = "billing_run_unit"
+
+
+def billing_queue() -> str:
+	"""The billing queue if the bench declares one, else `long`.
+
+	Enqueuing to a queue nobody consumes is silent death — the jobs sit in redis and
+	the month simply never gets billed. A bench that hasn't configured the billing
+	worker yet falls back to a queue that definitely has one, loudly.
+	"""
+	from frappe.utils.background_jobs import get_queues_timeout
+
+	if BILLING_QUEUE in get_queues_timeout():
+		return BILLING_QUEUE
+	frappe.logger("billing").warning(
+		f"no '{BILLING_QUEUE}' queue configured (common_site_config workers) — falling back to 'long'"
+	)
+	return "long"
 
 
 def _contain(unit: str, doctype: str, name: str, error: Exception, undo: bool) -> None:
@@ -96,13 +127,13 @@ def settle_draft(invoice: str) -> dict | None:
 		return None
 
 
-def teams_to_bill(page_size: int = PAGE_SIZE):
-	"""Yield every team holding a subscription, one page at a time.
+def team_pages(page_size: int = PAGE_SIZE):
+	"""Yield the teams holding a subscription, one bounded page at a time.
 
-	The orchestrator must not hold the whole subscription table in memory — at 50k
-	teams that is the run's first bottleneck. Keyset paging (`team > last seen`,
-	ordered) walks the `Subscription(team)` index in bounded pages and hands teams
-	out as it reads them, so memory is flat in team count.
+	The orchestrator must not hold the whole subscription table in memory — at a
+	million teams that is the run's first bottleneck. Keyset paging (`team > last
+	seen`, ordered) walks the `Subscription(team)` index in fixed-size pages, so
+	memory is flat in team count.
 	"""
 	sub = frappe.qb.DocType("Subscription")
 	after = ""
@@ -117,8 +148,47 @@ def teams_to_bill(page_size: int = PAGE_SIZE):
 		).run(pluck=True)
 		if not page:
 			return
-		yield from page
+		yield page
 		after = page[-1]
+
+
+def teams_to_bill(page_size: int = PAGE_SIZE):
+	"""Every team holding a subscription, page by page, flattened."""
+	for page in team_pages(page_size):
+		yield from page
+
+
+def teams_in_range(after: str, until: str) -> list[str]:
+	"""The teams in one cursor slice `(after, until]` — a page job's whole workload.
+
+	The slice is re-derived from the bounds rather than carried as a list of names:
+	the job argument stays two strings whatever the page size, and a team created
+	inside the slice after the tick read it is picked up rather than skipped.
+	"""
+	sub = frappe.qb.DocType("Subscription")
+	return (
+		frappe.qb.from_(sub)
+		.select(sub.team)
+		.distinct()
+		.where((sub.team > after) & (sub.team <= until))
+		.orderby(sub.team)
+	).run(pluck=True)
+
+
+def draft_team_page(after: str, until: str, period_start, period_end) -> dict:
+	"""Draft every team in one cursor slice — the unit a billing worker picks up.
+
+	Committing per team is the point of the loop: one team = one transaction = one
+	commit, so a page job killed at team 300 of 500 keeps the 299 it finished, and
+	re-running the page skips them (drafting is idempotent per (team, period)).
+	The page is the unit of *scheduling*; the team is still the unit of *work*.
+	"""
+	drafted = 0
+	for team in teams_in_range(after, until):
+		if draft_team_invoice(team, period_start, period_end):
+			drafted += 1
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit -- one team, one transaction
+	return {"after": after, "until": until, "drafted": drafted}
 
 
 def generate_draft_invoices(period_start, period_end, enqueue: bool = False) -> list[str]:
@@ -128,38 +198,45 @@ def generate_draft_invoices(period_start, period_end, enqueue: bool = False) -> 
 	invoice (generate_team_invoice aggregates all its clusters, and picks the
 	team's oldest subscription as the primary that funds the auto-charge).
 
-	With `enqueue` the orchestrator rates nothing itself: it pages the teams and
-	fans one job out per team, so the run scales with workers rather than with the
-	length of one scheduler tick. The job id is (period, team) and deduplicated —
-	a tick that fires twice, or overlaps a manual run, queues each team once.
+	With `enqueue` the orchestrator rates nothing itself, and — just as important —
+	enqueues nothing per team. It hands out **page jobs**: at a million teams, a
+	job-per-team tick is a million redis round-trips, which neither finishes inside
+	a scheduler timeout nor fits in redis. Two thousand page jobs do both. How many
+	run at once is the billing queue's worker count, which is also the number of
+	gateway calls phase 2 can have in flight — one knob, set by ops, not by code.
 
-	Returns the invoices drafted (inline) or the teams fanned out (enqueue).
+	Returns the invoices drafted (inline) or the page bounds fanned out (enqueue).
 	"""
 	created = []
-	for team in teams_to_bill():
+	after = ""
+	for page in team_pages():
+		until = page[-1]
 		if enqueue:
 			frappe.enqueue(
-				"central.billing.revenue.invoicing.draft_team_invoice",
-				queue=BILLING_QUEUE,
-				job_id=f"billing-draft::{period_end}::{team}",
+				"central.billing.revenue.invoicing.draft_team_page",
+				queue=billing_queue(),
+				job_id=f"billing-draft::{period_end}::{until}",
 				deduplicate=True,
-				team=team,
+				after=after,
+				until=until,
 				period_start=period_start,
 				period_end=period_end,
 			)
-			created.append(team)
+			created.append(until)
+			after = until
 			continue
-		name = draft_team_invoice(team, period_start, period_end)
-		if name:
-			created.append(name)
+		for team in page:
+			name = draft_team_invoice(team, period_start, period_end)
+			if name:
+				created.append(name)
 	return created
 
 
-def drafts_to_settle(period_end, page_size: int = PAGE_SIZE):
-	"""Yield the period's Draft invoices, one page at a time.
+def draft_pages(period_end, page_size: int = COLLECT_PAGE_SIZE):
+	"""Yield the period's Draft invoices, one bounded page at a time.
 
-	Keyset paging on the name, so it stays bounded at 50k invoices — and correct
-	even though settling a draft removes it from the filter as we walk.
+	Keyset paging on the name — correct even though settling a draft removes it
+	from the filter as we walk, because the cursor advances by name, not by offset.
 	"""
 	after = ""
 	while True:
@@ -172,31 +249,83 @@ def drafts_to_settle(period_end, page_size: int = PAGE_SIZE):
 		)
 		if not page:
 			return
-		yield from page
+		yield page
 		after = page[-1]
+
+
+def drafts_to_settle(period_end, page_size: int = COLLECT_PAGE_SIZE):
+	"""The period's Draft invoices, page by page, flattened."""
+	for page in draft_pages(period_end, page_size):
+		yield from page
+
+
+def drafts_in_range(period_end, after: str, until: str) -> list[str]:
+	"""The still-Draft invoices in one cursor slice `(after, until]`.
+
+	Re-read at run time, not carried in the job: by the time a page job starts, some
+	of its slice may already be settled (a retried tick, a customer paying
+	on-session), and those must not be touched again.
+	"""
+	return frappe.get_all(
+		"Invoice",
+		filters=[
+			["status", "=", "Draft"],
+			["period_end", "=", period_end],
+			["name", ">", after],
+			["name", "<=", until],
+		],
+		pluck="name",
+		order_by="name asc",
+	)
+
+
+def settle_draft_page(period_end, after: str, until: str) -> dict:
+	"""Settle every draft in one cursor slice — the unit a billing worker picks up.
+
+	Sequential within the page, deliberately: the gateway concurrency of the whole
+	run is the number of billing workers, and that is the only thing standing
+	between a million-invoice month and a wall of 429s. Widening the page would not
+	make it faster — it would make it rate-limited.
+	"""
+	settled = 0
+	for invoice in drafts_in_range(period_end, after, until):
+		if settle_draft(invoice):
+			settled += 1
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit -- one invoice, one transaction
+	return {"after": after, "until": until, "settled": settled}
 
 
 def open_drafts(period_end, enqueue: bool = False) -> list[str]:
 	"""Phase-2 orchestrator: open every Draft for the billing month.
 
-	One job per invoice, deduplicated on the invoice — collection is where the
-	gateway round-trips are, so this is the phase that must not be one long
-	sequential tick. Claiming Draft -> Open under a row lock already makes two
-	workers on one invoice harmless; the job id keeps them from queueing at all.
+	Page jobs, not a job per invoice — same reason as drafting, plus one specific to
+	collection: a job per invoice puts the run's gateway concurrency at the mercy of
+	how many workers happen to be free. A page job holds its invoices and works them
+	in order, so in-flight charges never exceed the billing worker count.
+
+	Claiming Draft -> Open under a row lock already makes two workers on one invoice
+	harmless; the deduplicated page job id keeps them from queueing at all.
 	"""
 	drafts = []
-	for inv in drafts_to_settle(period_end):
-		drafts.append(inv)
+	after = ""
+	for page in draft_pages(period_end):
+		until = page[-1]
 		if enqueue:
 			frappe.enqueue(
-				"central.billing.revenue.invoicing.settle_draft",
-				queue=BILLING_QUEUE,
-				job_id=f"billing-settle::{inv}",
+				"central.billing.revenue.invoicing.settle_draft_page",
+				queue=billing_queue(),
+				job_id=f"billing-settle::{period_end}::{until}",
 				deduplicate=True,
-				invoice=inv,
+				period_end=period_end,
+				after=after,
+				until=until,
 			)
-		else:
-			settle_draft(inv)
+			drafts.append(until)
+			after = until
+			continue
+		for invoice in page:
+			drafts.append(invoice)
+			settle_draft(invoice)
 	return drafts
 
 
@@ -220,8 +349,8 @@ def draft_monthly_invoices(today=None) -> dict:
 	"""
 	period_start, period_end = billing_period(today)
 	fanned = generate_draft_invoices(period_start, period_end, enqueue=True)
-	frappe.logger("billing").info(f"billing run {period_end}: drafting fanned out for {len(fanned)} teams")
-	return {"period_start": str(period_start), "period_end": str(period_end), "teams": len(fanned)}
+	frappe.logger("billing").info(f"billing run {period_end}: drafting handed out as {len(fanned)} pages")
+	return {"period_start": str(period_start), "period_end": str(period_end), "pages": len(fanned)}
 
 
 def collect_monthly_invoices(today=None) -> dict:
@@ -236,8 +365,8 @@ def collect_monthly_invoices(today=None) -> dict:
 	# missed) exists even if collection then falls over.
 	frappe.logger("billing").info(f"billing run {period_end}: {billing_run_status(today)}")
 	fanned = open_drafts(period_end, enqueue=True)
-	frappe.logger("billing").info(f"billing run {period_end}: collection fanned out for {len(fanned)} invoices")
-	return {"period_start": str(period_start), "period_end": str(period_end), "invoices": len(fanned)}
+	frappe.logger("billing").info(f"billing run {period_end}: collection handed out as {len(fanned)} pages")
+	return {"period_start": str(period_start), "period_end": str(period_end), "pages": len(fanned)}
 
 
 def billing_run_status(today=None) -> dict:

--- a/central/billing/revenue/invoicing/run.py
+++ b/central/billing/revenue/invoicing/run.py
@@ -12,40 +12,84 @@ import frappe
 from central.billing.revenue.invoicing.generate import generate_team_invoice
 from central.billing.revenue.invoicing.lifecycle import open_and_collect
 
+# How many teams / invoices a single orchestrator query pulls back at a time.
+PAGE_SIZE = 500
+
+
+def teams_to_bill(page_size: int = PAGE_SIZE):
+	"""Yield every team holding a subscription, one page at a time.
+
+	The orchestrator must not hold the whole subscription table in memory — at 50k
+	teams that is the run's first bottleneck. Keyset paging (`team > last seen`,
+	ordered) walks the `Subscription(team)` index in bounded pages and hands teams
+	out as it reads them, so memory is flat in team count.
+	"""
+	sub = frappe.qb.DocType("Subscription")
+	after = ""
+	while True:
+		page = (
+			frappe.qb.from_(sub)
+			.select(sub.team)
+			.distinct()
+			.where(sub.team > after)
+			.orderby(sub.team)
+			.limit(page_size)
+		).run(pluck=True)
+		if not page:
+			return
+		yield from page
+		after = page[-1]
+
 
 def generate_draft_invoices(period_start, period_end, enqueue: bool = False) -> list[str]:
 	"""Phase-1 orchestrator: ONE consolidated draft per team for the period.
 
 	A team that runs instances across several clusters still gets a single
-	invoice (generate_team_invoice aggregates all its clusters). The team's first
-	subscription is the primary (its payment method funds the auto-charge).
+	invoice (generate_team_invoice aggregates all its clusters, and picks the
+	team's oldest subscription as the primary that funds the auto-charge).
 	"""
-	primary = {}
-	for s in frappe.get_all("Subscription", fields=["name", "team"], order_by="creation asc"):
-		primary.setdefault(s.team, s.name)
 	created = []
-	for team, sub in primary.items():
+	for team in teams_to_bill():
 		if enqueue:
 			frappe.enqueue(
 				"central.billing.revenue.invoicing.generate_team_invoice",
 				team=team,
 				period_start=period_start,
 				period_end=period_end,
-				subscription=sub,
 			)
 			continue
-		name = generate_team_invoice(team, period_start, period_end, subscription=sub)
+		name = generate_team_invoice(team, period_start, period_end)
 		if name:
 			created.append(name)
 	return created
 
 
+def drafts_to_settle(period_end, page_size: int = PAGE_SIZE):
+	"""Yield the period's Draft invoices, one page at a time.
+
+	Keyset paging on the name, so it stays bounded at 50k invoices — and correct
+	even though settling a draft removes it from the filter as we walk.
+	"""
+	after = ""
+	while True:
+		page = frappe.get_all(
+			"Invoice",
+			filters={"status": "Draft", "period_end": period_end, "name": (">", after)},
+			pluck="name",
+			order_by="name asc",
+			limit_page_length=page_size,
+		)
+		if not page:
+			return
+		yield from page
+		after = page[-1]
+
+
 def open_drafts(period_end, enqueue: bool = False) -> list[str]:
 	"""Phase-2 orchestrator: open every Draft for the billing month."""
-	drafts = frappe.get_all(
-		"Invoice", filters={"status": "Draft", "period_end": period_end}, pluck="name"
-	)
-	for inv in drafts:
+	drafts = []
+	for inv in drafts_to_settle(period_end):
+		drafts.append(inv)
 		if enqueue:
 			frappe.enqueue("central.billing.revenue.invoicing.open_and_collect", invoice=inv)
 		else:

--- a/central/billing/revenue/invoicing/run.py
+++ b/central/billing/revenue/invoicing/run.py
@@ -15,6 +15,60 @@ from central.billing.revenue.invoicing.lifecycle import open_and_collect
 # How many teams / invoices a single orchestrator query pulls back at a time.
 PAGE_SIZE = 500
 
+# Every unit failure is logged under this one title, so an operator (and
+# `billing_run_status`) can count a run's casualties with a single filter.
+BILLING_RUN_FAILURE = "Billing Run Failure"
+
+_SAVEPOINT = "billing_run_unit"
+
+
+def draft_team_invoice(team: str, period_start, period_end) -> str | None:
+	"""Draft one team's invoice — the unit of work phase 1 fans out.
+
+	One team = one job = one transaction = one commit. Failure is contained to the
+	team: a missing rate or a broken tax profile must not take the other 49,999
+	teams' invoices with it. The savepoint undoes only this team's writes — the
+	inline path bills many teams in one transaction, so a blanket rollback here
+	would discard the teams already billed.
+
+	Nothing is re-raised, and nothing needs to be: drafting is idempotent per
+	(team, period), so re-running the phase retries exactly the teams that failed.
+	A partial run is resumable for free.
+	"""
+	frappe.db.savepoint(_SAVEPOINT)
+	try:
+		return generate_team_invoice(team, period_start, period_end)
+	except Exception:
+		frappe.db.rollback(save_point=_SAVEPOINT)
+		frappe.log_error(
+			title=BILLING_RUN_FAILURE,
+			message=f"Drafting {team} for {period_start}..{period_end}\n\n{frappe.get_traceback()}",
+			reference_doctype="Team",
+			reference_name=team,
+		)
+		return None
+
+
+def settle_draft(invoice: str) -> dict | None:
+	"""Open + collect one invoice — the unit of work phase 2 fans out.
+
+	No savepoint here, unlike drafting: by ADR 0017 the charge leg commits its
+	`Initiated` Payment Attempt *before* calling the gateway, precisely so a crash
+	leaves a durable claim. Undoing that would be undoing the safety. A failed unit
+	is logged and left where it is — `run_reconciliation` asks the gateway what
+	really happened, and dunning picks up whatever stayed Open.
+	"""
+	try:
+		return open_and_collect(invoice)
+	except Exception:
+		frappe.log_error(
+			title=BILLING_RUN_FAILURE,
+			message=f"Settling {invoice}\n\n{frappe.get_traceback()}",
+			reference_doctype="Invoice",
+			reference_name=invoice,
+		)
+		return None
+
 
 def teams_to_bill(page_size: int = PAGE_SIZE):
 	"""Yield every team holding a subscription, one page at a time.
@@ -52,13 +106,13 @@ def generate_draft_invoices(period_start, period_end, enqueue: bool = False) -> 
 	for team in teams_to_bill():
 		if enqueue:
 			frappe.enqueue(
-				"central.billing.revenue.invoicing.generate_team_invoice",
+				"central.billing.revenue.invoicing.draft_team_invoice",
 				team=team,
 				period_start=period_start,
 				period_end=period_end,
 			)
 			continue
-		name = generate_team_invoice(team, period_start, period_end)
+		name = draft_team_invoice(team, period_start, period_end)
 		if name:
 			created.append(name)
 	return created
@@ -77,7 +131,7 @@ def drafts_to_settle(period_end, page_size: int = PAGE_SIZE):
 			filters={"status": "Draft", "period_end": period_end, "name": (">", after)},
 			pluck="name",
 			order_by="name asc",
-			limit_page_length=page_size,
+			limit=page_size,
 		)
 		if not page:
 			return
@@ -91,9 +145,9 @@ def open_drafts(period_end, enqueue: bool = False) -> list[str]:
 	for inv in drafts_to_settle(period_end):
 		drafts.append(inv)
 		if enqueue:
-			frappe.enqueue("central.billing.revenue.invoicing.open_and_collect", invoice=inv)
+			frappe.enqueue("central.billing.revenue.invoicing.settle_draft", invoice=inv)
 		else:
-			open_and_collect(inv)
+			settle_draft(inv)
 	return drafts
 
 

--- a/central/billing/revenue/invoicing/run.py
+++ b/central/billing/revenue/invoicing/run.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""The monthly billing run — orchestration only.
+
+`generate.py` drafts one team; `lifecycle.py` settles one invoice. This module
+owns everything that spans them: which teams to visit, in what order, and how the
+work is spread over workers.
+"""
+
+import frappe
+
+from central.billing.revenue.invoicing.generate import generate_team_invoice
+from central.billing.revenue.invoicing.lifecycle import open_and_collect
+
+
+def generate_draft_invoices(period_start, period_end, enqueue: bool = False) -> list[str]:
+	"""Phase-1 orchestrator: ONE consolidated draft per team for the period.
+
+	A team that runs instances across several clusters still gets a single
+	invoice (generate_team_invoice aggregates all its clusters). The team's first
+	subscription is the primary (its payment method funds the auto-charge).
+	"""
+	primary = {}
+	for s in frappe.get_all("Subscription", fields=["name", "team"], order_by="creation asc"):
+		primary.setdefault(s.team, s.name)
+	created = []
+	for team, sub in primary.items():
+		if enqueue:
+			frappe.enqueue(
+				"central.billing.revenue.invoicing.generate_team_invoice",
+				team=team,
+				period_start=period_start,
+				period_end=period_end,
+				subscription=sub,
+			)
+			continue
+		name = generate_team_invoice(team, period_start, period_end, subscription=sub)
+		if name:
+			created.append(name)
+	return created
+
+
+def open_drafts(period_end, enqueue: bool = False) -> list[str]:
+	"""Phase-2 orchestrator: open every Draft for the billing month."""
+	drafts = frappe.get_all(
+		"Invoice", filters={"status": "Draft", "period_end": period_end}, pluck="name"
+	)
+	for inv in drafts:
+		if enqueue:
+			frappe.enqueue("central.billing.revenue.invoicing.open_and_collect", invoice=inv)
+		else:
+			open_and_collect(inv)
+	return drafts
+
+
+def run_monthly_billing(today=None) -> dict:
+	"""Scheduled entrypoint (1st of the month): bill the just-closed calendar month
+	end-to-end for every team — the production trigger for the two-phase invoicing
+	(#09/#10) that otherwise only ran from demos and tests.
+
+	Phase 1 drafts one consolidated invoice per team for the previous month; phase 2
+	opens each Draft and runs the credits-then-card waterfall — settling it, or leaving
+	it Open for dunning (#14). Idempotent: drafting is idempotent per (team, period) and
+	open_drafts only touches invoices still in Draft, so a retried tick is safe.
+	"""
+	today = frappe.utils.getdate(today or frappe.utils.nowdate())
+	period_start = frappe.utils.get_first_day(today, d_months=-1)
+	period_end = frappe.utils.get_last_day(period_start)
+
+	drafted = generate_draft_invoices(period_start, period_end)
+	opened = open_drafts(period_end)
+	return {
+		"period_start": str(period_start),
+		"period_end": str(period_end),
+		"drafted": len(drafted),
+		"opened": len(opened),
+	}

--- a/central/billing/revenue/invoicing/run.py
+++ b/central/billing/revenue/invoicing/run.py
@@ -178,20 +178,51 @@ def open_drafts(period_end, enqueue: bool = False) -> list[str]:
 	return drafts
 
 
-def run_monthly_billing(today=None) -> dict:
-	"""Scheduled entrypoint (1st of the month): bill the just-closed calendar month
-	end-to-end for every team — the production trigger for the two-phase invoicing
-	(#09/#10) that otherwise only ran from demos and tests.
-
-	Phase 1 drafts one consolidated invoice per team for the previous month; phase 2
-	opens each Draft and runs the credits-then-card waterfall — settling it, or leaving
-	it Open for dunning (#14). Idempotent: drafting is idempotent per (team, period) and
-	open_drafts only touches invoices still in Draft, so a retried tick is safe.
-	"""
+def billing_period(today=None) -> tuple:
+	"""The calendar month that just closed — the period a run on `today` bills."""
 	today = frappe.utils.getdate(today or frappe.utils.nowdate())
 	period_start = frappe.utils.get_first_day(today, d_months=-1)
-	period_end = frappe.utils.get_last_day(period_start)
+	return period_start, frappe.utils.get_last_day(period_start)
 
+
+def draft_monthly_invoices(today=None) -> dict:
+	"""Tick 1 (1st, off-peak): draft the just-closed month, one job per team.
+
+	The two phases are separate scheduler ticks, not one job that does both: rating
+	is heavy and local, collection is slow and external, and a run that interleaves
+	them can only go as fast as its slowest gateway call.
+
+	They are hours apart on the same day rather than the 28th and the 1st, because a
+	calendar month billed in arrears is not closed until it ends — drafting on the
+	28th would bill days that had not happened yet.
+	"""
+	period_start, period_end = billing_period(today)
+	fanned = generate_draft_invoices(period_start, period_end, enqueue=True)
+	frappe.logger("billing").info(f"billing run {period_end}: drafting fanned out for {len(fanned)} teams")
+	return {"period_start": str(period_start), "period_end": str(period_end), "teams": len(fanned)}
+
+
+def collect_monthly_invoices(today=None) -> dict:
+	"""Tick 2 (1st, once drafting has settled): open + collect, one job per invoice.
+
+	Whatever tick 1 failed to draft simply isn't here yet; it is picked up by the
+	next run rather than blocking this one, and the invoices that did draft still
+	get collected on time.
+	"""
+	period_start, period_end = billing_period(today)
+	fanned = open_drafts(period_end, enqueue=True)
+	frappe.logger("billing").info(f"billing run {period_end}: collection fanned out for {len(fanned)} invoices")
+	return {"period_start": str(period_start), "period_end": str(period_end), "invoices": len(fanned)}
+
+
+def run_monthly_billing(today=None) -> dict:
+	"""Bill the just-closed month end-to-end, inline — the manual/demo/test path.
+
+	The scheduler runs the two ticks above instead. This stays as the one-call
+	version for a small site, a demo, or an operator re-running a period by hand:
+	same work, same idempotency, no workers involved.
+	"""
+	period_start, period_end = billing_period(today)
 	drafted = generate_draft_invoices(period_start, period_end)
 	opened = open_drafts(period_end)
 	return {

--- a/central/billing/revenue/invoicing/run.py
+++ b/central/billing/revenue/invoicing/run.py
@@ -7,6 +7,9 @@ owns everything that spans them: which teams to visit, in what order, and how th
 work is spread over workers.
 """
 
+import random
+import time
+
 import frappe
 from frappe.query_builder.functions import Count
 
@@ -39,6 +42,17 @@ BILLING_QUEUE = "billing"
 BILLING_RUN_FAILURE = "Billing Run Failure"
 
 _SAVEPOINT = "billing_run_unit"
+
+# Drafting is the phase with a *global* lock in it: every Invoice insert takes the
+# `tabSeries` row for its number and holds it until commit, so every worker in the
+# run queues behind the same row for a few milliseconds. Nearly always invisible;
+# under a slow disk or a long page it surfaces as a lock-wait timeout (1205) or a
+# deadlock (1213). Containing those like a data error would be wrong — the team is
+# fine, it just lost a race — and the draft tick only comes round once a MONTH, so
+# a contained loser stays unbilled until someone notices. Retry instead.
+_CONTENTION = (frappe.QueryDeadlockError, frappe.QueryTimeoutError)
+CONTENTION_RETRIES = 4
+CONTENTION_BACKOFF = 0.1  # seconds; scaled by attempt, plus jitter
 
 
 def billing_queue() -> str:
@@ -93,22 +107,36 @@ def _contain(unit: str, doctype: str, name: str, error: Exception, undo: bool) -
 def draft_team_invoice(team: str, period_start, period_end) -> str | None:
 	"""Draft one team's invoice — the unit of work phase 1 fans out.
 
-	One team = one job = one transaction = one commit. Failure is contained to the
-	team: a missing rate or a broken tax profile must not take the other 49,999
-	teams' invoices with it. The savepoint undoes only this team's writes — the
-	inline path bills many teams in one transaction, so a blanket rollback here
-	would discard the teams already billed.
+	One team = one transaction = one commit, on every path. Failure is contained to
+	the team: a missing rate or a broken tax profile must not take the other 999,999
+	teams' invoices with it. The savepoint undoes only this team's writes, so a
+	caller part-way through a page keeps the teams it already billed.
 
 	A contained failure is not re-raised, and needn't be: drafting is idempotent per
 	(team, period), so re-running the phase retries exactly the teams that failed.
 	A partial run is resumable for free.
+
+	Lock contention is not a failure at all, though, and is retried here rather than
+	contained — see `_CONTENTION`. InnoDB has already rolled the transaction back by
+	the time we see it, which is safe precisely because the caller commits per team:
+	the rollback can only ever discard this one team's work.
 	"""
-	frappe.db.savepoint(_SAVEPOINT)
-	try:
-		return generate_team_invoice(team, period_start, period_end)
-	except Exception as error:
-		_contain(f"Drafting {team} for {period_start}..{period_end}", "Team", team, error, undo=True)
-		return None
+	unit = f"Drafting {team} for {period_start}..{period_end}"
+	for attempt in range(CONTENTION_RETRIES):
+		frappe.db.savepoint(_SAVEPOINT)
+		try:
+			return generate_team_invoice(team, period_start, period_end)
+		except _CONTENTION as error:
+			frappe.db.rollback()
+			if attempt == CONTENTION_RETRIES - 1:
+				# Out of patience: record it and let the next tick pick the team up.
+				_contain(unit, "Team", team, error, undo=False)
+				return None
+			# Jittered, so a whole page of retriers doesn't re-collide in lockstep.
+			time.sleep(CONTENTION_BACKOFF * (attempt + 1) + random.uniform(0, CONTENTION_BACKOFF))
+		except Exception as error:
+			_contain(unit, "Team", team, error, undo=True)
+			return None
 
 
 def settle_draft(invoice: str) -> dict | None:
@@ -234,6 +262,11 @@ def generate_draft_invoices(period_start, period_end, enqueue: bool = False) -> 
 			name = draft_team_invoice(team, period_start, period_end)
 			if name:
 				created.append(name)
+			# Inline or fanned out, a team is a transaction. It bounds what a
+			# contention rollback can discard, and it stops the run holding the
+			# `tabSeries` row (taken by every Invoice insert) for a whole page —
+			# which is how one slow run becomes everyone else's lock-wait timeout.
+			frappe.db.commit()  # nosemgrep: frappe-manual-commit -- one team, one transaction
 	return created
 
 
@@ -331,6 +364,7 @@ def open_drafts(period_end, enqueue: bool = False) -> list[str]:
 		for invoice in page:
 			drafts.append(invoice)
 			settle_draft(invoice)
+			frappe.db.commit()  # nosemgrep: frappe-manual-commit -- one invoice, one transaction
 	return drafts
 
 

--- a/central/billing/revenue/invoicing/run.py
+++ b/central/billing/revenue/invoicing/run.py
@@ -27,6 +27,38 @@ BILLING_RUN_FAILURE = "Billing Run Failure"
 _SAVEPOINT = "billing_run_unit"
 
 
+def _contain(unit: str, doctype: str, name: str, error: Exception, undo: bool) -> None:
+	"""Contain one unit's failure so the run survives it — or refuse to.
+
+	Order matters. The **file log** is written first and unconditionally, because it
+	is the only record that survives a transaction that never commits: "why was this
+	team not billed?" has to be answerable after a crash, not only after a tidy
+	failure. The Error Log row is the queryable copy (`billing_run_status` counts
+	it), but it is a database write like any other — a run whose worker is killed
+	before its commit keeps the file line and loses the row.
+
+	Then the judgement call. A savepoint exists only inside a live transaction: if
+	the database restarted, the connection dropped, or something in the unit
+	committed underneath us, `ROLLBACK TO SAVEPOINT` fails. That is not a bad team —
+	it is the machinery being broken, and swallowing it would convert one outage
+	into a silent run where every remaining team merely "wasn't billed". So the
+	original error is re-raised: the job dies, RQ records it, and the tick is
+	re-fired once the database is back.
+	"""
+	frappe.logger("billing").error(f"{BILLING_RUN_FAILURE}: {unit}", exc_info=error)
+	if undo:
+		try:
+			frappe.db.rollback(save_point=_SAVEPOINT)
+		except Exception as rollback_failed:
+			raise error from rollback_failed
+	frappe.log_error(
+		title=BILLING_RUN_FAILURE,
+		message=f"{unit}\n\n{frappe.get_traceback()}",
+		reference_doctype=doctype,
+		reference_name=name,
+	)
+
+
 def draft_team_invoice(team: str, period_start, period_end) -> str | None:
 	"""Draft one team's invoice — the unit of work phase 1 fans out.
 
@@ -36,42 +68,31 @@ def draft_team_invoice(team: str, period_start, period_end) -> str | None:
 	inline path bills many teams in one transaction, so a blanket rollback here
 	would discard the teams already billed.
 
-	Nothing is re-raised, and nothing needs to be: drafting is idempotent per
+	A contained failure is not re-raised, and needn't be: drafting is idempotent per
 	(team, period), so re-running the phase retries exactly the teams that failed.
 	A partial run is resumable for free.
 	"""
 	frappe.db.savepoint(_SAVEPOINT)
 	try:
 		return generate_team_invoice(team, period_start, period_end)
-	except Exception:
-		frappe.db.rollback(save_point=_SAVEPOINT)
-		frappe.log_error(
-			title=BILLING_RUN_FAILURE,
-			message=f"Drafting {team} for {period_start}..{period_end}\n\n{frappe.get_traceback()}",
-			reference_doctype="Team",
-			reference_name=team,
-		)
+	except Exception as error:
+		_contain(f"Drafting {team} for {period_start}..{period_end}", "Team", team, error, undo=True)
 		return None
 
 
 def settle_draft(invoice: str) -> dict | None:
 	"""Open + collect one invoice — the unit of work phase 2 fans out.
 
-	No savepoint here, unlike drafting: by ADR 0017 the charge leg commits its
+	Nothing is undone here, unlike drafting: by ADR 0017 the charge leg commits its
 	`Initiated` Payment Attempt *before* calling the gateway, precisely so a crash
-	leaves a durable claim. Undoing that would be undoing the safety. A failed unit
-	is logged and left where it is — `run_reconciliation` asks the gateway what
+	leaves a durable claim. Rolling that back would be undoing the safety. A failed
+	unit is logged and left where it is — `run_reconciliation` asks the gateway what
 	really happened, and dunning picks up whatever stayed Open.
 	"""
 	try:
 		return open_and_collect(invoice)
-	except Exception:
-		frappe.log_error(
-			title=BILLING_RUN_FAILURE,
-			message=f"Settling {invoice}\n\n{frappe.get_traceback()}",
-			reference_doctype="Invoice",
-			reference_name=invoice,
-		)
+	except Exception as error:
+		_contain(f"Settling {invoice}", "Invoice", invoice, error, undo=False)
 		return None
 
 

--- a/central/billing/revenue/invoicing/run.py
+++ b/central/billing/revenue/invoicing/run.py
@@ -15,6 +15,10 @@ from central.billing.revenue.invoicing.lifecycle import open_and_collect
 # How many teams / invoices a single orchestrator query pulls back at a time.
 PAGE_SIZE = 500
 
+# Billing units are minutes-long and gateway-bound; they belong on the long queue,
+# away from the short jobs a user is waiting on.
+BILLING_QUEUE = "long"
+
 # Every unit failure is logged under this one title, so an operator (and
 # `billing_run_status`) can count a run's casualties with a single filter.
 BILLING_RUN_FAILURE = "Billing Run Failure"
@@ -101,16 +105,27 @@ def generate_draft_invoices(period_start, period_end, enqueue: bool = False) -> 
 	A team that runs instances across several clusters still gets a single
 	invoice (generate_team_invoice aggregates all its clusters, and picks the
 	team's oldest subscription as the primary that funds the auto-charge).
+
+	With `enqueue` the orchestrator rates nothing itself: it pages the teams and
+	fans one job out per team, so the run scales with workers rather than with the
+	length of one scheduler tick. The job id is (period, team) and deduplicated —
+	a tick that fires twice, or overlaps a manual run, queues each team once.
+
+	Returns the invoices drafted (inline) or the teams fanned out (enqueue).
 	"""
 	created = []
 	for team in teams_to_bill():
 		if enqueue:
 			frappe.enqueue(
 				"central.billing.revenue.invoicing.draft_team_invoice",
+				queue=BILLING_QUEUE,
+				job_id=f"billing-draft::{period_end}::{team}",
+				deduplicate=True,
 				team=team,
 				period_start=period_start,
 				period_end=period_end,
 			)
+			created.append(team)
 			continue
 		name = draft_team_invoice(team, period_start, period_end)
 		if name:
@@ -140,12 +155,24 @@ def drafts_to_settle(period_end, page_size: int = PAGE_SIZE):
 
 
 def open_drafts(period_end, enqueue: bool = False) -> list[str]:
-	"""Phase-2 orchestrator: open every Draft for the billing month."""
+	"""Phase-2 orchestrator: open every Draft for the billing month.
+
+	One job per invoice, deduplicated on the invoice — collection is where the
+	gateway round-trips are, so this is the phase that must not be one long
+	sequential tick. Claiming Draft -> Open under a row lock already makes two
+	workers on one invoice harmless; the job id keeps them from queueing at all.
+	"""
 	drafts = []
 	for inv in drafts_to_settle(period_end):
 		drafts.append(inv)
 		if enqueue:
-			frappe.enqueue("central.billing.revenue.invoicing.settle_draft", invoice=inv)
+			frappe.enqueue(
+				"central.billing.revenue.invoicing.settle_draft",
+				queue=BILLING_QUEUE,
+				job_id=f"billing-settle::{inv}",
+				deduplicate=True,
+				invoice=inv,
+			)
 		else:
 			settle_draft(inv)
 	return drafts

--- a/central/billing/tests/test_billing.py
+++ b/central/billing/tests/test_billing.py
@@ -596,3 +596,44 @@ class TestFanOutRun(IntegrationTestCase):
 		self.assertEqual(logged.call_count, 1)
 		self.assertIn("team-fanout-a", logged.call_args.args[0])
 		self.assertIsInstance(logged.call_args.kwargs["exc_info"], ValueError)
+
+	def test_a_team_that_loses_a_lock_race_is_retried_not_dropped(self):
+		# Every Invoice insert takes the `tabSeries` row for its number, so workers do
+		# queue behind each other. Treating a lock-wait timeout like bad data would
+		# leave the team unbilled until the next tick — which is a MONTH away.
+		real = run.generate_team_invoice
+		calls = []
+
+		def contended(team, *args, **kwargs):
+			calls.append(team)
+			if team == "team-fanout-b" and calls.count("team-fanout-b") == 1:
+				raise frappe.QueryTimeoutError("Lock wait timeout exceeded")
+			return real(team, *args, **kwargs)
+
+		with patch.object(run, "generate_team_invoice", side_effect=contended):
+			run.generate_draft_invoices("2026-06-01", "2026-06-30")
+
+		self.assertEqual(calls.count("team-fanout-b"), 2)  # retried, not contained
+		for team in self.TEAMS:
+			self.assertEqual(frappe.db.count("Invoice", {"team": team}), 1)
+		self.assertFalse(
+			frappe.db.exists(
+				"Error Log", {"method": run.BILLING_RUN_FAILURE, "reference_name": "team-fanout-b"}
+			)
+		)
+
+	def test_relentless_contention_gives_up_and_records_it(self):
+		# Retrying forever would hold a worker hostage; after the budget the team is
+		# recorded as a casualty and the run moves on.
+		with patch.object(
+			run, "generate_team_invoice",
+			side_effect=frappe.QueryDeadlockError("Deadlock found"),
+		) as blocked, patch.object(run, "CONTENTION_BACKOFF", 0):
+			self.assertIsNone(run.draft_team_invoice("team-fanout-a", "2026-06-01", "2026-06-30"))
+
+		self.assertEqual(blocked.call_count, run.CONTENTION_RETRIES)
+		self.assertTrue(
+			frappe.db.exists(
+				"Error Log", {"method": run.BILLING_RUN_FAILURE, "reference_name": "team-fanout-a"}
+			)
+		)

--- a/central/billing/tests/test_billing.py
+++ b/central/billing/tests/test_billing.py
@@ -469,19 +469,32 @@ class TestFanOutRun(IntegrationTestCase):
 		for team in self.TEAMS:
 			self.assertEqual(frappe.db.count("Invoice", {"team": team}), 1)
 
-	def test_fan_out_enqueues_one_deduplicated_job_per_team(self):
-		with patch("frappe.enqueue") as enqueue:
+	def test_the_tick_hands_out_pages_not_one_job_per_team(self):
+		# A job per team is a redis round-trip per team: at a million teams the tick
+		# never finishes inside its timeout. Pages keep the tick O(teams/page_size).
+		with patch("frappe.enqueue") as enqueue, patch.object(run, "PAGE_SIZE", 2):
 			run.generate_draft_invoices("2026-06-01", "2026-06-30", enqueue=True)
 
-		calls = {c.kwargs["team"]: c for c in enqueue.call_args_list}
-		self.assertTrue(set(self.TEAMS) <= set(calls))
-		call = calls["team-fanout-a"]
-		self.assertEqual(call.args[0], "central.billing.revenue.invoicing.draft_team_invoice")
-		self.assertEqual(call.kwargs["queue"], run.BILLING_QUEUE)
-		self.assertEqual(call.kwargs["job_id"], "billing-draft::2026-06-30::team-fanout-a")
+		calls = enqueue.call_args_list
+		self.assertLess(len(calls), frappe.db.count("Subscription"))
+		call = calls[0]
+		self.assertEqual(call.args[0], "central.billing.revenue.invoicing.draft_team_page")
+		self.assertEqual(call.kwargs["queue"], run.billing_queue())
 		self.assertTrue(call.kwargs["deduplicate"])
+		# Contiguous, non-overlapping slices: every team falls in exactly one page.
+		bounds = [(c.kwargs["after"], c.kwargs["until"]) for c in calls]
+		self.assertEqual([b[0] for b in bounds[1:]], [b[1] for b in bounds[:-1]])
+		self.assertEqual(bounds[0][0], "")
 		# The orchestrator hands out work; it must not rate anything itself.
 		self.assertFalse(frappe.db.exists("Invoice", {"team": "team-fanout-a"}))
+
+	def test_a_page_covers_every_team_in_its_slice(self):
+		covered = run.teams_in_range("team-fanout-a", "team-fanout-c")
+		self.assertEqual(covered, ["team-fanout-b", "team-fanout-c"])  # (after, until]
+
+		run.draft_team_page("", "team-fanout-c", "2026-06-01", "2026-06-30")
+		for team in self.TEAMS:
+			self.assertEqual(frappe.db.count("Invoice", {"team": team}), 1)
 
 	def test_fanned_out_jobs_draft_exactly_what_the_inline_run_would(self):
 		from central.billing.tests.utils import run_enqueued_inline
@@ -502,7 +515,8 @@ class TestFanOutRun(IntegrationTestCase):
 		# Both ticks agree on the period: the month that closed, never a live one.
 		self.assertEqual(drafting["period_end"], "2026-06-30")
 		self.assertEqual(collecting["period_end"], "2026-06-30")
-		self.assertGreaterEqual(collecting["invoices"], len(self.TEAMS))
+		self.assertGreaterEqual(collecting["pages"], 1)
+		self.assertGreaterEqual(drafting["pages"], 1)
 		for team in self.TEAMS:
 			inv = frappe.get_doc("Invoice", {"team": team, "period_end": "2026-06-30"})
 			self.assertNotEqual(inv.status, "Draft")

--- a/central/billing/tests/test_billing.py
+++ b/central/billing/tests/test_billing.py
@@ -491,3 +491,29 @@ class TestFanOutRun(IntegrationTestCase):
 
 		for team in self.TEAMS:
 			self.assertEqual(frappe.db.count("Invoice", {"team": team}), 1)
+
+	def test_the_two_ticks_bill_the_closed_month_end_to_end(self):
+		from central.billing.tests.utils import run_enqueued_inline
+
+		with patch("frappe.enqueue", side_effect=run_enqueued_inline):
+			drafting = run.draft_monthly_invoices(today="2026-07-01")
+			collecting = run.collect_monthly_invoices(today="2026-07-01")
+
+		# Both ticks agree on the period: the month that closed, never a live one.
+		self.assertEqual(drafting["period_end"], "2026-06-30")
+		self.assertEqual(collecting["period_end"], "2026-06-30")
+		self.assertGreaterEqual(collecting["invoices"], len(self.TEAMS))
+		for team in self.TEAMS:
+			inv = frappe.get_doc("Invoice", {"team": team, "period_end": "2026-06-30"})
+			self.assertNotEqual(inv.status, "Draft")
+
+	def test_collection_tick_alone_settles_nothing(self):
+		# Order matters: the collect tick only ever touches drafts that already exist,
+		# so firing it before drafting is a no-op rather than a half-billed month.
+		with patch("frappe.enqueue") as enqueue:
+			run.collect_monthly_invoices(today="2026-07-01")
+
+		fanned = [c.kwargs["invoice"] for c in enqueue.call_args_list]
+		mine = frappe.get_all("Invoice", filters={"team": ["in", self.TEAMS]}, pluck="name")
+		self.assertEqual(mine, [])
+		self.assertEqual([i for i in fanned if i in mine], [])

--- a/central/billing/tests/test_billing.py
+++ b/central/billing/tests/test_billing.py
@@ -3,12 +3,14 @@
 """Postpaid two-phase invoice generation (issue #09)."""
 
 import threading
+from unittest.mock import patch
 
 import frappe
 from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
 
 from central.billing.catalog import subscriptions
 from central.billing.revenue import invoicing, credits
+from central.billing.revenue.invoicing import run
 from central.billing.tests.utils import (
 	add_segment,
 	make_billing_subscription,
@@ -398,3 +400,71 @@ class TestMonthlyBillingRun(BillingTestBase):
 		self.assertEqual(
 			frappe.db.count("Invoice", {"team": TEAM, "period_end": "2026-06-30"}), 1
 		)
+
+
+class TestFanOutRun(IntegrationTestCase):
+	"""The monthly run as an orchestrator: paged, fanned out, failure-isolated."""
+
+	CLUSTER = "ap-south-1"
+	PLAN = "bundle-fanout-test"
+	TEAMS = ["team-fanout-a", "team-fanout-b", "team-fanout-c"]
+
+	def setUp(self):
+		make_plan(self.PLAN)
+		self._purge()
+		for team in self.TEAMS:
+			sub = make_billing_subscription(team, self.CLUSTER, self.PLAN, billing_cycle="Monthly")
+			add_segment(sub, "Created", 1000, "2026-06-01 00:00:00")
+		frappe.db.commit()
+
+	def tearDown(self):
+		self._purge()
+
+	def _purge(self):
+		from central.billing.tests.utils import purge_teams
+
+		purge_teams(self.TEAMS)
+		frappe.db.delete("Error Log", {"method": run.BILLING_RUN_FAILURE})
+		frappe.db.commit()
+
+	def test_one_failing_team_does_not_take_the_run_down(self):
+		# Team b blows up mid-run: the team drafted before it must survive (the unit
+		# rolls back to its own savepoint, not the whole transaction), and the team
+		# after it must still be billed.
+		real = run.generate_team_invoice
+
+		def explode(team, *args, **kwargs):
+			if team == "team-fanout-b":
+				raise ValueError("no rate for this team")
+			return real(team, *args, **kwargs)
+
+		with patch.object(run, "generate_team_invoice", side_effect=explode):
+			run.generate_draft_invoices("2026-06-01", "2026-06-30")
+
+		self.assertTrue(frappe.db.exists("Invoice", {"team": "team-fanout-a"}))
+		self.assertFalse(frappe.db.exists("Invoice", {"team": "team-fanout-b"}))
+		self.assertTrue(frappe.db.exists("Invoice", {"team": "team-fanout-c"}))
+
+		# The casualty is logged under the one title an operator can count.
+		self.assertTrue(
+			frappe.db.exists(
+				"Error Log", {"method": run.BILLING_RUN_FAILURE, "reference_name": "team-fanout-b"}
+			)
+		)
+
+	def test_a_failed_team_is_redrafted_by_the_next_tick(self):
+		# Nothing is re-raised, so the run has to be resumable: the retry drafts the
+		# team that failed and does not double-bill the ones that succeeded.
+		real = run.generate_team_invoice
+
+		def explode(team, *args, **kwargs):
+			if team == "team-fanout-b":
+				raise ValueError("transient")
+			return real(team, *args, **kwargs)
+
+		with patch.object(run, "generate_team_invoice", side_effect=explode):
+			run.generate_draft_invoices("2026-06-01", "2026-06-30")
+		run.generate_draft_invoices("2026-06-01", "2026-06-30")
+
+		for team in self.TEAMS:
+			self.assertEqual(frappe.db.count("Invoice", {"team": team}), 1)

--- a/central/billing/tests/test_billing.py
+++ b/central/billing/tests/test_billing.py
@@ -468,3 +468,26 @@ class TestFanOutRun(IntegrationTestCase):
 
 		for team in self.TEAMS:
 			self.assertEqual(frappe.db.count("Invoice", {"team": team}), 1)
+
+	def test_fan_out_enqueues_one_deduplicated_job_per_team(self):
+		with patch("frappe.enqueue") as enqueue:
+			run.generate_draft_invoices("2026-06-01", "2026-06-30", enqueue=True)
+
+		calls = {c.kwargs["team"]: c for c in enqueue.call_args_list}
+		self.assertTrue(set(self.TEAMS) <= set(calls))
+		call = calls["team-fanout-a"]
+		self.assertEqual(call.args[0], "central.billing.revenue.invoicing.draft_team_invoice")
+		self.assertEqual(call.kwargs["queue"], run.BILLING_QUEUE)
+		self.assertEqual(call.kwargs["job_id"], "billing-draft::2026-06-30::team-fanout-a")
+		self.assertTrue(call.kwargs["deduplicate"])
+		# The orchestrator hands out work; it must not rate anything itself.
+		self.assertFalse(frappe.db.exists("Invoice", {"team": "team-fanout-a"}))
+
+	def test_fanned_out_jobs_draft_exactly_what_the_inline_run_would(self):
+		from central.billing.tests.utils import run_enqueued_inline
+
+		with patch("frappe.enqueue", side_effect=run_enqueued_inline):
+			run.generate_draft_invoices("2026-06-01", "2026-06-30", enqueue=True)
+
+		for team in self.TEAMS:
+			self.assertEqual(frappe.db.count("Invoice", {"team": team}), 1)

--- a/central/billing/tests/test_billing.py
+++ b/central/billing/tests/test_billing.py
@@ -510,7 +510,7 @@ class TestFanOutRun(IntegrationTestCase):
 
 		with patch("frappe.enqueue", side_effect=run_enqueued_inline):
 			drafting = run.draft_monthly_invoices(today="2026-07-01")
-			collecting = run.collect_monthly_invoices(today="2026-07-01")
+			collecting = run.collect_due_invoices(today="2026-07-01")
 
 		# Both ticks agree on the period: the month that closed, never a live one.
 		self.assertEqual(drafting["period_end"], "2026-06-30")
@@ -525,12 +525,55 @@ class TestFanOutRun(IntegrationTestCase):
 		# Order matters: the collect tick only ever touches drafts that already exist,
 		# so firing it before drafting is a no-op rather than a half-billed month.
 		with patch("frappe.enqueue") as enqueue:
-			run.collect_monthly_invoices(today="2026-07-01")
+			run.collect_due_invoices(today="2026-07-01")
 
 		fanned = [c.kwargs["invoice"] for c in enqueue.call_args_list]
 		mine = frappe.get_all("Invoice", filters={"team": ["in", self.TEAMS]}, pluck="name")
 		self.assertEqual(mine, [])
 		self.assertEqual([i for i in fanned if i in mine], [])
+
+	def test_a_draft_that_lands_after_a_sweep_is_collected_by_the_next(self):
+		# The reviewer's case: drafting is still running when collection first fires. A
+		# one-shot collect would settle only what had drafted and orphan the rest with
+		# no later pass. The daily sweep re-runs, so a draft that lands after it is
+		# collected by the next sweep instead of waiting a month.
+		from central.billing.tests.utils import run_enqueued_inline
+
+		# Only team-a has drafted so far.
+		run.draft_team_invoice("team-fanout-a", "2026-06-01", "2026-06-30")
+		frappe.db.commit()
+		with patch("frappe.enqueue", side_effect=run_enqueued_inline):
+			run.collect_due_invoices(today="2026-07-01")
+		self.assertNotEqual(
+			frappe.db.get_value("Invoice", {"team": "team-fanout-a"}, "status"), "Draft"
+		)
+
+		# Drafting catches up after the first sweep — team-b is now a Draft.
+		run.draft_team_invoice("team-fanout-b", "2026-06-01", "2026-06-30")
+		frappe.db.commit()
+		self.assertEqual(
+			frappe.db.get_value("Invoice", {"team": "team-fanout-b"}, "status"), "Draft"
+		)
+
+		# The next daily sweep collects it — nothing is stranded.
+		with patch("frappe.enqueue", side_effect=run_enqueued_inline):
+			run.collect_due_invoices(today="2026-07-01")
+		self.assertNotEqual(
+			frappe.db.get_value("Invoice", {"team": "team-fanout-b"}, "status"), "Draft"
+		)
+
+	def test_the_sweep_takes_every_closed_period_draft_not_one_exact_month(self):
+		# period_end <= cutoff, not ==: a draft an earlier run left behind in an older
+		# month stays in scope of a later sweep rather than being orphaned once the tick
+		# has moved on; a draft whose month has not closed yet is out of scope.
+		run.draft_team_invoice("team-fanout-a", "2026-06-01", "2026-06-30")
+		frappe.db.commit()
+		draft = frappe.db.get_value("Invoice", {"team": "team-fanout-a"}, "name")
+
+		# A sweep whose cutoff is a LATER month still finds the June draft (orphan case).
+		self.assertIn(draft, list(run.drafts_to_settle("2026-07-31")))
+		# A sweep whose cutoff predates the draft's closed month does not.
+		self.assertNotIn(draft, list(run.drafts_to_settle("2026-05-31")))
 
 	def test_status_shows_a_half_finished_run(self):
 		from central.billing.tests.utils import run_enqueued_inline
@@ -545,7 +588,7 @@ class TestFanOutRun(IntegrationTestCase):
 		self.assertEqual(mid["collected"], 0)
 
 		with patch("frappe.enqueue", side_effect=run_enqueued_inline):
-			run.collect_monthly_invoices(today="2026-07-01")
+			run.collect_due_invoices(today="2026-07-01")
 		done = run.billing_run_status(today="2026-07-01")
 		self.assertEqual(done["pending_collection"], 0)
 		self.assertEqual(done["collected"], done["drafted"])

--- a/central/billing/tests/test_billing.py
+++ b/central/billing/tests/test_billing.py
@@ -517,3 +517,37 @@ class TestFanOutRun(IntegrationTestCase):
 		mine = frappe.get_all("Invoice", filters={"team": ["in", self.TEAMS]}, pluck="name")
 		self.assertEqual(mine, [])
 		self.assertEqual([i for i in fanned if i in mine], [])
+
+	def test_status_shows_a_half_finished_run(self):
+		from central.billing.tests.utils import run_enqueued_inline
+
+		# Drafting only: every invoice is still waiting to be collected.
+		with patch("frappe.enqueue", side_effect=run_enqueued_inline):
+			run.draft_monthly_invoices(today="2026-07-01")
+		mid = run.billing_run_status(today="2026-07-01")
+		self.assertEqual(mid["period_end"], "2026-06-30")
+		self.assertGreaterEqual(mid["drafted"], len(self.TEAMS))
+		self.assertEqual(mid["pending_collection"], mid["drafted"])
+		self.assertEqual(mid["collected"], 0)
+
+		with patch("frappe.enqueue", side_effect=run_enqueued_inline):
+			run.collect_monthly_invoices(today="2026-07-01")
+		done = run.billing_run_status(today="2026-07-01")
+		self.assertEqual(done["pending_collection"], 0)
+		self.assertEqual(done["collected"], done["drafted"])
+
+	def test_status_counts_the_teams_a_failed_run_still_owes(self):
+		real = run.generate_team_invoice
+
+		def explode(team, *args, **kwargs):
+			if team == "team-fanout-b":
+				raise ValueError("no rate for this team")
+			return real(team, *args, **kwargs)
+
+		before = run.billing_run_status(today="2026-07-01")
+		with patch.object(run, "generate_team_invoice", side_effect=explode):
+			run.generate_draft_invoices("2026-06-01", "2026-06-30")
+		after = run.billing_run_status(today="2026-07-01")
+
+		self.assertEqual(after["failures"], before["failures"] + 1)
+		self.assertGreaterEqual(after["pending_draft"], 1)  # team b still owes a bill

--- a/central/billing/tests/test_billing.py
+++ b/central/billing/tests/test_billing.py
@@ -551,3 +551,34 @@ class TestFanOutRun(IntegrationTestCase):
 
 		self.assertEqual(after["failures"], before["failures"] + 1)
 		self.assertGreaterEqual(after["pending_draft"], 1)  # team b still owes a bill
+
+	def test_a_lost_savepoint_stops_the_run_instead_of_silencing_it(self):
+		# The database restarted (or something committed underneath the unit), so the
+		# savepoint is gone and the failure cannot be contained. Swallowing it would
+		# leave every remaining team merely "not billed", with no cause recorded.
+		def gone(*args, **kwargs):
+			raise frappe.db.ProgrammingError("SAVEPOINT billing_run_unit does not exist")
+
+		with (
+			patch.object(run, "generate_team_invoice", side_effect=ValueError("the real cause")),
+			patch.object(frappe.db, "rollback", side_effect=gone),
+			self.assertRaises(ValueError) as raised,
+		):
+			run.draft_team_invoice("team-fanout-a", "2026-06-01", "2026-06-30")
+
+		# The original cause survives — the rollback failure is its context, not a
+		# replacement for it.
+		self.assertEqual(str(raised.exception), "the real cause")
+
+	def test_a_contained_failure_is_written_to_the_log_file_too(self):
+		# The Error Log row is a database write: a worker killed before its commit
+		# loses it. The file line is what remains, so it must always be written.
+		with (
+			patch.object(run, "generate_team_invoice", side_effect=ValueError("boom")),
+			patch.object(frappe.logger("billing"), "error") as logged,
+		):
+			run.draft_team_invoice("team-fanout-a", "2026-06-01", "2026-06-30")
+
+		self.assertEqual(logged.call_count, 1)
+		self.assertIn("team-fanout-a", logged.call_args.args[0])
+		self.assertIsInstance(logged.call_args.kwargs["exc_info"], ValueError)

--- a/central/billing/tests/test_dunning.py
+++ b/central/billing/tests/test_dunning.py
@@ -195,3 +195,71 @@ class TestCreditsOnlyDunning(DunningTestBase):
 
 		self.assertEqual(self._attempts(inv), 0)  # nothing to retry against
 		self.assertEqual(self._standing(sub), "Suspended")  # but still escalates
+
+
+class TestOurDelayIsNotTheirDelinquency(DunningTestBase):
+	"""A backlogged billing run must not cost the customer their grace period.
+
+	Every dunning stage is counted from a date that assumes we asked for the money
+	when we said we would. When the run is late, rate-limited, or broken, that
+	assumption is false — and starting the retry ladder, the Overdue notice and the
+	suspension countdown anyway would charge the customer for our outage.
+	"""
+
+	def test_a_gateway_that_rate_limits_us_defers_the_ladder(self):
+		sub = self._subscription()
+		inv = self._open_invoice(sub)
+
+		# Day 7 with no deferral: the invoice would go Overdue and the team past_due.
+		# The rate limit lands first, so the same day must do nothing instead.
+		dunning.defer_dunning(inv, "429 from the gateway")
+		result = dunning.process_invoice_dunning(inv, now=day(7))
+
+		self.assertEqual(result["action"], "none")
+		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Open")
+		self.assertNotEqual(self._standing(sub), "Past Due")
+
+	def test_the_deferred_ladder_still_runs_from_the_fair_date(self):
+		from central.billing.revenue.invoicing import DEFAULT_DUE_DAYS
+
+		sub = self._subscription()
+		inv = self._open_invoice(sub)
+		dunning.defer_dunning(inv, "the run backed up")
+
+		# Deferral is grace, not amnesty: a week after the date we could actually
+		# have asked on, the ladder escalates exactly as it always would.
+		fair = frappe.db.get_value("Invoice", inv, "dunning_starts_on")
+		self.assertEqual(fair, frappe.utils.getdate(frappe.utils.add_days(frappe.utils.nowdate(), DEFAULT_DUE_DAYS)))
+		with declining_gateway():
+			dunning.process_invoice_dunning(inv, now=frappe.utils.add_days(fair, 7))
+		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Overdue")
+
+	def test_deferral_only_ever_moves_forward(self):
+		# Day 2 of a three-day backlog must not hand back the grace day 1 granted,
+		# and a stale failure arriving late must not rewind an already-fair clock.
+		sub = self._subscription()
+		inv = self._open_invoice(sub)
+		dunning.defer_dunning(inv, "first failure")
+		granted = frappe.db.get_value("Invoice", inv, "dunning_starts_on")
+
+		self.assertFalse(dunning.defer_dunning(inv, "same day, second failure"))
+		self.assertEqual(frappe.db.get_value("Invoice", inv, "dunning_starts_on"), granted)
+
+	def test_an_invoice_that_collected_normally_keeps_the_due_date_clock(self):
+		# The fairness rule must not slow down dunning for everyone else.
+		sub = self._subscription()
+		inv = self._open_invoice(sub)
+		frappe.db.set_value("Invoice", inv, "dunning_starts_on", DUE)
+
+		with declining_gateway():
+			result = dunning.process_invoice_dunning(inv, now=day(7))
+		self.assertEqual(frappe.db.get_value("Invoice", inv, "status"), "Overdue")
+		self.assertEqual(result["days_overdue"], 7)
+
+	def test_deferring_never_touches_the_due_date(self):
+		# What the customer owed and when is an accounting fact; AR aging keeps
+		# reading it. Only the escalation clock moves.
+		sub = self._subscription()
+		inv = self._open_invoice(sub)
+		dunning.defer_dunning(inv, "the run backed up")
+		self.assertEqual(str(frappe.db.get_value("Invoice", inv, "due_date")), DUE)

--- a/central/billing/tests/utils.py
+++ b/central/billing/tests/utils.py
@@ -64,6 +64,8 @@ _ENQUEUE_CONTROL_KWARGS = (
 def run_enqueued_inline(method, **kwargs):
 	for control in _ENQUEUE_CONTROL_KWARGS:
 		kwargs.pop(control, None)
+	if isinstance(method, str):  # enqueue takes a dotted path or a callable
+		method = frappe.get_attr(method)
 	return method(**kwargs)
 
 DEFAULT_RATES = [

--- a/central/hooks.py
+++ b/central/hooks.py
@@ -180,16 +180,24 @@ scheduler_events = {
 		# Asset mirror: reconcile against every Active Atlas every 10 minutes — the
 		# backstop that corrects drift the event push (central.api.atlas.event) missed.
 		"*/10 * * * *": ["central.integrations.atlas.reconcile"],
-		# Billing: the monthly run, as two ticks on the 1st. The first drafts the
-		# just-closed month (one job per team); the second, once drafting has
-		# settled, opens and collects (one job per invoice). Rating is heavy and
-		# local, collection is slow and external — a single tick doing both runs at
-		# the speed of the gateway.
+		# Billing: the monthly run. Drafting fires once, on the 1st, and fans the
+		# just-closed month out as one page job per team. Collection is NOT a second
+		# tick a fixed few hours later — at scale drafting may still be running then,
+		# and a one-shot scan would collect only what existed at that instant and
+		# orphan the rest. It is a daily sweep instead (see the `daily` list below):
+		# `collect_due_invoices` drains every Draft whose month has closed, re-running
+		# until nothing is owed. Rating is heavy and local, collection slow and
+		# external, so they stay separate ticks.
 		"0 1 1 * *": ["central.billing.revenue.invoicing.draft_monthly_invoices"],
-		"0 6 1 * *": ["central.billing.revenue.invoicing.collect_monthly_invoices"],
 	},
 	"daily": [
 		"central.central.doctype.team_invitation.team_invitation.expire_pending_invitations",
+		# Billing: collect the monthly run. A daily sweep of every Draft whose month
+		# has closed (period_end <= the just-closed month), fanned out as page jobs.
+		# Re-runs harmlessly: a settled draft drops out of the scan, so once the run
+		# has drained this is a cheap indexed no-op. Runs before dunning so a fresh
+		# charge is attempted before any retry ladder is considered.
+		"central.billing.revenue.invoicing.collect_due_invoices",
 		# Billing (module): retry/dunning + staged suspension for unpaid invoices,
 		# and pruning Payment Attempt / Webhook Event logs.
 		"central.billing.revenue.dunning.run_dunning",

--- a/central/hooks.py
+++ b/central/hooks.py
@@ -180,6 +180,13 @@ scheduler_events = {
 		# Asset mirror: reconcile against every Active Atlas every 10 minutes — the
 		# backstop that corrects drift the event push (central.api.atlas.event) missed.
 		"*/10 * * * *": ["central.integrations.atlas.reconcile"],
+		# Billing: the monthly run, as two ticks on the 1st. The first drafts the
+		# just-closed month (one job per team); the second, once drafting has
+		# settled, opens and collects (one job per invoice). Rating is heavy and
+		# local, collection is slow and external — a single tick doing both runs at
+		# the speed of the gateway.
+		"0 1 1 * *": ["central.billing.revenue.invoicing.draft_monthly_invoices"],
+		"0 6 1 * *": ["central.billing.revenue.invoicing.collect_monthly_invoices"],
 	},
 	"daily": [
 		"central.central.doctype.team_invitation.team_invitation.expire_pending_invitations",
@@ -211,10 +218,6 @@ scheduler_events = {
 		"central.billing.payments.reconciliation.run_reconciliation",
 	],
 	"monthly": [
-		# Billing: on the 1st, bill the just-closed month end-to-end for every team —
-		# draft one consolidated invoice per team, then open + collect (credits→card).
-		# The production trigger for the two-phase invoicing (#09/#10).
-		"central.billing.revenue.invoicing.run_monthly_billing",
 		# Billing: cards expire at the end of their printed month; flip lapsed ones.
 		"central.billing.payments.payments.expire_payment_methods",
 	],


### PR DESCRIPTION
## What

Turns the monthly billing run from a single monolithic scheduler job into a
fan-out orchestrator that hands each team its own unit of work. Closes **G2**
from the billing improvement scope (the run that "cannot do 10M ops").

## Why

`run_monthly_billing` drafted every team, then opened and collected every
invoice — including synchronous gateway HTTP calls — inline, sequentially, in
one scheduler tick. At ~2s per collected invoice, 50k teams ≈ 28h in a single
process, and one team's failure could sink the whole run. The `enqueue` fan-out
path existed but was never used.

## What changed

- **New `revenue/invoicing/run.py`** — the monthly run lives in its own module,
  as an orchestrator that enqueues one job per team on a dedicated **billing
  queue** rather than doing the work inline (`b66e671`, `443d9c0`, `353d4df`).
- **Two scheduler ticks** — drafting and collection are split (28th draft / 1st
  collect) instead of both running in the same monthly tick (`3ae57e3`).
- **Failure isolation** — each team is one job = one transaction = one commit;
  a failing team is contained to its own unit of work (`b514449`), and a team
  that loses a lock race is retried, not dropped for the month (`092638f`).
- **Paged scans** — the orchestrator pages the team/invoice scans instead of
  loading every row into memory (`a0b7805`).
- **Progress derived from the tables** — run progress (drafted/opened/failed) is
  read back from the data, making a partial run visible and resumable for free
  on top of the existing idempotency (`650b59f`).
- **Backlog ≠ dunning** — our own processing backlog must not start the
  customer's dunning clock; grace added so a late run doesn't punish customers
  (`41294c1`).
- **DB-error guard** — a broken database no longer reads as "a run with nothing
  to bill" (`11f26c2`).
- Docs: ARCHITECTURE.md + SETUP-AND-DEMO.md describe the two-ticks-and-a-worker-
  pool model, the billing-queue dial, what the run contends on, and the series
  ceiling (`a2cae30`, `c76a539`, `8881f6f`).