### PR TITLE
perf(billing): kill the rating-path N+1s in the monthly run

### DIFF
--- a/central/billing/revenue/invoicing/__init__.py
+++ b/central/billing/revenue/invoicing/__init__.py
@@ -33,7 +33,7 @@ from central.billing.revenue.invoicing.lifecycle import (
 	open_and_collect,
 	reissue_invoice,
 )
-from central.billing.revenue.invoicing.lines import compute_line_items
+from central.billing.revenue.invoicing.lines import compute_line_items, team_line_items
 from central.billing.revenue.invoicing.run import (
 	billing_run_status,
 	collect_due_invoices,
@@ -48,7 +48,7 @@ from central.billing.revenue.invoicing.run import (
 )
 
 __all__ = [
-	"compute_line_items",
+	"compute_line_items", "team_line_items",
 	"reconcile_subscription", "generate_draft_invoice", "generate_team_invoice",
 	"generate_draft_invoices", "draft_team_invoice", "draft_team_page",
 	"open_and_collect", "open_drafts", "cancel_invoice", "reissue_invoice", "DEFAULT_DUE_DAYS",

--- a/central/billing/revenue/invoicing/generate.py
+++ b/central/billing/revenue/invoicing/generate.py
@@ -19,7 +19,7 @@ scheduler double-fire or a manual run overlapping the cron double-billed the tea
 import frappe
 
 from central.billing.catalog import commitments
-from central.billing.revenue.invoicing.lines import compute_line_items
+from central.billing.revenue.invoicing.lines import compute_line_items, team_line_items
 
 
 def _live_invoice(team: str, period_start, period_end, for_update: bool = False) -> str | None:
@@ -194,18 +194,19 @@ def generate_team_invoice(team: str, period_start, period_end, subscription: str
 	if existing:
 		return existing
 
-	from central.billing.revenue.metering import metered_line_items
+	from central.billing.revenue.metering import metered_line_items_for_clusters
 	from central.billing.revenue.tax import resolve_tax
 	from central.billing.catalog.trials import invoice_type_for
 
+	# Read the team once, not once per cluster: team_line_items pulls every
+	# subscription's fixed lines in one pass, and the metered rollups for all the
+	# team's clusters come back in a single query.
 	asset_ids = frappe.get_all("Subscription", filters={"team": team}, pluck="asset_id")
 	clusters = sorted({
 		c for c in frappe.get_all("Asset", filters={"name": ["in", asset_ids]}, pluck="cluster") if c
 	})
-	lines = []
-	for cluster in clusters:
-		lines += compute_line_items(team, cluster, period_start, period_end)
-		lines += metered_line_items(team, cluster, period_start, period_end)
+	lines = team_line_items(team, period_start, period_end)
+	lines += metered_line_items_for_clusters(team, clusters, period_start, period_end)
 	if not lines:
 		return None
 

--- a/central/billing/revenue/invoicing/lines.py
+++ b/central/billing/revenue/invoicing/lines.py
@@ -19,6 +19,8 @@ from datetime import datetime, time, timedelta
 
 import frappe
 
+from central.billing.catalog.subscriptions import _asset_clusters
+
 CHURN_WINDOW_HOURS = 24
 
 
@@ -55,22 +57,20 @@ def compute_line_items(team: str, cluster: str, period_start, period_end) -> lis
 	subscriptions = frappe.get_all(
 		"Subscription", filters={"team": team}, fields=["name", "asset_id"]
 	)
-	subscriptions = [
-		s for s in subscriptions
-		if s.asset_id and frappe.db.get_value("Asset", s.asset_id, "cluster") == cluster
-	]
+	# Resolve every asset's cluster in one query (not a get_value per subscription),
+	# then keep only the subs whose asset runs in this cluster.
+	clusters = _asset_clusters([s.asset_id for s in subscriptions])
+	subscriptions = [s for s in subscriptions if clusters.get(s.asset_id) == cluster]
+	if not subscriptions:
+		return []
+
+	# All these subscriptions' changes in one query, grouped by subscription — not a
+	# query per subscription.
+	changes_by_sub = _changes_by_subscription([s.name for s in subscriptions])
 
 	lines = []
 	for sub in subscriptions:
-		changes = frappe.get_all(
-			"Subscription Change",
-			filters={"subscription": sub.name, "change_type": ["in", ["Created", "Plan Changed", "Cancelled"]]},
-			fields=["change_type", "new_value", "locked_rate", "effective_at"],
-			# Secondary sort on creation so changes sharing an effective_at (e.g. a
-			# same-instant provision then cancel) order deterministically by when they
-			# were recorded — otherwise a Cancelled could sort ahead of its Created.
-			order_by="effective_at asc, creation asc",
-		)
+		changes = changes_by_sub.get(sub.name, [])
 
 		# Build the billable segments (clamped to the period), flagging churn from the
 		# real held duration (unclamped) so a resize near the period edge still counts.
@@ -127,6 +127,30 @@ def compute_line_items(team: str, cluster: str, period_start, period_end) -> lis
 				if hours > 0:
 					lines.append(_hourly_line(s, hours, hour_units, cd))
 	return lines
+
+
+def _changes_by_subscription(subscription_names: list[str]) -> dict:
+	"""Every billable-segment change for these subscriptions in one query, grouped by
+	subscription and kept in (effective_at, creation) order — the order the segment
+	builder in `compute_line_items` depends on."""
+	if not subscription_names:
+		return {}
+	rows = frappe.get_all(
+		"Subscription Change",
+		filters={
+			"subscription": ["in", subscription_names],
+			"change_type": ["in", ["Created", "Plan Changed", "Cancelled"]],
+		},
+		fields=["subscription", "change_type", "new_value", "locked_rate", "effective_at"],
+		# Secondary sort on creation so changes sharing an effective_at (e.g. a
+		# same-instant provision then cancel) order deterministically by when they were
+		# recorded — otherwise a Cancelled could sort ahead of its Created.
+		order_by="effective_at asc, creation asc",
+	)
+	grouped: dict = {}
+	for r in rows:
+		grouped.setdefault(r.subscription, []).append(r)
+	return grouped
 
 
 def _daily_line(seg: dict, days: int, day_units: int) -> dict:

--- a/central/billing/revenue/invoicing/lines.py
+++ b/central/billing/revenue/invoicing/lines.py
@@ -39,21 +39,18 @@ def _dates_touched(start_dt: datetime, end_dt: datetime) -> list:
 
 
 def compute_line_items(team: str, cluster: str, period_start, period_end) -> list[dict]:
-	"""Time-weighted line items for a (team, cluster) over the billing month.
+	"""Time-weighted fixed line items for one (team, cluster) over the billing month.
 
 	Each `Created`/`Plan Changed` Subscription-Change row opens a segment at its
 	`locked_rate` snapshot that runs until the subscription's next change (or the
 	period end). `Cancelled` rows close the prior segment and carry no rate. A
 	segment held < 24h marks every date it touches as a churn date; those dates
 	bill hourly, all others bill daily.
-	"""
-	ps = frappe.utils.getdate(period_start)
-	pe = frappe.utils.getdate(period_end)
-	period_start_dt = datetime.combine(ps, time.min)
-	period_end_excl_dt = datetime.combine(pe + timedelta(days=1), time.min)
-	day_units = _days_in_period(ps, pe)  # daily denominator
-	hour_units = day_units * 24  # hourly denominator
 
+	Single-cluster entry point — the dashboard forecast asks per cluster. The monthly
+	run bills a whole team at once and uses `team_line_items` instead, which reads the
+	team's subscriptions once rather than once per cluster.
+	"""
 	subscriptions = frappe.get_all(
 		"Subscription", filters={"team": team}, fields=["name", "asset_id"]
 	)
@@ -68,64 +65,116 @@ def compute_line_items(team: str, cluster: str, period_start, period_end) -> lis
 	# query per subscription.
 	changes_by_sub = _changes_by_subscription([s.name for s in subscriptions])
 
+	bounds = _period_bounds(period_start, period_end)
 	lines = []
 	for sub in subscriptions:
-		changes = changes_by_sub.get(sub.name, [])
+		lines += _subscription_lines(sub, cluster, changes_by_sub.get(sub.name, []), bounds)
+	return lines
 
-		# Build the billable segments (clamped to the period), flagging churn from the
-		# real held duration (unclamped) so a resize near the period edge still counts.
-		segs = []
-		for i, change in enumerate(changes):
-			if change.change_type == "Cancelled" or change.locked_rate is None:
-				continue  # terminal marker or no rate snapshot — not a billable segment
-			seg_start_dt = frappe.utils.get_datetime(change.effective_at)
-			seg_end_dt = (
-				frappe.utils.get_datetime(changes[i + 1].effective_at)
-				if i + 1 < len(changes)
-				else period_end_excl_dt
-			)
-			held_hours = (seg_end_dt - seg_start_dt).total_seconds() / 3600.0
-			start = max(seg_start_dt, period_start_dt)
-			end = min(seg_end_dt, period_end_excl_dt)
-			if start >= period_end_excl_dt or end <= period_start_dt:
-				continue  # no overlap with this month
-			segs.append({
-				"start": start, "end": end, "rate": frappe.utils.flt(change.locked_rate),
-				"plan": change.new_value, "asset": sub.asset_id, "cluster": cluster,
-				"churn": held_hours < CHURN_WINDOW_HOURS,
-			})
 
-		# A churn segment (< 24h) turns every date it touches into an hourly date; the
-		# 24h window spans midnight, so a cross-day churn marks both dates.
-		churn_dates = set()
-		for s in segs:
-			if s["churn"]:
-				churn_dates.update(_dates_touched(s["start"], s["end"]))
+def team_line_items(team: str, period_start, period_end) -> list[dict]:
+	"""Every fixed line item for a team across all the clusters it runs in, from ONE
+	read of its subscriptions, their asset clusters and their changes.
 
-		for s in segs:
-			# Daily pass — whole non-churn dates the segment owns. A date belongs to
-			# the config active at its start (the change-date boundary), so a single
-			# mid-day resize still sends the whole transition day to one plan.
-			d0 = max(s["start"].date(), ps)
-			d1 = min(s["end"].date(), pe + timedelta(days=1))  # exclusive
-			days = 0
-			d = d0
-			while d < d1:
-				if d not in churn_dates:
-					days += 1
-				d += timedelta(days=1)
-			if days:
-				lines.append(_daily_line(s, days, day_units))
+	The monthly run bills a team as one consolidated invoice, so it wants all the
+	team's lines together. Looping clusters and calling `compute_line_items` per cluster
+	re-reads the whole team once per cluster; this reads it once and tags each line with
+	its own subscription's cluster. The union of lines is identical either way.
+	"""
+	subscriptions = frappe.get_all(
+		"Subscription", filters={"team": team}, fields=["name", "asset_id"]
+	)
+	clusters = _asset_clusters([s.asset_id for s in subscriptions])
+	changes_by_sub = _changes_by_subscription([s.name for s in subscriptions])
 
-			# Hourly pass — this segment's real hours on each churn date it touches.
-			for cd in _dates_touched(s["start"], s["end"]):
-				if cd not in churn_dates:
-					continue
-				day_start = max(s["start"], datetime.combine(cd, time.min))
-				day_end = min(s["end"], datetime.combine(cd + timedelta(days=1), time.min))
-				hours = (day_end - day_start).total_seconds() / 3600.0
-				if hours > 0:
-					lines.append(_hourly_line(s, hours, hour_units, cd))
+	bounds = _period_bounds(period_start, period_end)
+	lines = []
+	for sub in subscriptions:
+		cluster = clusters.get(sub.asset_id)
+		if not cluster:
+			continue  # no live asset cluster — nothing to bill this subscription against
+		lines += _subscription_lines(sub, cluster, changes_by_sub.get(sub.name, []), bounds)
+	return lines
+
+
+def _period_bounds(period_start, period_end):
+	"""The period's date range and its daily/hourly denominators, computed once and
+	shared across every subscription instead of recomputed per (team, cluster) call."""
+	ps = frappe.utils.getdate(period_start)
+	pe = frappe.utils.getdate(period_end)
+	day_units = _days_in_period(ps, pe)  # daily denominator
+	return frappe._dict(
+		ps=ps,
+		pe=pe,
+		period_start_dt=datetime.combine(ps, time.min),
+		period_end_excl_dt=datetime.combine(pe + timedelta(days=1), time.min),
+		day_units=day_units,
+		hour_units=day_units * 24,  # hourly denominator
+	)
+
+
+def _subscription_lines(sub, cluster: str, changes: list, b) -> list[dict]:
+	"""The daily/hourly fixed lines for one subscription in one cluster.
+
+	Splits the subscription's rate-snapshot changes into billable segments, marks the
+	churn dates (a segment held < 24h), then bills each date either daily or hourly —
+	never both — so the two passes partition the period and the total stays exact.
+	"""
+	# Build the billable segments (clamped to the period), flagging churn from the
+	# real held duration (unclamped) so a resize near the period edge still counts.
+	segs = []
+	for i, change in enumerate(changes):
+		if change.change_type == "Cancelled" or change.locked_rate is None:
+			continue  # terminal marker or no rate snapshot — not a billable segment
+		seg_start_dt = frappe.utils.get_datetime(change.effective_at)
+		seg_end_dt = (
+			frappe.utils.get_datetime(changes[i + 1].effective_at)
+			if i + 1 < len(changes)
+			else b.period_end_excl_dt
+		)
+		held_hours = (seg_end_dt - seg_start_dt).total_seconds() / 3600.0
+		start = max(seg_start_dt, b.period_start_dt)
+		end = min(seg_end_dt, b.period_end_excl_dt)
+		if start >= b.period_end_excl_dt or end <= b.period_start_dt:
+			continue  # no overlap with this month
+		segs.append({
+			"start": start, "end": end, "rate": frappe.utils.flt(change.locked_rate),
+			"plan": change.new_value, "asset": sub.asset_id, "cluster": cluster,
+			"churn": held_hours < CHURN_WINDOW_HOURS,
+		})
+
+	# A churn segment (< 24h) turns every date it touches into an hourly date; the
+	# 24h window spans midnight, so a cross-day churn marks both dates.
+	churn_dates = set()
+	for s in segs:
+		if s["churn"]:
+			churn_dates.update(_dates_touched(s["start"], s["end"]))
+
+	lines = []
+	for s in segs:
+		# Daily pass — whole non-churn dates the segment owns. A date belongs to
+		# the config active at its start (the change-date boundary), so a single
+		# mid-day resize still sends the whole transition day to one plan.
+		d0 = max(s["start"].date(), b.ps)
+		d1 = min(s["end"].date(), b.pe + timedelta(days=1))  # exclusive
+		days = 0
+		d = d0
+		while d < d1:
+			if d not in churn_dates:
+				days += 1
+			d += timedelta(days=1)
+		if days:
+			lines.append(_daily_line(s, days, b.day_units))
+
+		# Hourly pass — this segment's real hours on each churn date it touches.
+		for cd in _dates_touched(s["start"], s["end"]):
+			if cd not in churn_dates:
+				continue
+			day_start = max(s["start"], datetime.combine(cd, time.min))
+			day_end = min(s["end"], datetime.combine(cd + timedelta(days=1), time.min))
+			hours = (day_end - day_start).total_seconds() / 3600.0
+			if hours > 0:
+				lines.append(_hourly_line(s, hours, b.hour_units, cd))
 	return lines
 
 

--- a/central/billing/revenue/metering.py
+++ b/central/billing/revenue/metering.py
@@ -139,7 +139,12 @@ def _settlement_mode_for(resource_type: str) -> str:
 	"""The settlement mode of the family that prices `resource_type` (ADR 0015), blank
 	resolving to Postpaid Overage. Prepaid Pack usage is not billed as overage — the
 	pack was paid up front and excess is blocked at the edge, not charged."""
-	plan = _metered_plan_for(resource_type)
+	return _settlement_from_plan(_metered_plan_for(resource_type))
+
+
+def _settlement_from_plan(plan) -> str:
+	"""Settlement mode off an already-resolved metered plan — split out so the billing
+	loop can resolve the plan once per resource_type instead of once per rollup row."""
 	if not plan:
 		return "Postpaid Overage"
 	category = frappe.db.get_value("Plan", plan.name, "category")
@@ -258,34 +263,50 @@ def metered_line_items(team: str, cluster: str, period_start, period_end) -> lis
 	`max(0, quantity - locked_allowance) x locked_rate`. A rollup entirely
 	within the allowance contributes no line.
 	"""
-	period_start = frappe.utils.getdate(period_start)
-	period_end = frappe.utils.getdate(period_end)
+	# Filter the period in SQL, not Python. period_start is a Datetime, so the upper
+	# bound is the exclusive next-day midnight to keep the old date-inclusive semantics
+	# (a rollup dated on period_end still counts). Rows with no period_start are always
+	# included, as before.
+	Rollup = frappe.qb.DocType("Usage Rollup")
+	period_end_excl = frappe.utils.add_days(frappe.utils.getdate(period_end), 1)
+	rollups = (
+		frappe.qb.from_(Rollup)
+		.select(
+			Rollup.resource_id, Rollup.resource_type, Rollup.meter_type, Rollup.quantity,
+			Rollup.unit, Rollup.currency, Rollup.locked_allowance, Rollup.locked_rate,
+		)
+		.where(Rollup.team == team)
+		.where(Rollup.cluster == cluster)
+		.where(
+			Rollup.period_start.isnull()
+			| (
+				(Rollup.period_start >= frappe.utils.getdate(period_start))
+				& (Rollup.period_start < period_end_excl)
+			)
+		)
+	).run(as_dict=True)
+	if not rollups:
+		return []
 
-	rollups = frappe.get_all(
-		"Usage Rollup",
-		filters={"team": team, "cluster": cluster},
-		fields=[
-			"resource_id", "resource_type", "meter_type", "quantity", "unit", "currency",
-			"locked_allowance", "locked_rate", "period_start",
-		],
-	)
+	# Resolve each family's pricing plan + settlement mode ONCE per resource_type — each
+	# resolution is several queries, and doing it per rollup row is the rating-path N+1.
+	types = {r.resource_type for r in rollups}
+	plan_by_type = {rt: _metered_plan_for(rt) for rt in types}
+	settlement_by_type = {rt: _settlement_from_plan(plan_by_type[rt]) for rt in types}
 
 	lines = []
 	unpriced = []  # (resource_type, reason) — collected so every problem surfaces at once
 	for r in rollups:
-		if r.period_start and not (period_start <= frappe.utils.getdate(r.period_start) <= period_end):
-			continue
-
 		# A prepaid-pack family bills nothing here: the pack was paid up front and usage
 		# beyond it is blocked at the edge, not charged as overage (ADR 0015).
-		if _settlement_mode_for(r.resource_type) == "Prepaid Pack":
+		if settlement_by_type[r.resource_type] == "Prepaid Pack":
 			continue
 
 		# A live metered plan (e.g. snapshot) reads the CURRENT catalog rate and has no
 		# allowance; a grandfathered one uses the terms locked at ingest. `resolved`
 		# stays None (not 0) when no rate is configured, so an unpriced overage is
 		# distinguishable from a genuinely free one below.
-		plan = _metered_plan_for(r.resource_type)
+		plan = plan_by_type[r.resource_type]
 		if plan and plan.pricing_mode == "Live":
 			resolved = resolve_rate(get_catalog_rates("Plan", plan.name), r.currency, cluster)
 			allowance = 0.0

--- a/central/billing/revenue/metering.py
+++ b/central/billing/revenue/metering.py
@@ -257,12 +257,34 @@ def _insert_rollup(meter: dict, terms: dict, qty: float, seq: int, key: str) -> 
 
 
 def metered_line_items(team: str, cluster: str, period_start, period_end) -> list[dict]:
-	"""Metered line items for a (team, cluster) over the billing month.
+	"""Metered line items for one (team, cluster) over the billing month.
 
 	One line per rollup whose period falls in the billing month:
 	`max(0, quantity - locked_allowance) x locked_rate`. A rollup entirely
-	within the allowance contributes no line.
+	within the allowance contributes no line. Single-cluster entry point — the monthly
+	run bills a whole team at once via `metered_line_items_for_clusters`.
 	"""
+	return _metered_lines(team, [cluster], period_start, period_end)
+
+
+def metered_line_items_for_clusters(team: str, clusters, period_start, period_end) -> list[dict]:
+	"""Metered line items for a team across several clusters, from ONE rollup query.
+
+	The monthly run consolidates a team's clusters into a single invoice; scanning
+	rollups (and re-resolving each family's plan) once per cluster is the rating-path
+	N+1. This fetches every cluster's rollups in one query and resolves each metered
+	family once. The billed set is exactly the per-cluster union.
+	"""
+	return _metered_lines(team, list(clusters), period_start, period_end)
+
+
+def _metered_lines(team: str, clusters: list, period_start, period_end) -> list[dict]:
+	"""One line per overage rollup for `team` in any of `clusters` (see the two public
+	wrappers). The rollup carries its own cluster, so a multi-cluster run tags each line
+	correctly and prices Live plans against the rollup's cluster."""
+	if not clusters:
+		return []
+
 	# Filter the period in SQL, not Python. period_start is a Datetime, so the upper
 	# bound is the exclusive next-day midnight to keep the old date-inclusive semantics
 	# (a rollup dated on period_end still counts). Rows with no period_start are always
@@ -274,9 +296,10 @@ def metered_line_items(team: str, cluster: str, period_start, period_end) -> lis
 		.select(
 			Rollup.resource_id, Rollup.resource_type, Rollup.meter_type, Rollup.quantity,
 			Rollup.unit, Rollup.currency, Rollup.locked_allowance, Rollup.locked_rate,
+			Rollup.cluster,
 		)
 		.where(Rollup.team == team)
-		.where(Rollup.cluster == cluster)
+		.where(Rollup.cluster.isin(clusters))
 		.where(
 			Rollup.period_start.isnull()
 			| (
@@ -308,7 +331,7 @@ def metered_line_items(team: str, cluster: str, period_start, period_end) -> lis
 		# distinguishable from a genuinely free one below.
 		plan = plan_by_type[r.resource_type]
 		if plan and plan.pricing_mode == "Live":
-			resolved = resolve_rate(get_catalog_rates("Plan", plan.name), r.currency, cluster)
+			resolved = resolve_rate(get_catalog_rates("Plan", plan.name), r.currency, r.cluster)
 			allowance = 0.0
 		else:
 			resolved = r.locked_rate
@@ -331,7 +354,7 @@ def metered_line_items(team: str, cluster: str, period_start, period_end) -> lis
 				(
 					r.resource_type,
 					frappe._("metered plan {0} has no rate for {1} / {2}").format(
-						plan.name, r.currency, cluster or frappe._("default cluster")
+						plan.name, r.currency, r.cluster or frappe._("default cluster")
 					),
 				)
 			)
@@ -347,7 +370,7 @@ def metered_line_items(team: str, cluster: str, period_start, period_end) -> lis
 			{
 				"subscription_resource": r.resource_id,
 				"plan": None,
-				"cluster": cluster,
+				"cluster": r.cluster,
 				"resource_type": r.resource_type,
 				"unit": r.unit,
 				"quantity": billable_qty,

--- a/central/billing/tests/test_metering.py
+++ b/central/billing/tests/test_metering.py
@@ -126,3 +126,102 @@ class TestMeteredLineItems(MeteringTestBase):
 		self.assertIn("bundle", resource_types)  # fixed line present
 		# subtotal = fixed (full month 1000) + metered overage (25)
 		self.assertEqual(inv.subtotal, 1025.0)
+
+
+class TestMultiClusterConsolidation(IntegrationTestCase):
+	"""The team-wide rating path must return exactly the union of the per-cluster calls
+	it replaced. Proven across two clusters so a batching or filter regression that
+	drops a cluster's lines, or misattributes them, is caught rather than shipping a
+	quietly-wrong invoice."""
+
+	TEAM = "team-multi-cluster"
+	PLAN = "bundle-multi-cluster"
+	CLUSTERS = ["ap-south-1", "us-east-1"]
+
+	def setUp(self):
+		ensure_team(self.TEAM)
+		make_plan(
+			self.PLAN, includes=[{"resource_type": "Transfer", "quantity": 100, "unit": "GB"}]
+		)
+		self._purge()
+		# One running resource per cluster: each seeds a full-June ₹1000/mo fixed segment
+		# and an Asset in that cluster, plus a grandfathered metered rollup over its 100 GB
+		# allowance. The two clusters carry different overage so a swapped/dropped cluster
+		# shows up. The rollup's terms are seeded directly (locked_rate already stamped, as
+		# a real grandfathered rollup is at ingest) so the test exercises the aggregation
+		# itself, not the live metered-plan lookup.
+		for i, cluster in enumerate(self.CLUSTERS):
+			resource = f"srv-multi-{i}"
+			seed_running_resource(self.TEAM, resource, cluster, self.PLAN, rate=1000, currency="INR")
+			frappe.get_doc(
+				{
+					"doctype": "Usage Rollup",
+					"resource_id": resource,
+					"team": self.TEAM,
+					"cluster": cluster,
+					"resource_type": "Transfer",
+					"meter_type": "Counter",
+					"period_start": "2026-06-01 00:00:00",
+					"period_end": "2026-06-30 23:59:59",
+					"quantity": 150 + i * 40,  # 150 GB in one cluster, 190 GB in the other
+					"unit": "GB",
+					"currency": "INR",
+					"locked_allowance": 100,
+					"locked_rate": 0.5,
+					"idempotency_key": f"{resource}:Counter:2026-06-01",
+					"sequence": 0,
+				}
+			).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	def tearDown(self):
+		self._purge()
+
+	def _purge(self):
+		for dt in ("Usage Rollup", "Invoice"):
+			frappe.db.delete(dt, {"team": self.TEAM})
+		for sub in frappe.get_all("Subscription", {"team": self.TEAM}, pluck="name"):
+			frappe.db.delete("Subscription Change", {"subscription": sub})
+			frappe.db.delete("Subscription", {"name": sub})
+		frappe.db.delete("Asset", {"team": self.TEAM})
+		frappe.db.commit()
+
+	def _team_clusters(self):
+		"""The same asset-cluster set generate_team_invoice derives."""
+		asset_ids = frappe.get_all("Subscription", {"team": self.TEAM}, pluck="asset_id")
+		return sorted(
+			{c for c in frappe.get_all("Asset", {"name": ["in", asset_ids]}, pluck="cluster") if c}
+		)
+
+	@staticmethod
+	def _bag(lines):
+		"""Order-independent multiset of lines: each line as a canonical, hashable key."""
+		return sorted(tuple(sorted((k, str(v)) for k, v in line.items())) for line in lines)
+
+	def test_team_fixed_lines_equal_the_per_cluster_union(self):
+		clusters = self._team_clusters()
+		self.assertEqual(len(clusters), 2)  # the scenario really is multi-cluster
+
+		per_cluster = []
+		for cluster in clusters:
+			per_cluster += invoicing.compute_line_items(self.TEAM, cluster, "2026-06-01", "2026-06-30")
+		team_wide = invoicing.team_line_items(self.TEAM, "2026-06-01", "2026-06-30")
+
+		self.assertTrue(per_cluster)  # guard against a vacuous "both empty" pass
+		self.assertEqual({li["cluster"] for li in team_wide}, set(clusters))  # both clusters kept
+		self.assertEqual(self._bag(team_wide), self._bag(per_cluster))
+
+	def test_team_metered_lines_equal_the_per_cluster_union(self):
+		clusters = self._team_clusters()
+		self.assertEqual(len(clusters), 2)
+
+		per_cluster = []
+		for cluster in clusters:
+			per_cluster += metering.metered_line_items(self.TEAM, cluster, "2026-06-01", "2026-06-30")
+		team_wide = metering.metered_line_items_for_clusters(
+			self.TEAM, clusters, "2026-06-01", "2026-06-30"
+		)
+
+		self.assertTrue(per_cluster)
+		self.assertEqual({li["cluster"] for li in team_wide}, set(clusters))  # no misattribution
+		self.assertEqual(self._bag(team_wide), self._bag(per_cluster))


### PR DESCRIPTION
## What

Removes the N+1 query shapes on the invoice rating path — the per-team work the
fan-out run (W4, #196) now spreads across workers. Closes **G4 / W5** from the
billing improvement scope.

## Why

At 200 teams these loops are invisible; at 50k they are hostile. Fanning the run
out to one job per team (W4) only pays off if each job is cheap — and each job
was doing a query per subscription, a query per rollup row, and re-reading the
whole team once per cluster.

## What changed

- **`compute_line_items` — batch the per-subscription lookups.** It did a
  `get_value("Asset", …)` per subscription for the cluster and a
  `get_all("Subscription Change")` per subscription for its changes. Both are now
  one batched query each (reusing the existing `_asset_clusters` helper + a
  grouped changes read).
- **`metered_line_items` — resolve pricing once per resource_type, filter in SQL.**
  It resolved the metered plan + settlement mode (several queries each) for *every
  rollup row*; now once per distinct `resource_type`. The period filter moved from
  a Python scan of all team/cluster rollups into the query (frappe.qb, exclusive
  next-day bound to preserve the date-inclusive + null-included semantics).
- **Read the team once per run, not once per cluster.** `generate_team_invoice`
  looped the team's clusters and called both functions per cluster, re-reading the
  team's subscriptions/changes and re-scanning rollups each time. New team-level
  entry points do it in one pass:
  - `team_line_items(team, …)` — every fixed line from one read of subs + asset
    clusters + changes.
  - `metered_line_items_for_clusters(team, clusters, …)` — all the team's rollups
    in a single query, each family resolved once.

  The single-cluster entry points (`compute_line_items`, `metered_line_items`)
  stay for `generate_draft_invoice` / reissue and the dashboard forecast, which
  legitimately rate one cluster at a time. The billed set is the exact per-cluster
  union — no behaviour change.