### PR TITLE
fix(atlas): surface Atlas's own error instead of a bare FrappeException

### DIFF
--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import json
 import re
 import time
+from typing import Any
 from urllib.parse import urlparse
 
 import frappe
 import requests
-from frappe.frappeclient import FrappeClient
+from frappe import _
+from frappe.frappeclient import FrappeClient, FrappeException
 
 from central.central.doctype.asset.asset import Asset
 from central.central.doctype.pilot_credential.pilot_credential import PilotCredential
@@ -34,6 +36,36 @@ CAPACITY_TIMEOUT = 3
 
 class AtlasError(frappe.ValidationError):
 	pass
+
+
+# The last line of a Python traceback is always "<dotted.ExcType>: <message>". That is
+# the only part of a remote failure worth showing a caller, so it is what we lift out of
+# the traceback FrappeClient hands us (see `_post`).
+_REMOTE_EXC_LINE = re.compile(r"^(?P<type>[\w.]+):\s*(?P<message>.+)$")
+
+
+def _remote_error_message(exception: Exception) -> str | None:
+	"""Pull Atlas's own error sentence out of a FrappeClient failure, or None.
+
+	`FrappeClient.post_process` raises FrappeException whose single argument is
+	"FrappeClient Request Failed\\n\\n" followed by Atlas's ENTIRE remote traceback as
+	one string. The actionable sentence Atlas raised — "Capacity is being freed by
+	migrating small VMs — retry shortly.", "Image X is not present on any active
+	server yet", "No capacity available — contact your operator." — is the last line.
+	Everything above it is Atlas's internal frames, which are useless to the caller and
+	should not be rendered into a tenant's browser.
+
+	Returns None when the payload isn't a remote traceback (a connection error, say),
+	so the caller can fall back to a generic message rather than print something wrong.
+	"""
+	text = str(exception or "").strip()
+	if not text:
+		return None
+	for line in reversed(text.splitlines()):
+		match = _REMOTE_EXC_LINE.match(line.strip())
+		if match:
+			return match.group("message").strip() or None
+	return None
 
 
 def get_atlas_instance(region: str):
@@ -68,6 +100,35 @@ class AtlasClient:
 			return self.instance.tunnel_url
 		return self.instance.base_url
 
+	def _post(self, method: str, params: dict, *, action: str) -> Any:
+		"""POST to Atlas, translating a remote failure into Atlas's own error.
+
+		Every tenant-triggered write goes through here. Without it, an Atlas-side
+		`frappe.throw` (region full, image not on any host, size rejected) surfaces to
+		the tenant as a bare `FrappeException` wrapping Atlas's whole traceback: the one
+		sentence that tells them what to do is buried under Atlas internals they should
+		never see. We re-raise it as `AtlasError` carrying just that sentence, and keep
+		the full traceback in the Error Log for operators.
+
+		`action` names the operation for the fallback message, used when the failure
+		isn't a remote traceback at all (Atlas unreachable, TLS error, timeout).
+		"""
+		try:
+			return self.client().post_api(method, params=params)
+		except FrappeException as exception:
+			frappe.log_error(
+				title=f"Atlas '{self.instance.region}': {action} failed",
+				message=str(exception),
+			)
+			message = _remote_error_message(exception)
+			frappe.throw(
+				message
+				or _("Could not {0} — Atlas '{1}' is unreachable. Try again shortly.").format(
+					action, self.instance.region
+				),
+				AtlasError,
+			)
+
 	def ping(self) -> dict:
 		"""Reachability + auth check against the frappe ping endpoint."""
 		return self.client().get_api("ping")
@@ -75,8 +136,10 @@ class AtlasClient:
 	def vm_action(self, name: str, method: str) -> str:
 		"""Invoke a Virtual Machine lifecycle method (start/stop/terminate) as the
 		operator; return the resulting Task name."""
