### PR TITLE
feat(billing): one transition authority for every billing status

### DIFF
--- a/central/billing/catalog/commitments.py
+++ b/central/billing/catalog/commitments.py
@@ -14,6 +14,8 @@ Breach detection + clawback is issue #31.
 
 import frappe
 
+from central.billing.states import transition
+
 BUNDLE = "bundle"
 
 
@@ -93,4 +95,6 @@ def mark_breached(commitment: dict) -> None:
 	idempotent per (team, period), so this never double-applies.
 	"""
 	if commitment.get("breach"):
-		frappe.db.set_value("Commitment", commitment["breach"], "status", "Breached")
+		doc = frappe.get_doc("Commitment", commitment["breach"])
+		transition(doc, "Breached", actor="scheduler", reason="commitment period breached")
+		doc.save(ignore_permissions=True)

--- a/central/billing/catalog/subscriptions.py
+++ b/central/billing/catalog/subscriptions.py
@@ -18,19 +18,10 @@ writes an append-only Subscription Change.
 
 import frappe
 
-
-class InvalidTransition(frappe.ValidationError):
-	"""An account-standing transition that the state machine does not permit."""
-
-
-# Account-standing transitions Central allows. Suspension is staged through
-# past_due (grace) — never a direct current -> suspended jump; reactivation
-# returns to current from either past_due or suspended.
-_STANDING_TRANSITIONS = {
-	"Current": {"Past Due"},
-	"Past Due": {"Current", "Suspended"},
-	"Suspended": {"Current"},
-}
+# The account-standing state machine (which moves are legal) now lives in the one
+# transition authority; re-exported so callers that catch `subscriptions.InvalidTransition`
+# keep working. Suspension is still staged through Past Due (grace), never a direct jump.
+from central.billing.states import InvalidTransition, transition
 
 # The Subscription Change type that records a move *into* a standing.
 _STANDING_CHANGE_TYPE = {
@@ -882,19 +873,18 @@ def _control_subscription_server(sub, action: str) -> None:
 def set_standing(subscription: str, new_standing: str, changed_by: str | None = None, reason=None):
 	"""Move a subscription's account standing through the allowed transitions.
 
-	Raises InvalidTransition for any move the state machine forbids (same-state,
-	skipping the grace step, unknown standing). Records the move as an
-	append-only Subscription Change. Never touches operational state.
+	Routes the move through the transition authority: it raises InvalidTransition for a
+	forbidden move (skipping the grace step, an unknown standing) and appends a Billing
+	Event. A move to the current standing is an idempotent no-op — dunning re-applies the
+	same standing on each retry day and must not error or record a spurious change. The
+	move is also recorded as an append-only Subscription Change (the load-bearing ledger).
 	"""
 	doc = frappe.get_doc("Subscription", subscription)
 	current = doc.account_standing
+	if current == new_standing:
+		return
 
-	if new_standing not in _STANDING_TRANSITIONS.get(current, set()):
-		raise InvalidTransition(
-			f"Cannot move account standing from '{current}' to '{new_standing}'."
-		)
-
-	doc.account_standing = new_standing
+	transition(doc, new_standing, reason=reason, actor=changed_by)
 	doc.save(ignore_permissions=True)
 	_record_change(
 		subscription,

--- a/central/billing/doctype/billing_event/billing_event.json
+++ b/central/billing/doctype/billing_event/billing_event.json
@@ -55,10 +55,11 @@
   },
   {
    "fieldname": "subject",
-   "fieldtype": "Dynamic Link",
+   "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Subject",
-   "options": "subject_doctype"
+   "search_index": 1,
+   "description": "Docname of the subject. Plain Data, not a Dynamic Link: this append-only log must outlive (and never block the deletion or pruning of) the documents it records."
   },
   {
    "fieldname": "from_state",

--- a/central/billing/doctype/billing_event/billing_event.json
+++ b/central/billing/doctype/billing_event/billing_event.json
@@ -1,0 +1,136 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-07-27 00:00:00.000000",
+ "description": "Append-only, derived stream of billing state transitions and money movements (ADR 0016). Read model for humans and reports; the write path must never read it.",
+ "doctype": "DocType",
+ "editable_grid": 0,
+ "engine": "InnoDB",
+ "field_order": [
+  "team",
+  "occurred_at",
+  "event_type",
+  "subject_doctype",
+  "subject",
+  "from_state",
+  "to_state",
+  "column_break_money",
+  "amount",
+  "currency",
+  "actor",
+  "correlation",
+  "section_break_detail",
+  "reason",
+  "payload"
+ ],
+ "fields": [
+  {
+   "fieldname": "team",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Team",
+   "options": "Team",
+   "search_index": 1
+  },
+  {
+   "fieldname": "occurred_at",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "Occurred At",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "event_type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Event Type"
+  },
+  {
+   "fieldname": "subject_doctype",
+   "fieldtype": "Link",
+   "label": "Subject DocType",
+   "options": "DocType"
+  },
+  {
+   "fieldname": "subject",
+   "fieldtype": "Dynamic Link",
+   "in_list_view": 1,
+   "label": "Subject",
+   "options": "subject_doctype"
+  },
+  {
+   "fieldname": "from_state",
+   "fieldtype": "Data",
+   "label": "From State"
+  },
+  {
+   "fieldname": "to_state",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "To State"
+  },
+  {
+   "fieldname": "column_break_money",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "label": "Amount",
+   "options": "currency"
+  },
+  {
+   "fieldname": "currency",
+   "fieldtype": "Link",
+   "label": "Currency",
+   "options": "Currency"
+  },
+  {
+   "fieldname": "actor",
+   "fieldtype": "Data",
+   "label": "Actor"
+  },
+  {
+   "fieldname": "correlation",
+   "fieldtype": "Data",
+   "label": "Correlation",
+   "search_index": 1
+  },
+  {
+   "fieldname": "section_break_detail",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "reason",
+   "fieldtype": "Small Text",
+   "label": "Reason"
+  },
+  {
+   "fieldname": "payload",
+   "fieldtype": "Code",
+   "label": "Payload",
+   "options": "JSON"
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-07-27 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Billing",
+ "name": "Billing Event",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "export": 1,
+   "share": 1
+  }
+ ],
+ "sort_field": "occurred_at",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/central/billing/doctype/billing_event/billing_event.py
+++ b/central/billing/doctype/billing_event/billing_event.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Billing Event — the append-only, derived transition/money stream (ADR 0016).
+
+Written only by `billing.states.transition()`. It is a projection: no pricing,
+invoicing, settlement, dunning or entitlement code may read it, so dropping the table
+would not change a single invoice total. Its readers are engineers debugging, the
+admin UI, and the reports.
+"""
+
+from frappe.model.document import Document
+
+
+class BillingEvent(Document):
+	pass

