### PR TITLE
feat(sso): better relay approach for Pilot sso

### DIFF
--- a/central/api/sites.py
+++ b/central/api/sites.py
@@ -5,7 +5,7 @@ from frappe import _
 
 from central.iam import can, get_user_team_names, resolve_team
 from central.integrations.atlas import AtlasClient
-from central.sso import mint_site_login
+from central.integrations.pilot import fetch_site_login_url
 
 # Self-serve site endpoints for the SMB onboarding flow. Reads come from the Site
 # mirror (kept fresh by the site.* events Atlas pushes); writes go to Atlas as the
@@ -97,9 +97,10 @@ def _site_login_url(doc) -> str | None:
 
 
 def _pilot_site_login_url(doc) -> str | None:
-	"""Mint a one-time site assertion the pilot exchanges locally. Resolves the hosting bench's
-	audience + gateway from the credential Central bound at create_site; None (→ Atlas fallback)
-	until the pilot has enrolled and its VM reports a Running gateway."""
+	"""Relay a Central-signed assertion to the site's own pilot, which returns a desk URL with a
+	fresh local session. Resolves the hosting bench's audience + gateway from the credential
+	Central bound at create_site; None (→ Atlas fallback) until the pilot enrolled and its VM is
+	Running."""
 	if not doc.pilot_credential_id:
 		return None
 	credential = frappe.qb.DocType("Pilot Credential")
@@ -116,7 +117,7 @@ def _pilot_site_login_url(doc) -> str | None:
 	gateway = (row[0].gateway_url or "").rstrip("/")
 	if not gateway:
 		return None
-	return f"{gateway}/api/v1/sites/{doc.name}/login?sid={mint_site_login(row[0].audience_id, doc.name)}"
+	return fetch_site_login_url(gateway, row[0].audience_id, doc.name)
 
 
 def _fresh_site_login_url(doc) -> str | None:

--- a/central/integrations/pilot.py
+++ b/central/integrations/pilot.py
@@ -63,7 +63,8 @@ def fetch_site_login_url(gateway_url: str, audience_id: str, site: str) -> str |
 			allow_redirects=False,
 		)
 		response.raise_for_status()
-		url = response.json().get("url")
+		payload = response.json()
+		url = payload.get("url") if isinstance(payload, dict) else None
 	except (requests.RequestException, ValueError, PilotMonitoringError) as exc:
 		frappe.log_error(title=f"Site login relay failed: {site}", message=f"{gateway_url}: {exc}")
 		return None

--- a/central/integrations/pilot.py
+++ b/central/integrations/pilot.py
@@ -53,8 +53,9 @@ class PilotMonitoringClient:
 
 def fetch_site_login_url(gateway_url: str, audience_id: str, site: str) -> str | None:
 	"""Relay a Central-signed site assertion to the bench's login endpoint and return the desk
-	URL it mints (a fresh local session). None on failure — logged, so a bench that consistently
-	fails the relay is diagnosable, then the caller falls back to Atlas."""
+	URL it mints (a fresh local session). None on any failure — minting, request, or an unusable
+	response — logged so a consistently-failing bench or Central is diagnosable, then the caller
+	falls back to Atlas."""
 	try:
 		response = requests.post(
 			f"{_gateway_url(gateway_url)}/api/v1/sites/{site}/login",
@@ -65,7 +66,7 @@ def fetch_site_login_url(gateway_url: str, audience_id: str, site: str) -> str |
 		response.raise_for_status()
 		payload = response.json()
 		url = payload.get("url") if isinstance(payload, dict) else None
-	except (requests.RequestException, ValueError, PilotMonitoringError) as exc:
+	except Exception as exc:  # minting (signing key / DB / encode) must also fall back, not 500
 		frappe.log_error(title=f"Site login relay failed: {site}", message=f"{gateway_url}: {exc}")
 		return None
 	if not isinstance(url, str) or not url:

--- a/central/integrations/pilot.py
+++ b/central/integrations/pilot.py
@@ -6,10 +6,11 @@ from urllib.parse import urlparse
 import frappe
 import requests
 
-from central.sso import mint_bench_login
+from central.sso import mint_bench_login, mint_site_login
 
 METRICS_CACHE_TTL_SECONDS = 30
 PILOT_TIMEOUT_SECONDS = 3
+SITE_LOGIN_TIMEOUT_SECONDS = 10  # the bench spins up a subprocess to mint the session
 
 
 class PilotMonitoringClient:
@@ -48,6 +49,23 @@ class PilotMonitoringClient:
 		if not isinstance(payload, dict):
 			raise PilotMonitoringError
 		return payload
+
+
+def fetch_site_login_url(gateway_url: str, audience_id: str, site: str) -> str | None:
+	"""Relay a Central-signed site assertion to the bench's login endpoint and return the desk
+	URL it mints (a fresh local session). None on any failure, so the caller can fall back."""
+	try:
+		response = requests.post(
+			f"{_gateway_url(gateway_url)}/api/v1/sites/{site}/login",
+			headers={"Authorization": f"Bearer {mint_site_login(audience_id, site)}"},
+			timeout=SITE_LOGIN_TIMEOUT_SECONDS,
+			allow_redirects=False,
+		)
+		response.raise_for_status()
+		url = response.json().get("url")
+	except (requests.RequestException, ValueError, PilotMonitoringError):
+		return None
+	return url if isinstance(url, str) and url else None
 
 
 class PilotMonitoringError(Exception):

--- a/central/integrations/pilot.py
+++ b/central/integrations/pilot.py
@@ -53,7 +53,8 @@ class PilotMonitoringClient:
 
 def fetch_site_login_url(gateway_url: str, audience_id: str, site: str) -> str | None:
 	"""Relay a Central-signed site assertion to the bench's login endpoint and return the desk
