### PR TITLE
fix(ux): better loading for open site

### DIFF
--- a/dashboard/src/components/servers/ServerListPanel.vue
+++ b/dashboard/src/components/servers/ServerListPanel.vue
@@ -37,6 +37,7 @@ const props = defineProps<{
 	canTerminate: boolean
 	busy: string | null
 	opening: string | null
+	openingSite: string | null
 }>()
 
 defineEmits<{
@@ -131,7 +132,7 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 					</span>
 					<span
 						class="sp-row-actions"
-						:class="{ 'sp-row-actions-active': busy === row.id || opening === row.id }"
+						:class="{ 'sp-row-actions-active': busy === row.id || opening === row.id || openingSite === row.id }"
 						@click.stop
 					>
 						<ServerRowActions
@@ -154,7 +155,7 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 							:site="row.site"
 							:can-open="canOpen"
 							:can-terminate="canTerminate"
-							:busy="busy === row.id"
+							:busy="busy === row.id || openingSite === row.id"
 							@open="$emit('openSite', $event)"
 							@terminate="$emit('terminateSite', $event)"
 						/>

--- a/dashboard/src/components/servers/ServerMap.vue
+++ b/dashboard/src/components/servers/ServerMap.vue
@@ -44,6 +44,8 @@ const props = withDefaults(
 		allowCreate?: boolean
 		/** Show direct bench-open affordances inside cluster cards. */
 		allowOpen?: boolean
+		/** Site name currently being opened — spins its cluster-card open button. */
+		openingSite?: string | null
 	}>(),
 	{
 		pins: () => [],
@@ -55,6 +57,7 @@ const props = withDefaults(
 		interactive: true,
 		allowCreate: false,
 		allowOpen: false,
+		openingSite: null,
 	},
 )
 
@@ -749,12 +752,15 @@ function clickNode(n: MapNode): void {
 						<button
 							v-else-if="m.site"
 							class="grid size-7 shrink-0 place-items-center rounded text-ink-gray-5 transition-opacity disabled:cursor-default disabled:opacity-30 enabled:opacity-0 enabled:hover:text-ink-gray-8 group-hover:enabled:opacity-100"
-							:disabled="!allowOpen || !m.site.url"
+							:class="{ '!opacity-100': openingSite === m.site.name }"
+							:disabled="!allowOpen || !m.site.url || openingSite === m.site.name"
 							title="Open site"
 							aria-label="Open site"
 							@click.stop="m.site.url && emit('open-site', m.site.name)"
 						>
-							<span class="lucide-arrow-up-right size-3.5" />
+							<span
+								:class="openingSite === m.site.name ? 'lucide-loader-circle size-3.5 animate-spin' : 'lucide-arrow-up-right size-3.5'"
+							/>
 						</button>
 					</div>
 				</template>

--- a/dashboard/src/pages/servers/ServersPage.vue
+++ b/dashboard/src/pages/servers/ServersPage.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router'
 import { Button, Dialog, Spinner, useCall } from 'frappe-ui'
 import { API, method } from '@/api/methods'
 import { errorToast } from '@/lib/toast'
+import signingInHtml from './signing-in.html?raw'
 import EmptyState from '@/components/common/EmptyState.vue'
 import CreateTeamDialog from '@/components/team/CreateTeamDialog.vue'
 import MapMessageCard from '@/components/servers/MapMessageCard.vue'
@@ -368,19 +369,33 @@ const overviewOpen = computed({
 })
 
 // — Sites. Open logs in: fetch a fresh login_url (Central mints a session on read),
-// opening the tab synchronously so it isn't popup-blocked. Terminate tears down the VM.
+// opening the tab synchronously so it isn't popup-blocked (with a signing-in page so
+// it isn't a blank white screen during the round-trip). Terminate tears down the VM.
+const openingSite = ref<string | null>(null)
 async function openSite(name: string): Promise<void> {
-	const tab = window.open('', '_blank')
+	if (openingSite.value) return // one open at a time — no duplicate tabs/session mints
+	openingSite.value = name
+	// Open the signing-in page from a blob URL (no deprecated document.write, and a
+	// synchronous window.open isn't popup-blocked), then point the tab at the real
+	// session URL once it resolves.
+	const loadingUrl = URL.createObjectURL(new Blob([signingInHtml], { type: 'text/html' }))
+	const tab = window.open(loadingUrl, '_blank')
 	try {
 		await getSiteCall.submit({ name })
 		if (getSiteCall.error) throw getSiteCall.error
 		const url = getSiteCall.data?.login_url || getSiteCall.data?.url
 		if (url && tab) tab.location.href = url
 		else if (url) window.location.href = url
-		else tab?.close()
+		else {
+			tab?.close()
+			errorToast(undefined, "Couldn't open the site — it may not be ready yet. Try again in a moment.")
+		}
 	} catch (e) {
 		tab?.close()
 		errorToast(e)
+	} finally {
+		URL.revokeObjectURL(loadingUrl)
+		openingSite.value = null
 	}
 }
 const pendingSiteTerminate = ref<{ name: string } | null>(null)
@@ -449,6 +464,7 @@ async function confirmSiteTerminate(): Promise<void> {
 				:highlight-id="hoverId"
 				:allow-create="canCreateServer"
 				:allow-open="canOpenServer"
+				:opening-site="openingSite"
 				@open="onOpen"
 				@open-server="open"
 				@open-site="openSite"
@@ -476,6 +492,7 @@ async function confirmSiteTerminate(): Promise<void> {
 						:site="pin.site"
 						:can-open="canOpenServer"
 						:can-terminate="canTerminateServer"
+						:busy="openingSite === pin.site.name"
 						@open="openSite"
 						@terminate="pendingSiteTerminate = { name: $event }"
 					/>
@@ -509,6 +526,7 @@ async function confirmSiteTerminate(): Promise<void> {
 				:can-terminate="canTerminateServer"
 				:busy="busy"
 				:opening="opening"
+				:opening-site="openingSite"
 				@focus-row="focusRow"
 				@clear-location="locationFilter = null"
 				@overview="overviewServer = $event"

--- a/dashboard/src/pages/servers/signing-in.html
+++ b/dashboard/src/pages/servers/signing-in.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Signing you in…</title>
+		<style>
+			/* Espresso (frappe-ui) design tokens — the subset this page uses, resolved to
+			   their RGB triplets so the page is self-contained in the opened tab. */
+			:root {
+				--surface-base: 255 255 255;
+				--text-ink-gray-9: 23 23 23;
+				--text-ink-gray-6: 82 82 82;
+				--outline-gray-2: 226 226 226;
+			}
+			@media (prefers-color-scheme: dark) {
+				:root {
+					--surface-base: 23 23 23;
+					--text-ink-gray-9: 248 248 248;
+					--text-ink-gray-6: 153 153 153;
+					--outline-gray-2: 52 52 52;
+				}
+			}
+			* {
+				box-sizing: border-box;
+			}
+			html,
+			body {
+				height: 100%;
+				margin: 0;
+			}
+			body {
+				display: grid;
+				place-items: center;
+				background: rgb(var(--surface-base));
+				color: rgb(var(--text-ink-gray-9));
+				font-family: InterVar, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+				-webkit-font-smoothing: antialiased;
+			}
+			.stack {
+				display: grid;
+				justify-items: center;
+				gap: 16px;
+			}
+			.spinner {
+				width: 28px;
+				height: 28px;
+				border: 2.5px solid rgb(var(--outline-gray-2));
+				border-top-color: rgb(var(--text-ink-gray-6));
+				border-radius: 9999px;
+				animation: spin 0.7s linear infinite;
+			}
+			@media (prefers-reduced-motion: reduce) {
+				.spinner {
+					animation-duration: 1.6s;
+				}
+			}
+			.text {
+				display: grid;
+				gap: 4px;
+				text-align: center;
+			}
+			.title {
+				font-size: 14px;
+				font-weight: 500;
+				line-height: 1.4;
+			}
+			.subtitle {
+				font-size: 12px;
+				color: rgb(var(--text-ink-gray-6));
+			}
+			@keyframes spin {
+				to {
+					transform: rotate(360deg);
+				}
+			}
+		</style>
+	</head>
+	<body>
+		<div class="stack">
+			<div class="spinner" role="status" aria-label="Signing you in"></div>
+			<div class="text">
+				<div class="title">Signing you in</div>
+				<!-- reminder to be tasteful (xD) -->
+				<div class="subtitle">
+					Brewing your site to get you started…
+				</div>
+			</div>
+		</div>
+	</body>
+</html>


### PR DESCRIPTION
Opening a site showed a ~2s about:blank page. That was due to us opening a new tab and waiting for Pilot to respond with a freshly brewed session for the site. We can show a better loading raw html screen instead for better UX.