### PR TITLE
feat(sso): Central mints site login instead of Atlas

### DIFF
--- a/central/api/sites.py
+++ b/central/api/sites.py
@@ -5,6 +5,7 @@ from frappe import _
 
 from central.iam import can, get_user_team_names, resolve_team
 from central.integrations.atlas import AtlasClient
+from central.sso import mint_site_login
 
 # Self-serve site endpoints for the SMB onboarding flow. Reads come from the Site
 # mirror (kept fresh by the site.* events Atlas pushes); writes go to Atlas as the
@@ -85,8 +86,37 @@ def get_site(name: str) -> dict:
 		"name": doc.name,
 		"status": doc.status,
 		"url": doc.url if running else None,
-		"login_url": _fresh_site_login_url(doc) if running else None,
+		"login_url": _site_login_url(doc) if running else None,
 	}
+
+
+def _site_login_url(doc) -> str | None:
+	"""Prefer a Central-signed assertion the site's own pilot exchanges (no Atlas hop);
+	fall back to Atlas's regenerated URL when the pilot isn't enrolled or reachable yet."""
+	return _pilot_site_login_url(doc) or _fresh_site_login_url(doc)
+
+
+def _pilot_site_login_url(doc) -> str | None:
+	"""Mint a one-time site assertion the pilot exchanges locally. Resolves the hosting bench's
+	audience + gateway from the credential Central bound at create_site; None (→ Atlas fallback)
+	until the pilot has enrolled and its VM reports a Running gateway."""
+	if not doc.pilot_credential_id:
+		return None
+	credential = frappe.qb.DocType("Pilot Credential")
+	asset = frappe.qb.DocType("Asset")
+	row = (
+		frappe.qb.from_(credential)
+		.inner_join(asset)
+		.on(credential.asset == asset.name)
+		.select(credential.audience_id, asset.gateway_url, asset.status)
+		.where((credential.name == doc.pilot_credential_id) & (credential.status == "Active"))
+	).run(as_dict=True)
+	if not row or row[0].status != "Running":
+		return None
+	gateway = (row[0].gateway_url or "").rstrip("/")
+	if not gateway:
+		return None
+	return f"{gateway}/api/v1/sites/{doc.name}/login?sid={mint_site_login(row[0].audience_id, doc.name)}"
 
 
 def _fresh_site_login_url(doc) -> str | None:

--- a/central/central/doctype/site/site.json
+++ b/central/central/doctype/site/site.json
@@ -13,6 +13,7 @@
   "region",
   "status",
   "url",
+  "pilot_credential_id",
   "login_url",
   "login_url_expires_at",
   "last_synced_at",
@@ -78,6 +79,14 @@
    "fieldtype": "Data",
    "label": "URL",
    "options": "URL",
