### PR TITLE
fix: declare frappe dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
+[tool.bench.frappe-dependencies]
+frappe = ">=17.0.0-dev,<18.0.0"
+
 # These dependencies are only installed when developer mode is enabled
 [tool.bench.dev-dependencies]
 # package_name = "~=1.1.0"


### PR DESCRIPTION
Central has no `[tool.bench.frappe-dependencies]` table, so `bench get-app` warns "Required frappe version not set in pyproject.toml" ([frappe/bench#1524](https://github.com/frappe/bench/issues/1524)), and tooling that treats the declaration as mandatory refuses to install the app.

```toml
[tool.bench.frappe-dependencies]
frappe = ">=17.0.0-dev,<18.0.0"
```

`develop` is central's only development line, so it tracks frappe `develop` — same as what erpnext and hrms declare on their own `develop` branches.

The comma-separated form is deliberate: the commented-out `frappe~=16.0.0` in `[project].dependencies` would resolve to `>=16.0.0,<16.1.0` under bench's `SimpleSpec` parser and exclude most v16 releases.