-	URL it mints (a fresh local session). None on any failure, so the caller can fall back."""
+	URL it mints (a fresh local session). None on failure — logged, so a bench that consistently
+	fails the relay is diagnosable, then the caller falls back to Atlas."""
 	try:
 		response = requests.post(
 			f"{_gateway_url(gateway_url)}/api/v1/sites/{site}/login",
@@ -63,9 +64,13 @@ def fetch_site_login_url(gateway_url: str, audience_id: str, site: str) -> str |
 		)
 		response.raise_for_status()
 		url = response.json().get("url")
-	except (requests.RequestException, ValueError, PilotMonitoringError):
+	except (requests.RequestException, ValueError, PilotMonitoringError) as exc:
+		frappe.log_error(title=f"Site login relay failed: {site}", message=f"{gateway_url}: {exc}")
 		return None
-	return url if isinstance(url, str) and url else None
+	if not isinstance(url, str) or not url:
+		frappe.log_error(title=f"Site login relay returned no URL: {site}", message=f"{gateway_url}: {url!r}")
+		return None
+	return url
 
 
 class PilotMonitoringError(Exception):

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -322,9 +322,11 @@ class TestAtlasMirror(IntegrationTestCase):
 			frappe.delete_doc("Pilot Credential", pcid, force=True)
 		PilotCredential.mint(team=self.team.name, pilot_credential_id=pcid, asset=rid, audience_id=pcid)
 
-	def test_get_site_mints_pilot_direct_login(self):
-		# An enrolled pilot: get_site hands back a Central-signed site assertion at the bench's
-		# own gateway (no Atlas regenerate); the pilot exchanges it locally for the session.
+	def test_get_site_relays_to_pilot_for_login(self):
+		# An enrolled pilot: get_site POSTs a Central-signed site assertion to the bench's own
+		# gateway (no Atlas regenerate) and returns the desk URL the bench mints.
+		from unittest.mock import MagicMock
+
 		import jwt
 		from jwt.algorithms import RSAAlgorithm
 
@@ -334,6 +336,7 @@ class TestAtlasMirror(IntegrationTestCase):
 		from central.sso import central_url
 
 		fqdn = "direct.blr1.frappe.dev"