+   "read_only": 1
+  },
+  {
+   "description": "The hosting bench's pilot credential / JWT audience — set at create_site, the key for a Central-minted site login.",
+   "fieldname": "pilot_credential_id",
+   "fieldtype": "Data",
+   "label": "Pilot Credential ID",
+   "no_copy": 1,
    "read_only": 1
   },
   {

--- a/central/central/doctype/site/site.py
+++ b/central/central/doctype/site/site.py
@@ -76,7 +76,7 @@ class Site(Document):
 		doc.url = site.get("url") or None
 		# Write-once: create_site stamps the pilot credential once; later status events
 		# omit it and must not blank the binding a site login resolves through.
-		if site.get("pilot_credential_id"):
+		if site.get("pilot_credential_id") and not doc.pilot_credential_id:
 			doc.pilot_credential_id = site["pilot_credential_id"]
 		# Write-once: the one-click login URL + its expiry only arrive once Running
 		# (Atlas gates them on status), so never blank a handoff we've already stored on

--- a/central/central/doctype/site/site.py
+++ b/central/central/doctype/site/site.py
@@ -18,6 +18,7 @@ class Site(Document):
 		last_synced_at: DF.Datetime | None
 		login_url: DF.SmallText | None
 		login_url_expires_at: DF.Datetime | None
+		pilot_credential_id: DF.Data | None
 		region: DF.Data | None
 		site_name: DF.Data
 		status: DF.Literal["Pending", "Provisioning", "Deploying", "Running", "Failed", "Terminated"]
@@ -73,6 +74,10 @@ class Site(Document):
 		doc.region = site.get("region")
 		doc.status = site.get("status") or "Pending"
 		doc.url = site.get("url") or None
+		# Write-once: create_site stamps the pilot credential once; later status events
+		# omit it and must not blank the binding a site login resolves through.
+		if site.get("pilot_credential_id"):
+			doc.pilot_credential_id = site["pilot_credential_id"]
 		# Write-once: the one-click login URL + its expiry only arrive once Running
 		# (Atlas gates them on status), so never blank a handoff we've already stored on
 		# a later (e.g. status-only) event. Same rule as Asset's login_url.

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -356,7 +356,10 @@ class AtlasClient:
 		# long-lived credential is created only later at enrollment, so nothing else here
 		# needs committing; an unused token after a failed Atlas call is harmless.
 		frappe.db.commit()
-		return self._post("atlas.atlas.api.site.create_site", params, action="create this site")
+		site = self._post("atlas.atlas.api.site.create_site", params, action="create this site")
+		# Central minted this credential, so carry it onto the mirror as the site→pilot key.
+		site["pilot_credential_id"] = params["pilot_credential_id"]
+		return site
 
 	def _pilot_credential(self, team: str) -> dict:
 		"""

--- a/central/sso.py
+++ b/central/sso.py
@@ -38,6 +38,12 @@ def mint_bench_login(audience: str) -> str:
 	return _mint(audience, {"sub": "admin", "scope": "bench"}, BENCH_LOGIN_TTL)
 
 
+def mint_site_login(audience: str, site: str) -> str:
+	"""A one-time assertion the site's pilot exchanges for an Administrator session, scoped to
+	one site. `aud` is the hosting bench's audience id; the pilot verifies it against the JWKS."""
+	return _mint(audience, {"sub": "admin", "scope": "site", "site": site}, BENCH_LOGIN_TTL)
+
+
 def mint_bootstrap_token(team: str, pilot_credential_id: str) -> str:
 	"""A single-use enrollment token seeded into a VM at create time. The pilot presents it
 	once to `central.api.pilot.enroll` to fetch its long-lived credential.

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -308,6 +308,102 @@ class TestAtlasMirror(IntegrationTestCase):
 		regen.assert_called_once_with(fqdn)
 		self.assertEqual(got["login_url"], f"https://{fqdn}/app?sid=fresh")
 
+	def _backing_pilot(self, pcid, rid, *, status="Running", gateway="https://vm.blr1.frappe.dev"):
+		"""The site's 1:1 VM: the Asset carries the gateway, the Pilot Credential the audience."""
+		from central.central.doctype.pilot_credential.pilot_credential import PilotCredential
+
+		if frappe.db.exists("Asset", rid):
+			frappe.delete_doc("Asset", rid, force=True, ignore_permissions=True)
+		frappe.get_doc(
+			{"doctype": "Asset", "resource_id": rid, "team": self.team.name,
+			 "cluster": self.region, "status": status, "gateway_url": gateway or None}
+		).insert(ignore_permissions=True)
+		if frappe.db.exists("Pilot Credential", pcid):
+			frappe.delete_doc("Pilot Credential", pcid, force=True)
+		PilotCredential.mint(team=self.team.name, pilot_credential_id=pcid, asset=rid, audience_id=pcid)
+
+	def test_get_site_mints_pilot_direct_login(self):
+		# An enrolled pilot: get_site hands back a Central-signed site assertion at the bench's
+		# own gateway (no Atlas regenerate); the pilot exchanges it locally for the session.
+		import jwt
+		from jwt.algorithms import RSAAlgorithm
+
+		from central.api import sites
+		from central.api.jwks import jwks_document
+		from central.central.doctype.central_sso_settings.central_sso_settings import ALGORITHM
+		from central.sso import central_url
+
+		fqdn = "direct.blr1.frappe.dev"
+		self._push(
+			"site.status_changed",
+			{"name": fqdn, "team": self.team.name, "subdomain": "direct", "status": "Running",
+			 "url": f"https://{fqdn}", "pilot_credential_id": "pcred-direct"},
+			"2026-06-18 10:05:00",
+		)
+		self._backing_pilot("pcred-direct", "vm-direct")
+
+		frappe.set_user(self.owner)
+		try:
+			with patch("central.integrations.atlas.AtlasClient.regenerate_site_login") as regen:
+				got = sites.get_site(fqdn)
+		finally:
+			frappe.set_user("Administrator")
+		regen.assert_not_called()
+		self.assertTrue(
+			got["login_url"].startswith(f"https://vm.blr1.frappe.dev/api/v1/sites/{fqdn}/login?sid=")
+		)
+		claims = jwt.decode(
+			got["login_url"].split("sid=", 1)[1],
+			RSAAlgorithm.from_jwk(jwks_document()["keys"][0]),
+			algorithms=[ALGORITHM], audience="pcred-direct", issuer=central_url(),
+		)
+		self.assertEqual((claims["scope"], claims["site"]), ("site", fqdn))
+
+	def test_site_pilot_credential_id_is_write_once(self):
+		fqdn = "woc.blr1.frappe.dev"
+		self._push(
+			"site.created",
+			{"name": fqdn, "team": self.team.name, "subdomain": "woc",
+			 "status": "Provisioning", "pilot_credential_id": "pcred-woc"},
+			"2026-06-18 10:00:00",
+		)
+		self.assertEqual(frappe.db.get_value("Site", fqdn, "pilot_credential_id"), "pcred-woc")
+		self._push(
+			"site.status_changed",
+			{"name": fqdn, "team": self.team.name, "subdomain": "woc", "status": "Running"},
+			"2026-06-18 10:05:00",
+		)
+		self.assertEqual(frappe.db.get_value("Site", fqdn, "pilot_credential_id"), "pcred-woc")
+
+	def test_get_site_falls_back_to_atlas_when_pilot_not_ready(self):
+		# pilot_credential_id is stamped but the VM isn't Running (no gateway) — the resolver
+		# returns None and get_site falls back to Atlas's regenerated URL.
+		from central.api import sites
+
+		fqdn = "notready.blr1.frappe.dev"
+		self._push(
+			"site.status_changed",
+			{"name": fqdn, "team": self.team.name, "subdomain": "notready", "status": "Running",
+			 "url": f"https://{fqdn}", "pilot_credential_id": "pcred-notready",
+			 "login_url": f"https://{fqdn}/app?sid=stale",
+			 "login_url_expires_at": "2000-01-01 00:00:00"},
+			"2026-06-18 10:05:00",
+		)
+		self._backing_pilot("pcred-notready", "vm-notready", status="Stopped")
+		fresh = {"name": fqdn, "team": self.team.name, "subdomain": "notready", "status": "Running",
+			 "url": f"https://{fqdn}", "login_url": f"https://{fqdn}/app?sid=atlas",
+			 "login_url_expires_at": "2099-01-01 00:00:00"}
+		frappe.set_user(self.owner)
+		try:
+			with patch(
+				"central.integrations.atlas.AtlasClient.regenerate_site_login", return_value=fresh
+			) as regen:
+				got = sites.get_site(fqdn)
+		finally:
+			frappe.set_user("Administrator")
+		regen.assert_called_once_with(fqdn)
+		self.assertEqual(got["login_url"], f"https://{fqdn}/app?sid=atlas")
+
 	def test_resize_vm_posts_run_doc_method_with_args(self):
 		import json
 

--- a/spec/SSO.md
+++ b/spec/SSO.md
@@ -1,0 +1,50 @@
+# SSO — Central-minted login
+
+Central is the signing authority. It mints short-lived RS256 assertions; benches verify them
+offline against Central's published JWKS. Atlas is not in the login path.
+
+## Flows
+
+**Bench (console) login** — `central.api.sso.get_bench_link`
+1. Central mints `mint_bench_login(aud)` — `scope=bench`, 5 min, single jti.
+2. Browser → `{gateway}/?sid=<jwt>`; the bench SPA exchanges it for a local session cookie.
+
+**Site login** — `central.api.sites.get_site` → `_pilot_site_login_url`
+1. Central resolves the site's hosting bench (audience + gateway) from `Site.pilot_credential_id`
+   → `Pilot Credential` → `Asset.gateway_url`, then mints `mint_site_login(aud, site)` —
+   `scope=site`, `site` claim, 5 min, single jti.
+2. Browser → `{gateway}/api/v1/sites/<site>/login?sid=<jwt>`.
+3. The bench verifies the assertion (JWKS, `aud`, `site`-match, single-use), logs into the
+   Frappe site locally, and 302s to `.../desk?sid=<real session id>`.
+
+If the pilot hasn't enrolled or its VM isn't Running, Central falls back to the Atlas-minted
+`login_url` (`AtlasClient.regenerate_site_login`). Retiring that fallback + the deploy-time mint
+is a follow-up once every bench is enrolled.
+
+## Where tokens live
+
+| What | Stored | Notes |
+|------|--------|-------|
+| Central signing key | `Central SSO Settings` — `private_key` (Password, encrypted), `public_key`, `kid` | Signs every assertion + bootstrap token |
+| Bench durable credential | `Pilot Credential.token_hash` (SHA-256) | Plaintext bearer returned once at enroll, never stored |
+| Site → bench binding | `Site.pilot_credential_id` | A reference, not a token |
+| Bench/site login assertions | **nowhere** | Stateless JWTs — minted on demand, handed off, forgotten |
+| Bootstrap single-use guard | Redis SETNX on the jti | Ephemeral |
+
+On the bench (Pilot): the durable bearer is `bench.toml [central].auth_token` (Central holds only
+its hash); `[admin].jwks_url`/`jwks_audience` are host-shared verification config (public); login
+assertions are never stored — the single-use jti is tracked in-memory (`used_logins`) then dropped;
+the real site session id lives in the Frappe site's own session store.
+
+## Contract
+
+- **RS256 + JWKS**, verified offline. Benches hold only the public key.
+- **`aud` = the bench's `pilot_credential_id`**, assigned by Central. A SID for bench A is
+  rejected by bench B; a pilot cannot self-declare its audience.
+- **5-minute TTL + single-use jti.** Redeemable once, within five minutes; then dead.
+- **Fail closed.** A bench rejects any assertion whose scope it does not understand
+  (`Session.has_scope` is an allowlist) rather than downgrading to Administrator.
+- **Extensibility (distinct scope).** Site login is Administrator today. A future constrained,
+  per-user session must ride a NEW scope (e.g. `site_user`) so older benches reject it here — the
+  identity is threaded through `SiteLogin.create_session(login_as=...)`, which defaults to
+  Administrator. Adding it is additive: a new claim + a new scope handler, no contract change.


### PR DESCRIPTION
Central now signs the site assertion and sends the user to the bench's own pilot, instead of
asking Atlas to regenerate a login URL (Central → Atlas → guest SSH). Mirrors the console login.

### Changes
- `mint_site_login(aud, site)` — `scope=site` assertion (RS256, 5 min, single-use).
- `Site.pilot_credential_id` (write-once) — site → bench key, stamped at `create_site`. No new
  data from Atlas.
- `_site_login_url` prefers a local mint (`frappe.qb` join Pilot Credential ⋈ Asset → gateway +
  audience), else falls back to the Atlas path when the pilot isn't enrolled.
- `spec/SSO.md` — flow, token storage, contract.

Tests in `test_atlas_sync.py`.

### Notes
Depends on the [Pilot PR](https://github.com/frappe/pilot/pull/331). Follow-up once verified: remove the Atlas fallback
(`_fresh_site_login_url`, `AtlasClient.regenerate_site_login`, `Site.login_url*`) and Atlas's
deploy-time mint - only after every site-hosting bench is enrolled.