-		return self.client().post_api(
-			"run_doc_method", params={"dt": "Virtual Machine", "dn": name, "method": method}
+		return self._post(
+			"run_doc_method",
+			{"dt": "Virtual Machine", "dn": name, "method": method},
+			action=f"{method} this server",
 		)
 
 	def resize_vm(
@@ -91,9 +154,9 @@ class AtlasClient:
 		the arg-less lifecycle verbs, so it goes through run_doc_method's `args`).
 		Atlas refuses a resize on a running VM — the caller gates on Stopped first.
 		Returns the on-host resize Task name."""
-		return self.client().post_api(
+		return self._post(
 			"run_doc_method",
-			params={
+			{
 				"dt": "Virtual Machine",
 				"dn": name,
 				"method": "resize",
@@ -105,6 +168,7 @@ class AtlasClient:
 					}
 				),
 			},
+			action="resize this server",
 		)
 
 	def create_vm(
@@ -136,7 +200,17 @@ class AtlasClient:
 			params["cpu_max_cores"] = cpu_max_cores
 		if frappe_version:
 			params["frappe_version"] = frappe_version
-		return self.client().post_api("atlas.atlas.api.provision.create_vm", params=params)
+		# Same enrollment carriage as create_site: mint the single-use bootstrap token and
+		# credential id so the bench can run `bench admin enroll` on first boot. Without it
+		# a server provisions fine but never enrols, and Open Console refuses it with
+		# "This VM's pilot hasn't enrolled yet" (central/api/sso.py). Sites had this;
+		# servers did not, which is why only servers were unopenable.
+		params.update(self._pilot_credential(team))
+		# Commit before the Atlas call for the same durability reason create_site has:
+		# minting lazily generates Central's signing key, and a rollback of the enclosing
+		# request must not discard a key the booting bench already holds a token signed by.
+		frappe.db.commit()
+		return self._post("atlas.atlas.api.provision.create_vm", params, action="create this server")
 
 	def capacity(self) -> dict:
 		"""Ask this region what it can seat right now: `{available, unmeasured, largest_vm}`.
@@ -282,7 +356,7 @@ class AtlasClient:
 		# long-lived credential is created only later at enrollment, so nothing else here
 		# needs committing; an unused token after a failed Atlas call is harmless.
 		frappe.db.commit()
-		return self.client().post_api("atlas.atlas.api.site.create_site", params=params)
+		return self._post("atlas.atlas.api.site.create_site", params, action="create this site")
 
 	def _pilot_credential(self, team: str) -> dict:
 		"""
@@ -321,17 +395,19 @@ class AtlasClient:
 		clicks their login link after the stored URL's 24h session has expired — the URL
 		is short-lived by design, so it is re-signed on demand. The Atlas Site controller
 		re-mints in the guest, re-stamps, and returns the mirror."""
-		return self.client().post_api(
+		return self._post(
 			"run_doc_method",
-			params={"dt": "Site", "dn": name, "method": "regenerate_login_url"},
+			{"dt": "Site", "dn": name, "method": "regenerate_login_url"},
+			action="refresh this site's login link",
 		)
 
 	def terminate_site(self, name: str) -> dict:
 		"""Tear down a self-serve site and its 1:1 backing VM. The Atlas Site controller
 		terminates the guest + VM; the site.* events flip the mirror to Terminated."""
-		return self.client().post_api(
+		return self._post(
 			"run_doc_method",
-			params={"dt": "Site", "dn": name, "method": "terminate"},
+			{"dt": "Site", "dn": name, "method": "terminate"},
+			action="terminate this site",
 		)
 
 

--- a/central/tests/test_atlas_errors.py
+++ b/central/tests/test_atlas_errors.py
@@ -1,0 +1,93 @@
+"""Atlas failures must reach the caller as Atlas's own sentence, not a raw traceback.
+
+`FrappeClient` raises `FrappeException` carrying the ENTIRE remote traceback as one
+string, so before `AtlasClient._post` an Atlas-side `frappe.throw` ("region full",
+"image not on any host") surfaced in the console as "FrappeException" over a wall of
+Atlas internals — the actionable sentence buried in the last line.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.frappeclient import FrappeException
+from frappe.tests import IntegrationTestCase
+
+from central.integrations.atlas import AtlasClient, AtlasError, _remote_error_message
+
+# A verbatim capture of what FrappeClient raised for a create that hit a full region.
+CONSOLIDATION_TRACEBACK = """FrappeClient Request Failed
+
+Traceback (most recent call last):
+  File "apps/frappe/frappe/app.py", line 121, in application
+    response = frappe.api.handle(request)
+  File "apps/atlas/atlas/atlas/api/provision.py", line 97, in create_vm
+    pilot.insert(ignore_permissions=True)
+  File "apps/atlas/atlas/atlas/placement.py", line 452, in _raise_no_capacity
+    frappe.throw(
+  File "apps/frappe/frappe/utils/messages.py", line 59, in _raise_exception
+    raise exc
+atlas.atlas.placement.ConsolidationInProgressError: Capacity is being freed by \
+migrating small VMs — retry shortly."""
+
+
+class TestRemoteErrorMessage(IntegrationTestCase):
+	def test_lifts_the_message_off_the_last_traceback_line(self):
+		self.assertEqual(
+			_remote_error_message(FrappeException(CONSOLIDATION_TRACEBACK)),
+			"Capacity is being freed by migrating small VMs — retry shortly.",
+		)
+
+	def test_handles_a_bare_exception_line(self):
+		self.assertEqual(
+			_remote_error_message(FrappeException("atlas.placement.NoCapacityError: Region full.")),
+			"Region full.",
+		)
+
+	def test_returns_none_when_there_is_no_remote_traceback(self):
+		# A connection error carries no "ExcType: message" line, so there is nothing
+		# truthful to show — the caller falls back to its own wording.
+		self.assertIsNone(_remote_error_message(FrappeException("")))
+		self.assertIsNone(_remote_error_message(FrappeException("connection aborted")))
+
+
+class TestAtlasClientPost(IntegrationTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.client = AtlasClient(
+			frappe._dict(region="blr-err", status="Active", tunnel_status=None, tunnel_url=None)
+		)
+
+	def test_remote_throw_becomes_atlas_error_with_only_the_message(self):
+		with patch.object(AtlasClient, "client") as client, patch.object(frappe, "log_error"):
+			client.return_value.post_api.side_effect = FrappeException(CONSOLIDATION_TRACEBACK)
+			with self.assertRaises(AtlasError) as caught:
+				self.client._post("atlas.api.provision.create_vm", {}, action="create this server")
+		rendered = str(caught.exception)
+		self.assertIn("retry shortly", rendered)
+		# The tenant must never see Atlas's frames or file paths.
+		self.assertNotIn("Traceback", rendered)
+		self.assertNotIn("apps/atlas", rendered)
+		self.assertNotIn("FrappeClient Request Failed", rendered)
+
+	def test_unreachable_atlas_falls_back_to_a_generic_message(self):
+		with patch.object(AtlasClient, "client") as client, patch.object(frappe, "log_error"):
+			client.return_value.post_api.side_effect = FrappeException("connection aborted")
+			with self.assertRaises(AtlasError) as caught:
+				self.client._post("atlas.api.provision.create_vm", {}, action="create this server")
+		self.assertIn("create this server", str(caught.exception))
+
+	def test_the_full_traceback_still_reaches_the_error_log(self):
+		with patch.object(AtlasClient, "client") as client, patch.object(frappe, "log_error") as log_error:
+			client.return_value.post_api.side_effect = FrappeException(CONSOLIDATION_TRACEBACK)
+			with self.assertRaises(AtlasError):
+				self.client._post("atlas.api.provision.create_vm", {}, action="create this server")
+		self.assertTrue(log_error.called)
+		self.assertIn("apps/atlas", log_error.call_args.kwargs["message"])
+
+	def test_a_successful_post_is_returned_unchanged(self):
+		with patch.object(AtlasClient, "client") as client:
+			client.return_value.post_api.return_value = {"name": "vm-1"}
+			self.assertEqual(
+				self.client._post("atlas.api.provision.create_vm", {}, action="create this server"),
+				{"name": "vm-1"},
+			)


### PR DESCRIPTION
## The bug

Creating a server against a region with no room failed in the console with a bare
**`FrappeException`** over a wall of Atlas's internal traceback.

`FrappeClient.post_process` raises `FrappeException` whose single argument is the
*entire* remote traceback as one string, and `AtlasClient` passed it straight
through. So the one actionable sentence Atlas actually raised —

- `Capacity is being freed by migrating small VMs — retry shortly.`
- `No capacity available — contact your operator.`
- `Image X is not present on any active server yet — export it to a server first.`

— was buried under frames a tenant should never see, along with Atlas's file
paths. The user-visible result was an error that said nothing and suggested
nothing.

## The change

Route the tenant-triggered writes (`create_vm`, `create_site`, `vm_action`,
`resize_vm`, `regenerate_site_login`, `terminate_site`) through a new
`AtlasClient._post`, which:

- lifts the message off the last traceback line and re-raises it as `AtlasError`,
- keeps the **full** traceback in the Error Log for operators,
- falls back to a message naming the attempted action when the failure isn't a
  remote traceback at all (Atlas unreachable, TLS, timeout) rather than printing
  something misleading.

`AtlasError` subclasses `frappe.ValidationError`, and every existing caller
catches broad `Exception`, so no call site changes behaviour beyond the message.

## Also included

`create_vm` never minted the bootstrap token / credential id that `create_site`
does, so a **server** provisioned fine but never enrolled, and Open Console
refused it with *"This VM's pilot hasn't enrolled yet"* (`central/api/sso.py`).
Sites had this carriage; servers did not — which is why only servers were
unopenable. This had been hand-applied to the staging Central and existed nowhere
in git, so shipping the file without it would have regressed enrollment.

## Verification

Against the real staging wire (`central.x.frappe.dev` → `atlas.x.frappe.dev`),
not a mock — an impossible-size create now returns:

```
No capacity available — contact your operator.
```

with no `Traceback`, no `apps/atlas` paths, and no `FrappeClient Request Failed`
noise, while the full traceback still lands in the Error Log. Normal server
creation was re-verified end to end afterwards (VM Running, `[central]` endpoint
+ token written into the guest's `bench.toml`).

`central/tests/test_atlas_errors.py` covers the extraction (real captured
traceback, bare exception line, non-traceback payloads) and `_post` (message
reaches the caller, no traceback leaks, full traceback logged, unreachable
fallback, success passes through).

## Context

This surfaced while debugging why server creation failed on staging. The
*underlying* cause there was operational and is fixed separately: Atlas's
scheduler had never run, so an image export froze mid-flight and left the
`default_user_image` on a single host, which single-homed placement until that
host filled. This PR is only about the failure being **unreadable** when it
happens.