+		desk_url = f"https://{fqdn}/desk?sid=real-session"
 		self._push(
 			"site.status_changed",
 			{"name": fqdn, "team": self.team.name, "subdomain": "direct", "status": "Running",
@@ -342,19 +345,23 @@ class TestAtlasMirror(IntegrationTestCase):
 		)
 		self._backing_pilot("pcred-direct", "vm-direct")
 
+		response = MagicMock()
+		response.json.return_value = {"url": desk_url}
 		frappe.set_user(self.owner)
 		try:
-			with patch("central.integrations.atlas.AtlasClient.regenerate_site_login") as regen:
+			with patch("central.integrations.pilot.requests.post", return_value=response) as post, patch(
+				"central.integrations.atlas.AtlasClient.regenerate_site_login"
+			) as regen:
 				got = sites.get_site(fqdn)
 		finally:
 			frappe.set_user("Administrator")
+
 		regen.assert_not_called()
-		self.assertTrue(
-			got["login_url"].startswith(f"https://vm.blr1.frappe.dev/api/v1/sites/{fqdn}/login?sid=")
-		)
+		self.assertEqual(got["login_url"], desk_url)
+		self.assertEqual(post.call_args.args[0], f"https://vm.blr1.frappe.dev/api/v1/sites/{fqdn}/login")
+		token = post.call_args.kwargs["headers"]["Authorization"].split(" ", 1)[1]
 		claims = jwt.decode(
-			got["login_url"].split("sid=", 1)[1],
-			RSAAlgorithm.from_jwk(jwks_document()["keys"][0]),
+			token, RSAAlgorithm.from_jwk(jwks_document()["keys"][0]),
 			algorithms=[ALGORITHM], audience="pcred-direct", issuer=central_url(),
 		)
 		self.assertEqual((claims["scope"], claims["site"]), ("site", fqdn))

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -398,6 +398,35 @@ class TestAtlasMirror(IntegrationTestCase):
 		regen.assert_called_once_with(fqdn)
 		self.assertEqual(got["login_url"], f"https://{fqdn}/app?sid=atlas")
 
+	def test_relay_mint_failure_is_logged_then_falls_back_to_atlas(self):
+		# A signing/mint failure must degrade to Atlas with a log, not surface as a 500.
+		from central.api import sites
+
+		fqdn = "mintfail.blr1.frappe.dev"
+		self._push(
+			"site.status_changed",
+			{"name": fqdn, "team": self.team.name, "subdomain": "mintfail", "status": "Running",
+			 "url": f"https://{fqdn}", "pilot_credential_id": "pcred-mintfail"},
+			"2026-06-18 10:05:00",
+		)
+		self._backing_pilot("pcred-mintfail", "vm-mintfail")
+		fresh = {"name": fqdn, "team": self.team.name, "subdomain": "mintfail", "status": "Running",
+			 "url": f"https://{fqdn}", "login_url": f"https://{fqdn}/app?sid=atlas",
+			 "login_url_expires_at": "2099-01-01 00:00:00"}
+		frappe.set_user(self.owner)
+		try:
+			with patch(
+				"central.integrations.pilot.mint_site_login", side_effect=RuntimeError("signing key")
+			), patch("central.integrations.pilot.frappe.log_error") as log, patch(
+				"central.integrations.atlas.AtlasClient.regenerate_site_login", return_value=fresh
+			) as regen:
+				got = sites.get_site(fqdn)
+		finally:
+			frappe.set_user("Administrator")
+		log.assert_called()
+		regen.assert_called_once_with(fqdn)
+		self.assertEqual(got["login_url"], f"https://{fqdn}/app?sid=atlas")
+
 	def test_site_pilot_credential_id_is_write_once(self):
 		fqdn = "woc.blr1.frappe.dev"
 		self._push(

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -366,6 +366,38 @@ class TestAtlasMirror(IntegrationTestCase):
 		)
 		self.assertEqual((claims["scope"], claims["site"]), ("site", fqdn))
 
+	def test_relay_failure_is_logged_then_falls_back_to_atlas(self):
+		# The pilot is enrolled and Running, but the relay POST fails: log it (so a broken bench
+		# is diagnosable) and fall back to Atlas rather than dropping the login.
+		import requests
+
+		from central.api import sites
+
+		fqdn = "relayfail.blr1.frappe.dev"
+		self._push(
+			"site.status_changed",
+			{"name": fqdn, "team": self.team.name, "subdomain": "relayfail", "status": "Running",
+			 "url": f"https://{fqdn}", "pilot_credential_id": "pcred-relayfail"},
+			"2026-06-18 10:05:00",
+		)
+		self._backing_pilot("pcred-relayfail", "vm-relayfail")
+		fresh = {"name": fqdn, "team": self.team.name, "subdomain": "relayfail", "status": "Running",
+			 "url": f"https://{fqdn}", "login_url": f"https://{fqdn}/app?sid=atlas",
+			 "login_url_expires_at": "2099-01-01 00:00:00"}
+		frappe.set_user(self.owner)
+		try:
+			with patch(
+				"central.integrations.pilot.requests.post", side_effect=requests.RequestException("boom")
+			), patch("central.integrations.pilot.frappe.log_error") as log, patch(
+				"central.integrations.atlas.AtlasClient.regenerate_site_login", return_value=fresh
+			) as regen:
+				got = sites.get_site(fqdn)
+		finally:
+			frappe.set_user("Administrator")
+		log.assert_called()
+		regen.assert_called_once_with(fqdn)
+		self.assertEqual(got["login_url"], f"https://{fqdn}/app?sid=atlas")
+
 	def test_site_pilot_credential_id_is_write_once(self):
 		fqdn = "woc.blr1.frappe.dev"
 		self._push(

--- a/spec/SSO.md
+++ b/spec/SSO.md
@@ -12,14 +12,17 @@ offline against Central's published JWKS. Atlas is not in the login path.
 **Site login** — `central.api.sites.get_site` → `_pilot_site_login_url`
 1. Central resolves the site's hosting bench (audience + gateway) from `Site.pilot_credential_id`
    → `Pilot Credential` → `Asset.gateway_url`, then mints `mint_site_login(aud, site)` —
-   `scope=site`, `site` claim, 5 min, single jti.
-2. Browser → `{gateway}/api/v1/sites/<site>/login?sid=<jwt>`.
-3. The bench verifies the assertion (JWKS, `aud`, `site`-match, single-use), logs into the
-   Frappe site locally, and 302s to `.../desk?sid=<real session id>`.
+   `scope=site`, `site` claim, 5 min.
+2. Central POSTs it to `{gateway}/api/v1/sites/<site>/login` as the `Bearer`
+   (`central.integrations.pilot.fetch_site_login_url`).
+3. The bench verifies the assertion (JWKS, `aud`, `site`-match), logs into the Frappe site
+   locally, and returns `{url: .../desk?sid=<real session id>}`. Central redirects the user there.
 
 If the pilot hasn't enrolled or its VM isn't Running, Central falls back to the Atlas-minted
 `login_url` (`AtlasClient.regenerate_site_login`). Retiring that fallback + the deploy-time mint
 is a follow-up once every bench is enrolled.
+
+The console (bench) login stays browser-carried; only the site login is a Central→bench relay.
 
 ## Where tokens live
 
@@ -41,7 +44,9 @@ the real site session id lives in the Frappe site's own session store.
 - **RS256 + JWKS**, verified offline. Benches hold only the public key.
 - **`aud` = the bench's `pilot_credential_id`**, assigned by Central. A SID for bench A is
   rejected by bench B; a pilot cannot self-declare its audience.
-- **5-minute TTL + single-use jti.** Redeemable once, within five minutes; then dead.
+- **5-minute TTL.** The bench login SID is browser-carried and single-use (jti tracked at the
+  bench); the site assertion is server-to-server (Central→bench, never browser-exposed), bounded
+  by its short TTL.
 - **Fail closed.** A bench rejects any assertion whose scope it does not understand
   (`Session.has_scope` is an allowlist) rather than downgrading to Administrator.
 - **Extensibility (distinct scope).** Site login is Administrator today. A future constrained,


### PR DESCRIPTION
## feat(sso): Central mints + relays the site login instead of Atlas

Central signs the site assertion and POSTs it to the bench's own pilot, which returns a desk URL
with a fresh local session. Before this, Central asked Atlas to regenerate a login URL
(Central → Atlas → SSH into the guest). Removing that SSH mint is the point — the guest becomes
self-sufficient via Central's JWKS.

### Changes
- `mint_site_login(aud, site)` — `scope=site` assertion (RS256, 5 min), same key/JWKS as bench login.
- `Site.pilot_credential_id` (write-once) — site → bench key, stamped at `create_site`. No new
  data from Atlas.
- `_site_login_url` resolves gateway + audience (`frappe.qb` join Pilot Credential ⋈ Asset), then
  `integrations/pilot.fetch_site_login_url` POSTs the assertion as `Bearer` to the bench and
  returns the desk URL. Falls back to the Atlas path when the pilot isn't enrolled / VM not Running.
- `spec/SSO.md` — flow, token storage, contract.

Tests in `test_atlas_sync.py`.

### Notes
- Depends on the [Pilot PR](https://github.com/frappe/pilot/pull/331). Needs a Central → bench network path (same one the monitoring client
  already uses).
- Follow-up once verified: remove the Atlas fallback (`_fresh_site_login_url`,
  `AtlasClient.regenerate_site_login`, `Site.login_url*`) and Atlas's deploy-time `bench browse`
  mint — only after every site-hosting bench is enrolled.