### PR TITLE
fix(ui): Add spacing between navlinks and btns in sidebar

### DIFF
--- a/dashboard/src/components/navigation/Sidebar.vue
+++ b/dashboard/src/components/navigation/Sidebar.vue
@@ -91,6 +91,7 @@ const onEdgeMove = (event: MouseEvent): void => {
 						:icon="item.icon"
 						:to="item.to"
 						class="mb-0.5"
+            :class="item.class"
 						:active="!!item.to && item.to === route.path"
 					>
 						<span class="truncate text-sm">{{ item.label }}</span>

--- a/dashboard/src/components/navigation/list.ts
+++ b/dashboard/src/components/navigation/list.ts
@@ -14,9 +14,11 @@ export const sidebarSections = computed(() => {
 					icon: 'lucide-bell',
 					to: '/notifications',
 					condition: isMember.value,
+					class: 'mb-3',
 				},
 			],
 		},
+
 		{
 			items: [
 				{
@@ -33,6 +35,7 @@ export const sidebarSections = computed(() => {
 				},
 			],
 		},
+
 		{
 			label: 'Services',
 			collapsible: true,
@@ -45,6 +48,7 @@ export const sidebarSections = computed(() => {
 				},
 			],
 		},
+
 		{
 			label: 'Billing',
 			items: [


### PR DESCRIPTION
any item on navlinks arr can have a class prop now for more customization of sidebaritem

<img width="323" height="526" alt="image" src="https://github.com/user-attachments/assets/da6a226c-51a7-4f2e-a7f7-07d1c7caad11" />