--- a/central/billing/payments/charges.py
+++ b/central/billing/payments/charges.py
@@ -185,9 +185,11 @@ def _charge_claimed_attempt(attempt_name: str) -> dict:
 
 	attempt.gateway_transaction_id = result.gateway_transaction_id
 	if result.success:
-		attempt.status = "Captured"  # gateway captured; invoice Paid waits on webhook
+		# gateway captured; invoice Paid waits on the webhook
+		transition(attempt, "Captured", actor="gateway", correlation=attempt.invoice)
 	else:
-		attempt.status = "Failed"
+		transition(attempt, "Failed", actor="gateway", correlation=attempt.invoice,
+				   reason=result.failure_reason)
 		_stamp_failure(attempt, result.failure_code, result.decline_code,
 					   result.failure_reason, result.raw)
 		attempt.completed_at = frappe.utils.now_datetime()
@@ -286,7 +288,8 @@ def confirm_invoice_payment(attempt: str, razorpay_order_id: str | None = None,
 	if not ok:
 		frappe.throw("Payment confirmation failed.", frappe.ValidationError)
 	att.gateway_transaction_id = razorpay_payment_id
-	att.status = "Captured"  # gateway captured; invoice Paid waits on the webhook
+	# gateway captured; invoice Paid waits on the webhook
+	transition(att, "Captured", actor="gateway", correlation=att.invoice)
 	att.save(ignore_permissions=True)
 	return {"confirmed": True, "attempt": att.name, "status": att.status}
 
@@ -374,7 +377,7 @@ def apply_webhook(event_name: str) -> dict:
 		# Funds held, capture pending. Advance only from initiated — never walk a
 		# terminal attempt backwards if the capture/fail webhook arrived first.
 		if attempt.status == "Initiated":
-			attempt.status = "Authorised"
+			transition(attempt, "Authorised", actor="webhook", correlation=attempt.invoice)
 			attempt.save(ignore_permissions=True)
 		_mark_event(event, "Processed")
 		return {"handled": True, "result": "Authorised", "attempt": attempt_name}
@@ -386,7 +389,7 @@ def apply_webhook(event_name: str) -> dict:
 		# webhook). Gate on invoice status, not attempt status, and act once.
 		inv_status = frappe.db.get_value("Invoice", attempt.invoice, "status")
 		if inv_status != "Paid" and attempt.status not in ("Failed", "Refunded"):
-			attempt.status = "Failed"
+			transition(attempt, "Failed", actor="webhook", correlation=attempt.invoice)
 			# Off-session declines surface their real reason here, not on the sync
 			# charge response — pull it off the event so the attempt records why.
 			detail = _extract_failure(adapter_key, payload)
@@ -412,7 +415,7 @@ def apply_webhook(event_name: str) -> dict:
 		return {"handled": True, "result": "Failed", "attempt": attempt_name, "fell_back": fell_back}
 
 	settled = _settle_invoice(attempt)
-	attempt.status = "Captured"
+	transition(attempt, "Captured", actor="webhook", correlation=attempt.invoice)
 	attempt.completed_at = frappe.utils.now_datetime()
 	attempt.resolved_by = "Webhook"
 	attempt.save(ignore_permissions=True)

--- a/central/billing/payments/charges.py
+++ b/central/billing/payments/charges.py
@@ -18,6 +18,7 @@ import frappe
 
 from central.billing.doctype.payment_attempt.payment_attempt import idempotency_key
 from central.billing.gateways.base import GatewayTimeout
+from central.billing.states import transition
 
 # An attempt occupying the invoice — a second charge must not start beside it.
 _IN_FLIGHT = ("Initiated", "Authorised", "Captured")
@@ -435,7 +436,8 @@ def _mark_invoice_paid(invoice: str, amount) -> bool:
 	if inv.status == "Paid":
 		return False  # a duplicate webhook — already settled
 	inv.amount_paid = frappe.utils.flt(amount)
-	inv.status = "Paid"
+	transition(inv, "Paid", reason="gateway capture settled", actor="webhook",
+			   correlation=inv.name, amount=inv.amount_paid)
 	inv.save(ignore_permissions=True)
 
 	from central.billing.platform import notifications

--- a/central/billing/payments/charges.py
+++ b/central/billing/payments/charges.py
@@ -668,7 +668,7 @@ def _credit_topup(event, topup: dict) -> dict:
 
 
 def _mark_event(event, status: str):
-	event.status = status
+	transition(event, status, actor="webhook", correlation=event.gateway_event_id)
 	event.processed_at = frappe.utils.now_datetime()
 	event.save(ignore_permissions=True)
 

--- a/central/billing/payments/mandates.py
+++ b/central/billing/payments/mandates.py
@@ -14,6 +14,8 @@ through the registry, keeping the gateway seam intact (see gateways/base.py).
 
 import frappe
 
+from central.billing.states import transition
+
 MANDATE_METHOD = "UPI Autopay"
 CARD_METHOD = "Card"
 
@@ -244,12 +246,12 @@ def confirm_mandate(payment_method: str, callback: dict):
 	adapter = _adapter(method.gateway)
 
 	if not adapter.verify_payment_signature(callback):
-		method.status = "Failed"
+		transition(method, "Failed", actor=frappe.session.user, reason="mandate signature invalid")
 		method.save(ignore_permissions=True)
 		frappe.throw("Mandate authorisation signature invalid", frappe.ValidationError)
 
 	method.gateway_method_id = callback.get("razorpay_token_id") or callback.get("token_id")
-	method.status = "Active"
+	transition(method, "Active", actor=frappe.session.user)
 	method.validated_at = frappe.utils.now_datetime()
 	method.reauth_required = 0
 	method.save(ignore_permissions=True)
@@ -273,7 +275,7 @@ def cancel_mandate(payment_method: str):
 		_adapter(method.gateway).cancel_mandate(
 			method.gateway_method_id, customer_reference=method.gateway_customer_id
 		)
-	method.status = "Cancelled"
+	transition(method, "Cancelled", actor=frappe.session.user, reason="mandate revoked")
 	method.save(ignore_permissions=True)
 	return method
 

--- a/central/billing/payments/payments.py
+++ b/central/billing/payments/payments.py
@@ -19,6 +19,8 @@ adapter through the registry, keeping the gateway seam intact.
 import frappe
 from frappe.model.document import Document
 
+from central.billing.states import transition
+
 CARD_METHOD = "Card"
 
 
@@ -159,11 +161,11 @@ def confirm_payment_method(
 	method.save(ignore_permissions=True)
 
 	if not _adapter(method.gateway).validate_payment_method(method):
-		method.status = "Failed"
+		transition(method, "Failed", actor=frappe.session.user, reason="validation failed")
 		method.save(ignore_permissions=True)
 		return method
 
-	method.status = "Active"
+	transition(method, "Active", actor=frappe.session.user)
 	method.validated_at = frappe.utils.now_datetime()
 	method.save(ignore_permissions=True)
 	densify_priorities(method.team)
@@ -265,7 +267,9 @@ def expire_payment_methods(now=None) -> dict:
 			continue
 		month_start = frappe.utils.getdate(f"{int(m.expiry_year):04d}-{int(m.expiry_month):02d}-01")
 		if frappe.utils.get_last_day(month_start) < today:
-			frappe.db.set_value("Payment Method", m.name, "status", "Expired")
+			md = frappe.get_doc("Payment Method", m.name)
+			transition(md, "Expired", actor="scheduler", reason="card expiry date passed")
+			md.save(ignore_permissions=True)
 			expired.append(m.name)
 			notifications.notify(
 				m.team, "Card Expiry", context={"label": m.display_label or "Card"},

--- a/central/billing/payments/reconciliation.py
+++ b/central/billing/payments/reconciliation.py
@@ -28,6 +28,8 @@ at the gateway and settles it through the same idempotent path.
 
 import frappe
 
+from central.billing.states import transition
+
 _AMBIGUOUS = ("Initiated", "Authorised")
 _GATEWAY_SUCCESS = {"succeeded", "captured", "paid", "completed"}
 _GATEWAY_FAILED = {"failed", "canceled", "cancelled", "declined", "expired", "voided"}
@@ -192,7 +194,7 @@ def _resolve_paid(attempt):
 	"""Settle through the same idempotent path a webhook uses; tag provenance."""
 	from central.billing.payments import charges
 
-	attempt.status = "Captured"
+	transition(attempt, "Captured", actor="reconciliation", correlation=attempt.invoice)
 	attempt.completed_at = frappe.utils.now_datetime()
 	attempt.resolved_by = "Reconciliation"
 	attempt.save(ignore_permissions=True)
@@ -200,7 +202,8 @@ def _resolve_paid(attempt):
 
 
 def _resolve_failed(attempt, reason: str):
-	attempt.status = "Failed"
+	transition(attempt, "Failed", actor="reconciliation", correlation=attempt.invoice,
+			   reason=reason[:140])
 	attempt.completed_at = frappe.utils.now_datetime()
 	attempt.resolved_by = "Reconciliation"
 	attempt.failure_reason = reason[:140]

--- a/central/billing/payments/refunds.py
+++ b/central/billing/payments/refunds.py
@@ -19,6 +19,7 @@ issued line item is never mutated (see billing.reissue_invoice).
 import frappe
 
 from central.billing.revenue import credits
+from central.billing.states import transition
 
 
 def _adapter(gateway: str):
@@ -90,7 +91,8 @@ def _to_wallet(refund, attempt):
 		reference_name=refund.name,
 		note=refund.reason or f"Overcharge refund for {attempt.invoice}",
 	)
-	refund.status = "Completed"
+	transition(refund, "Completed", actor=frappe.session.user, correlation=attempt.invoice,
+			   amount=refund.amount)
 	refund.completed_at = frappe.utils.now_datetime()
 	refund.save(ignore_permissions=True)
 	return refund
@@ -100,11 +102,14 @@ def _to_source(refund, attempt, reason):
 	"""Refund to the gateway via the adapter (symmetric across gateways)."""
 	result = _adapter(attempt.gateway).refund(attempt, refund.amount, reason or "")
 	refund.gateway_refund_id = result.gateway_refund_id
-	refund.status = "Completed" if result.success else "Failed"
+	transition(refund, "Completed" if result.success else "Failed", actor=frappe.session.user,
+			   correlation=attempt.invoice, amount=refund.amount)
 	if result.success:
 		refund.completed_at = frappe.utils.now_datetime()
 		# A full refund marks the attempt refunded (the invoice still stays Paid).
 		if frappe.utils.flt(refund.amount) >= frappe.utils.flt(attempt.amount):
-			frappe.db.set_value("Payment Attempt", attempt.name, "status", "Refunded")
+			transition(attempt, "Refunded", actor=frappe.session.user, correlation=attempt.invoice,
+					   amount=refund.amount)
+			attempt.save(ignore_permissions=True)
 	refund.save(ignore_permissions=True)
 	return refund

--- a/central/billing/revenue/dunning.py
+++ b/central/billing/revenue/dunning.py
@@ -22,6 +22,7 @@ import frappe
 
 from central.billing.catalog import subscriptions
 from central.billing.catalog.entitlements import issue_token
+from central.billing.states import transition
 
 RETRY_DAYS = [1, 3, 7]
 SUSPEND_AFTER_DAYS = 14
@@ -172,7 +173,8 @@ def process_invoice_dunning(invoice_name: str, now=None) -> dict:
 	# --- Day 7: Overdue + past_due, still running --------------------------
 	if days >= RETRY_DAYS[-1]:
 		if inv.status == "Open":
-			inv.db_set("status", "Overdue")
+			transition(inv, "Overdue", reason="dunning: past due window elapsed", actor="scheduler")
+			inv.save(ignore_permissions=True)
 			actions.append("overdue")
 			from central.billing.platform import notifications
 

--- a/central/billing/revenue/invoicing/lifecycle.py
+++ b/central/billing/revenue/invoicing/lifecycle.py
@@ -13,6 +13,7 @@ import frappe
 
 from central.billing.revenue import credits
 from central.billing.revenue.invoicing.generate import generate_draft_invoice
+from central.billing.states import transition
 
 DEFAULT_DUE_DAYS = 7
 
@@ -50,7 +51,7 @@ def open_and_collect(invoice: str, collect: bool = True) -> dict:
 	if doc.invoice_type == "Cost Report":
 		doc.credit_applied = 0
 		doc.expected_collection = 0
-		doc.status = "Open"
+		transition(doc, "Open", reason="cost report opened", actor="scheduler")
 		doc.save(ignore_permissions=True)
 		return {"invoice": invoice, "claimed": True, "cost_report": True, "expected_collection": 0}
 
@@ -83,12 +84,13 @@ def open_and_collect(invoice: str, collect: bool = True) -> dict:
 
 	# Credits cover it in full — settled, no card charge needed.
 	if doc.expected_collection <= 0:
-		doc.status = "Paid"
+		transition(doc, "Paid", reason="credits covered in full", actor="scheduler",
+				   amount=applied)
 		doc.save(ignore_permissions=True)
 		return {"invoice": invoice, "claimed": True, "credit_applied": applied,
 				"expected_collection": 0, "status": "Paid"}
 
-	doc.status = "Open"
+	transition(doc, "Open", reason="drafted invoice opened for collection", actor="scheduler")
 	doc.save(ignore_permissions=True)
 
 	# Leg 2 — charge the remainder, walking the team's methods primary→backup
@@ -114,7 +116,7 @@ def cancel_invoice(invoice: str, reason: str | None = None) -> str:
 		frappe.throw("A paid invoice cannot be cancelled — issue a refund instead.", frappe.ValidationError)
 	if doc.status == "Cancelled":
 		return invoice
-	doc.status = "Cancelled"
+	transition(doc, "Cancelled", reason=reason, actor=frappe.session.user)
 	doc.save(ignore_permissions=True)
 	if reason:
 		doc.add_comment("Info", f"Cancelled: {reason}")

--- a/central/billing/states.py
+++ b/central/billing/states.py
@@ -119,6 +119,16 @@ WEBHOOK_EVENT = StateMachine(
 	},
 )
 
+COMMITMENT = StateMachine(
+	"Commitment",
+	"status",
+	{
+		"Active": {"Completed", "Breached"},
+		"Completed": set(),  # terminal — the term ran and was honoured
+		"Breached": set(),  # terminal — a period fell short; later periods get no discount
+	},
+)
+
 _MACHINES = {
 	m.doctype: m
 	for m in (
@@ -128,6 +138,7 @@ _MACHINES = {
 		REFUND,
 		PAYMENT_METHOD,
 		WEBHOOK_EVENT,
+		COMMITMENT,
 	)
 }
 

--- a/central/billing/states.py
+++ b/central/billing/states.py
@@ -56,7 +56,46 @@ INVOICE = StateMachine(
 	},
 )
 
-_MACHINES = {m.doctype: m for m in (INVOICE,)}
+PAYMENT_ATTEMPT = StateMachine(
+	"Payment Attempt",
+	"status",
+	{
+		"Initiated": {"Authorised", "Captured", "Failed"},
+		"Authorised": {"Captured", "Failed"},
+		# A synced capture is not final until the webhook, and a failure webhook may still
+		# land first; a full refund sends it onward. Same-state re-captures no-op above.
+		"Captured": {"Failed", "Refunded"},
+		"Failed": set(),  # terminal
+		"Refunded": set(),  # terminal
+	},
+)
+
+# Account standing carries a mandatory grace step: Current cannot jump straight to
+# Suspended. Reactivation from either non-current state returns to Current.
+SUBSCRIPTION_STANDING = StateMachine(
+	"Subscription",
+	"account_standing",
+	{
+		"Current": {"Past Due"},
+		"Past Due": {"Current", "Suspended"},
+		"Suspended": {"Current"},
+	},
+)
+
+REFUND = StateMachine(
+	"Refund",
+	"status",
+	{
+		"Initiated": {"Completed", "Failed"},
+		"Completed": set(),  # terminal
+		"Failed": set(),  # terminal
+	},
+)
+
+_MACHINES = {
+	m.doctype: m
+	for m in (INVOICE, PAYMENT_ATTEMPT, SUBSCRIPTION_STANDING, REFUND)
+}
 
 
 def machine_for(doctype: str) -> StateMachine:
@@ -89,6 +128,11 @@ def transition(
 	"""
 	machine = machine_for(doc.doctype)
 	from_state = doc.get(machine.field)
+	if from_state == to_state:
+		# Idempotent no-op. A duplicate/late webhook, a reconciliation replay, or dunning
+		# re-applying a standing all re-drive the SAME outcome; that is not an illegal move
+		# and must not raise (or append a second event) — it simply already happened.
+		return
 	if not machine.allows(from_state, to_state):
 		frappe.throw(
 			f"{doc.doctype} {doc.name}: illegal transition {from_state} → {to_state}.",

--- a/central/billing/states.py
+++ b/central/billing/states.py
@@ -92,9 +92,43 @@ REFUND = StateMachine(
 	},
 )
 
+PAYMENT_METHOD = StateMachine(
+	"Payment Method",
+	"status",
+	{
+		"Pending Validation": {"Active", "Failed"},
+		"Active": {"Paused", "Cancelled", "Expired", "Failed"},
+		"Paused": {"Active", "Cancelled", "Expired"},
+		"Failed": set(),  # terminal — a fresh attempt is a new method
+		"Cancelled": set(),  # terminal
+		"Expired": set(),  # terminal
+	},
+)
+
+# Inbound gateway webhook processing. No team and no money of its own, but routed
+# through the authority so "why was this webhook ignored" is one query, and so the
+# single owner rule holds uniformly (the grep guard has no special cases).
+WEBHOOK_EVENT = StateMachine(
+	"Webhook Event",
+	"status",
+	{
+		"Received": {"Processed", "Failed", "Ignored"},
+		"Failed": {"Processed", "Ignored"},  # a retried webhook can still land
+		"Processed": set(),
+		"Ignored": set(),
+	},
+)
+
 _MACHINES = {
 	m.doctype: m
-	for m in (INVOICE, PAYMENT_ATTEMPT, SUBSCRIPTION_STANDING, REFUND)
+	for m in (
+		INVOICE,
+		PAYMENT_ATTEMPT,
+		SUBSCRIPTION_STANDING,
+		REFUND,
+		PAYMENT_METHOD,
+		WEBHOOK_EVENT,
+	)
 }
 
 

--- a/central/billing/states.py
+++ b/central/billing/states.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""The single transition authority for billing state machines (ADR 0016).
+
+Every billing status change goes through `transition()`: it validates the move against
+the machine that owns that document's status, writes the field, and appends one
+immutable `Billing Event`. Assigning a status field directly anywhere else in
+`central/billing` is banned — a test greps the module for it, the same shape of guard
+that keeps raw SQL out.
+
+The Billing Event stream is **derived**: no pricing, invoicing, settlement, dunning or
+entitlement code may read it. Drop the table and not one invoice total changes. This is
+the load-bearing constraint that stops the stream becoming a second source of truth
+(ADR 0010).
+"""
+
+import frappe
+
+
+class InvalidTransition(frappe.ValidationError):
+	"""A status move the owning state machine forbids."""
+
+
+class StateMachine:
+	"""One document's status field and the legal moves between its states."""
+
+	def __init__(self, doctype: str, field: str, edges: dict):
+		self.doctype = doctype
+		self.field = field
+		self.edges = {frm: set(tos) for frm, tos in edges.items()}
+
+	def allows(self, from_state, to_state) -> bool:
+		return to_state in self.edges.get(from_state, set())
+
+	def states(self) -> set:
+		out = set(self.edges)
+		for tos in self.edges.values():
+			out |= tos
+		return out
+
+
+# --- The machines -------------------------------------------------------------
+# One entry per billing state machine. Terminal states carry an empty edge set, so the
+# machine — not the caller — refuses to pay a cancelled invoice or reopen a paid one.
+
+INVOICE = StateMachine(
+	"Invoice",
+	"status",
+	{
+		"Draft": {"Open", "Paid", "Cancelled"},  # opened, or settled outright by credits
+		"Open": {"Paid", "Overdue", "Cancelled", "Waived"},
+		"Overdue": {"Paid", "Cancelled", "Waived"},
+		"Paid": set(),  # terminal — corrections are cancel+reissue (pre-pay) or refund
+		"Cancelled": set(),  # terminal
+		"Waived": set(),  # terminal
+	},
+)
+
+_MACHINES = {m.doctype: m for m in (INVOICE,)}
+
+
+def machine_for(doctype: str) -> StateMachine:
+	machine = _MACHINES.get(doctype)
+	if not machine:
+		frappe.throw(f"No billing state machine owns {doctype}.", InvalidTransition)
+	return machine
+
+
+def transition(
+	doc,
+	to_state: str,
+	reason: str | None = None,
+	actor: str | None = None,
+	correlation: str | None = None,
+	amount=None,
+	event_type: str | None = None,
+) -> None:
+	"""Move `doc` to `to_state` through its machine, and append a Billing Event.
+
+	Validates the edge (raising `InvalidTransition` on an illegal move), writes the
+	status field on the in-memory doc, and records the move on the derived stream. It
+	does **not** save the doc: a caller usually sets other fields in the same save, and
+	the event insert rides the same transaction, so both commit or roll back together.
+
+	`correlation` threads everything triggered by settling one invoice onto that
+	invoice's name; it defaults to the doc's own name, which is right for an invoice's
+	own transitions and is what a caller acting on a related doc (an attempt, a refund)
+	overrides.
+	"""
+	machine = machine_for(doc.doctype)
+	from_state = doc.get(machine.field)
+	if not machine.allows(from_state, to_state):
+		frappe.throw(
+			f"{doc.doctype} {doc.name}: illegal transition {from_state} → {to_state}.",
+			InvalidTransition,
+		)
+	doc.set(machine.field, to_state)
+	_append_event(doc, from_state, to_state, reason, actor, correlation, amount, event_type)
+
+
+def _append_event(doc, from_state, to_state, reason, actor, correlation, amount, event_type) -> None:
+	frappe.get_doc(
+		{
+			"doctype": "Billing Event",
+			"team": doc.get("team"),
+			"occurred_at": frappe.utils.now_datetime(),
+			"event_type": event_type or f"{doc.doctype} {to_state}",
+			"subject_doctype": doc.doctype,
+			"subject": doc.name,
+			"from_state": from_state,
+			"to_state": to_state,
+			"amount": amount,
+			"currency": doc.get("currency"),
+			"actor": actor or _default_actor(),
+			"reason": reason,
+			"correlation": correlation or doc.name,
+		}
+	).insert(ignore_permissions=True)
+
+
+def _default_actor() -> str:
+	"""Who is making the move when a caller does not say — the session user, or the
+	scheduler/worker running headless."""
+	user = getattr(frappe.session, "user", None)
+	return user or "system"

--- a/central/billing/tests/test_states.py
+++ b/central/billing/tests/test_states.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""The single transition authority + the derived Billing Event stream (ADR 0016)."""
+
+import frappe
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+
+from central.billing.revenue import invoicing
+from central.billing.states import InvalidTransition, transition
+from central.billing.tests.utils import add_segment, make_billing_subscription, make_plan
+
+TEAM = "team-states"
+CLUSTER = "ap-south-1"
+PLAN = "bundle-states-test"
+
+
+class TestInvoiceStateMachine(IntegrationTestCase):
+	def setUp(self):
+		make_plan(PLAN)
+		self._purge()
+		self.sub = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
+		add_segment(self.sub, "Created", 1000, "2026-06-01 00:00:00")
+		self.inv = invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
+		frappe.db.commit()
+
+	def tearDown(self):
+		self._purge()
+
+	def _purge(self):
+		frappe.db.delete("Billing Event", {"team": TEAM})
+		for dt in ("Invoice", "Credit Ledger Entry"):
+			frappe.db.delete(dt, {"team": TEAM})
+		frappe.db.delete("Credit Wallet", {"team": TEAM})
+		for sub in frappe.get_all("Subscription", {"team": TEAM}, pluck="name"):
+			frappe.db.delete("Subscription Change", {"subscription": sub})
+			frappe.db.delete("Subscription", {"name": sub})
+		frappe.db.commit()
+
+	def _events(self):
+		return frappe.get_all(
+			"Billing Event",
+			filters={"subject_doctype": "Invoice", "subject": self.inv},
+			fields=["from_state", "to_state", "actor", "reason", "correlation", "event_type"],
+			order_by="occurred_at asc, creation asc",
+		)
+
+	def test_a_legal_move_writes_the_field_and_appends_one_event(self):
+		doc = frappe.get_doc("Invoice", self.inv)
+		transition(doc, "Open", reason="opened", actor="scheduler")
+
+		self.assertEqual(doc.status, "Open")  # field written on the in-memory doc
+		events = self._events()
+		self.assertEqual(len(events), 1)
+		self.assertEqual(events[0].from_state, "Draft")
+		self.assertEqual(events[0].to_state, "Open")
+		self.assertEqual(events[0].actor, "scheduler")
+		self.assertEqual(events[0].reason, "opened")
+		# Correlation defaults to the invoice's own name, so its events thread together.
+		self.assertEqual(events[0].correlation, self.inv)
+		self.assertEqual(events[0].event_type, "Invoice Open")
+
+	def test_an_illegal_move_is_refused_and_records_nothing(self):
+		doc = frappe.get_doc("Invoice", self.inv)
+		transition(doc, "Paid", reason="credits")  # Draft → Paid is legal
+		self.assertEqual(len(self._events()), 1)
+
+		# Paid is terminal: reopening it is impossible, and the refusal leaves no trace.
+		with self.assertRaises(InvalidTransition):
+			transition(doc, "Open")
+		self.assertEqual(doc.status, "Paid")  # unchanged
+		self.assertEqual(len(self._events()), 1)  # no event for the rejected move
+
+	def test_paying_a_cancelled_invoice_is_impossible(self):
+		doc = frappe.get_doc("Invoice", self.inv)
+		transition(doc, "Cancelled", reason="superseded")
+		with self.assertRaises(InvalidTransition):
+			transition(doc, "Paid")
+
+	def test_open_and_collect_records_the_open_transition(self):
+		# The split-brain fix end to end: opening a draft goes through the authority, so
+		# the stream carries the move even when the caller is the billing run.
+		invoicing.open_and_collect(self.inv, collect=False)
+
+		self.assertEqual(frappe.db.get_value("Invoice", self.inv, "status"), "Open")
+		to_states = [e.to_state for e in self._events()]
+		self.assertIn("Open", to_states)

--- a/central/billing/tests/test_states.py
+++ b/central/billing/tests/test_states.py
@@ -113,3 +113,15 @@ class TestDeclaredMachines(IntegrationTestCase):
 		self.assertTrue(states.REFUND.allows("Initiated", "Completed"))
 		self.assertTrue(states.REFUND.allows("Initiated", "Failed"))
 		self.assertFalse(states.REFUND.allows("Completed", "Failed"))
+
+	def test_payment_method_edges(self):
+		self.assertTrue(states.PAYMENT_METHOD.allows("Pending Validation", "Active"))
+		self.assertTrue(states.PAYMENT_METHOD.allows("Active", "Expired"))
+		self.assertTrue(states.PAYMENT_METHOD.allows("Active", "Cancelled"))
+		self.assertFalse(states.PAYMENT_METHOD.allows("Cancelled", "Active"))  # terminal
+		self.assertFalse(states.PAYMENT_METHOD.allows("Expired", "Active"))  # terminal
+
+	def test_webhook_event_edges(self):
+		self.assertTrue(states.WEBHOOK_EVENT.allows("Received", "Processed"))
+		self.assertTrue(states.WEBHOOK_EVENT.allows("Received", "Ignored"))
+		self.assertFalse(states.WEBHOOK_EVENT.allows("Processed", "Ignored"))

--- a/central/billing/tests/test_states.py
+++ b/central/billing/tests/test_states.py
@@ -5,6 +5,7 @@
 import frappe
 from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
 
+from central.billing import states
 from central.billing.revenue import invoicing
 from central.billing.states import InvalidTransition, transition
 from central.billing.tests.utils import add_segment, make_billing_subscription, make_plan
@@ -84,3 +85,31 @@ class TestInvoiceStateMachine(IntegrationTestCase):
 		self.assertEqual(frappe.db.get_value("Invoice", self.inv, "status"), "Open")
 		to_states = [e.to_state for e in self._events()]
 		self.assertIn("Open", to_states)
+
+
+class TestDeclaredMachines(IntegrationTestCase):
+	"""The legal edges each machine declares — locked down so a refactor can't quietly
+	widen a machine (e.g. let a refunded attempt be re-captured, or an invoice reopen)."""
+
+	def test_invoice_edges(self):
+		self.assertTrue(states.INVOICE.allows("Draft", "Open"))
+		self.assertTrue(states.INVOICE.allows("Open", "Paid"))
+		self.assertFalse(states.INVOICE.allows("Paid", "Open"))  # terminal
+		self.assertFalse(states.INVOICE.allows("Cancelled", "Paid"))  # can't pay a cancel
+
+	def test_payment_attempt_edges(self):
+		self.assertTrue(states.PAYMENT_ATTEMPT.allows("Initiated", "Captured"))
+		self.assertTrue(states.PAYMENT_ATTEMPT.allows("Captured", "Refunded"))
+		self.assertTrue(states.PAYMENT_ATTEMPT.allows("Captured", "Failed"))  # failure webhook races capture
+		self.assertFalse(states.PAYMENT_ATTEMPT.allows("Refunded", "Captured"))
+		self.assertFalse(states.PAYMENT_ATTEMPT.allows("Failed", "Captured"))
+
+	def test_standing_edges(self):
+		self.assertTrue(states.SUBSCRIPTION_STANDING.allows("Current", "Past Due"))
+		self.assertTrue(states.SUBSCRIPTION_STANDING.allows("Past Due", "Suspended"))
+		self.assertFalse(states.SUBSCRIPTION_STANDING.allows("Current", "Suspended"))  # grace step
+
+	def test_refund_edges(self):
+		self.assertTrue(states.REFUND.allows("Initiated", "Completed"))
+		self.assertTrue(states.REFUND.allows("Initiated", "Failed"))
+		self.assertFalse(states.REFUND.allows("Completed", "Failed"))

--- a/central/billing/tests/test_status_boundary.py
+++ b/central/billing/tests/test_status_boundary.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Every billing status transition goes through one authority (ADR 0016).
+
+`states.transition()` is the only code that may write a billing status field. Assigning
+`.status` / `.account_standing` directly — or through `set_value` / `db_set` — anywhere
+else in `central/billing` lets a caller move a document to a state the machine forbids
+(pay a cancelled invoice, skip the dunning grace step) with nothing recording it on the
+Billing Event stream. This module is that rule as a test, the same mechanical guard that
+keeps `@frappe.whitelist` out of the domain layer.
+
+Setting the INITIAL state at insert is fine (a dict literal `{"status": ...}` on a new
+doc); this catches later *reassignments* and `set_value`/`db_set` writes. The demo
+factories and the tests construct arbitrary historical states on purpose and are out of
+scope.
+"""
+
+import ast
+from pathlib import Path
+
+from central.billing.tests.utils import BillingTestCase
+
+BILLING_ROOT = Path(__file__).resolve().parent.parent
+STATE_FIELDS = {"status", "account_standing"}
+MUTATORS = {"set_value", "db_set"}
+
+# Reviewed exceptions: relative paths whose direct status writes are not billing-state
+# transitions. Empty — every billing status write goes through the authority.
+ALLOWLIST: set[str] = set()
+
+
+def _scoped_files():
+	"""Production billing modules the rule applies to (not states.py itself, not the
+	demo factories or the tests, which stage historical states deliberately)."""
+	for path in sorted(BILLING_ROOT.rglob("*.py")):
+		parts = path.parts
+		if "__pycache__" in parts or "tests" in parts or "demo" in parts:
+			continue
+		rel = path.relative_to(BILLING_ROOT).as_posix()
+		if rel == "states.py" or rel in ALLOWLIST:
+			continue
+		yield path, rel
+
+
+def _mutator_touches_state(call: ast.Call) -> bool:
+	"""A set_value/db_set that writes a state field, positionally ("status", …) or via a
+	dict payload ({"status": …})."""
+	for arg in call.args:
+		if isinstance(arg, ast.Constant) and arg.value in STATE_FIELDS:
+			return True
+		if isinstance(arg, ast.Dict) and any(
+			isinstance(k, ast.Constant) and k.value in STATE_FIELDS for k in arg.keys
+		):
+			return True
+	return False
+
+
+def _direct_state_writes(tree: ast.AST) -> list[int]:
+	"""Line numbers where a billing status field is written directly (not via transition)."""
+	hits = []
+	for node in ast.walk(tree):
+		targets = (
+			node.targets
+			if isinstance(node, ast.Assign)
+			else [node.target]
+			if isinstance(node, ast.AugAssign)
+			else []
+		)
+		if any(isinstance(t, ast.Attribute) and t.attr in STATE_FIELDS for t in targets):
+			hits.append(node.lineno)
+		if (
+			isinstance(node, ast.Call)
+			and isinstance(node.func, ast.Attribute)
+			and node.func.attr in MUTATORS
+			and _mutator_touches_state(node)
+		):
+			hits.append(node.lineno)
+	return hits
+
+
+class TestStatusTransitionBoundary(BillingTestCase):
+	def test_no_direct_status_writes_outside_the_authority(self):
+		violations = []
+		for path, rel in _scoped_files():
+			for lineno in _direct_state_writes(ast.parse(path.read_text())):
+				violations.append(f"{rel}:{lineno}")
+		self.assertEqual(
+			violations,
+			[],
+			"billing status written outside states.py — route it through "
+			f"central.billing.states.transition(): {violations}",
+		)
+
+	def test_the_guard_actually_catches_a_violation(self):
+		# Guard against the guard silently passing: a planted direct write must be caught,
+		# both the attribute-assignment form and the set_value form.
+		planted = ast.parse(
+			'inv.status = "Paid"\n'
+			'frappe.db.set_value("Subscription", n, "account_standing", "Current")\n'
+			'frappe.db.set_value("Invoice", n, {"status": "Open"})\n'
+		)
+		self.assertEqual(len(_direct_state_writes(planted)), 3)

--- a/central/billing/tests/test_subscriptions.py
+++ b/central/billing/tests/test_subscriptions.py
@@ -104,13 +104,20 @@ class TestAccountStandingStateMachine(SubscriptionTestBase):
 		# current -> suspended skips the grace step.
 		with self.assertRaises(InvalidTransition):
 			subscriptions.set_standing(sub.name, "Suspended")
-		# current -> current is a no-op transition, not allowed.
-		with self.assertRaises(InvalidTransition):
-			subscriptions.set_standing(sub.name, "Current")
-		# Move to past_due, then an illegal jump back-and-forth.
+
+	def test_same_standing_is_an_idempotent_noop(self):
+		# Dunning re-applies the same standing on each retry day: it must not raise or
+		# record a spurious change — the move already happened.
+		sub = self.make_sub()  # starts Current
+		subscriptions.set_standing(sub.name, "Current")
+		self.assertEqual(frappe.db.get_value("Subscription", sub.name, "account_standing"), "Current")
 		subscriptions.set_standing(sub.name, "Past Due")
-		with self.assertRaises(InvalidTransition):
-			subscriptions.set_standing(sub.name, "Past Due")  # same-state
+		subscriptions.set_standing(sub.name, "Past Due")  # same-state, no-op
+		self.assertEqual(frappe.db.get_value("Subscription", sub.name, "account_standing"), "Past Due")
+		self.assertEqual(
+			frappe.db.count("Subscription Change", {"subscription": sub.name, "change_type": "Past Due"}),
+			1,  # recorded once, not twice
+		)
 
 	def test_unknown_standing_raises(self):
 		sub = self.make_sub()


### PR DESCRIPTION
Billing has seven status fields — `Invoice.status`, `Payment Attempt.status`,
`Payment Method.status`, `Subscription.account_standing`, `Refund.status`,
`Webhook Event.status`, `Commitment.status` — and until now nothing owned any of
them. Nine production modules assigned a status directly onto a document.

`Invoice.status` alone was written from two places that did not know about each
other: `payments/charges.py` set `Paid` when a webhook settled an attempt, and
`revenue/invoicing/lifecycle.py` set `Open`/`Paid`/`Cancelled` during the run.
There was no transition table and no guard, so nothing forbade paying a cancelled
invoice or reopening a paid one. The second half of the problem is that nothing
recorded what happened, in order: answering "why wasn't this team charged" meant
joining six mutable tables by timestamp and hoping their status fields agreed.

## What this does

Adds `billing/states.py` — a `transition(doc, to_state, reason, actor, correlation)`
authority that validates the move against the machine owning that document's status,
writes the field, and appends one immutable `Billing Event`. All seven machines are
declared there with their legal edges; terminal states carry an empty edge set, so
the machine — not the caller — refuses the illegal move.

Every writer is routed through it: lifecycle, charges, dunning, reconciliation,
refunds, mandates, payments, subscriptions (`set_standing`), commitments.
`InvalidTransition` and `set_standing`'s own machine move into `states.py`;
`subscriptions` re-exports the exception so existing `except` clauses keep working.

`Billing Event` is a new append-only doctype: team, occurred_at, event_type,
subject, from_state → to_state, amount/currency, actor, correlation, reason,
payload. The stream is **derived** — no pricing, invoicing, settlement, dunning or
entitlement code may read it. Drop the table and not one invoice total changes.
That constraint is what stops it becoming a second source of truth (ADR 0010).

## Decisions worth reviewing

- **A same-state move is an idempotent no-op, not an error.** A late or duplicate
  webhook, a reconciliation replay, and dunning re-applying a standing all re-drive
  the same outcome. It must not raise, and must not append a second event.
- **`Billing Event.subject` is plain `Data`, not a Dynamic Link.** The log has to
  outlive what it records — a link was already blocking deletion of a payment
  method, and would have blocked webhook-event pruning.
- **`transition()` does not save the doc.** Callers usually set other fields in the
  same save, and the event insert rides the same transaction, so the status change
  and its event commit or roll back together.
- **`correlation` defaults to the doc's own name** and is overridden by callers
  acting on a related document, threading everything triggered by settling one
  invoice onto that invoice.