### PR TITLE
feat: Split billing decisions from their effects

### DIFF
--- a/central/billing/revenue/dunning.py
+++ b/central/billing/revenue/dunning.py
@@ -64,6 +64,58 @@ def dunning_clock_start(invoice_doc):
 	return invoice_doc.get("dunning_starts_on") or invoice_doc.due_date
 
 
+def dunning_policy() -> frappe._dict:
+	"""The ladder's knobs, read once.
+
+	`overdue_after` is not its own setting — the invoice falls overdue once the last
+	retry has been spent, so with no retries configured there is nothing to wait for
+	and it goes overdue on day zero.
+	"""
+	retry_days = settings.dunning_retry_days()
+	return frappe._dict(
+		retry_days=retry_days,
+		overdue_after=retry_days[-1] if retry_days else 0,
+		suspend_after=settings.suspend_after_days(),
+		terminate_after=settings.terminate_after_days(),
+	)
+
+
+# Stages that land on the same day still have an order: a retry is attempted before
+# the invoice is declared overdue, and suspension precedes termination.
+_STAGE_ORDER = {"Retry": 0, "Overdue": 1, "Suspend": 2, "Terminate": 3}
+
+
+def dunning_schedule(clock_start, policy=None) -> list[frappe._dict]:
+	"""The dated ladder for an invoice whose dunning clock starts on `clock_start`.
+
+	Pure date arithmetic over the policy — no document reads, no writes, and no
+	knowledge of any particular invoice. `process_invoice_dunning` executes this
+	schedule; anything that wants to *show* the ladder without running it (which
+	dates, which stage, when the resource stops) reads the same list.
+
+	Pass an explicit `policy` to ask what a different ladder would do.
+	"""
+	policy = policy or dunning_policy()
+	start = frappe.utils.getdate(clock_start)
+	stages = [
+		frappe._dict(stage="Retry", attempt=n, day=day)
+		for n, day in enumerate(policy.retry_days, start=1)
+	]
+	stages.append(frappe._dict(stage="Overdue", day=policy.overdue_after))
+	stages.append(frappe._dict(stage="Suspend", day=policy.suspend_after))
+	stages.append(frappe._dict(stage="Terminate", day=policy.terminate_after))
+
+	for s in stages:
+		s.date = frappe.utils.add_days(start, s.day)
+	return sorted(stages, key=lambda s: (s.day, _STAGE_ORDER[s.stage]))
+
+
+def stages_reached(schedule: list, on) -> set:
+	"""The stage names whose date has arrived by `on`."""
+	today = frappe.utils.getdate(on)
+	return {s.stage for s in schedule if frappe.utils.getdate(s.date) <= today}
+
+
 def _notify(invoice, message: str):
 	invoice.add_comment("Info", message)
 
@@ -140,12 +192,11 @@ def process_invoice_dunning(invoice_name: str, now=None) -> dict:
 	if not inv.due_date:
 		return {"invoice": invoice_name, "skipped": "no_due_date"}
 
-	days = (frappe.utils.getdate(now) - frappe.utils.getdate(dunning_clock_start(inv))).days
-	retry_days = settings.dunning_retry_days()
-	# With no retries configured there is nothing to wait for, so the invoice goes
-	# Overdue on day zero and the ladder below carries on from there.
-	overdue_after = retry_days[-1] if retry_days else 0
-	if retry_days and days < retry_days[0]:
+	clock_start = dunning_clock_start(inv)
+	days = (frappe.utils.getdate(now) - frappe.utils.getdate(clock_start)).days
+	policy = dunning_policy()
+	reached = stages_reached(dunning_schedule(clock_start, policy), now)
+	if policy.retry_days and "Retry" not in reached:
 		return {"invoice": invoice_name, "days_overdue": days, "action": "none"}
 
 	sub = frappe.get_doc("Subscription", inv.subscription) if inv.subscription else None
@@ -172,7 +223,7 @@ def process_invoice_dunning(invoice_name: str, now=None) -> dict:
 	standing = sub.account_standing if sub else None
 
 	# --- Day 7: Overdue + past_due, still running --------------------------
-	if days >= overdue_after:
+	if "Overdue" in reached:
 		if inv.status == "Open":
 			transition(inv, "Overdue", reason="dunning: past due window elapsed", actor="scheduler")
 			inv.save(ignore_permissions=True)
@@ -191,7 +242,7 @@ def process_invoice_dunning(invoice_name: str, now=None) -> dict:
 			standing = _advance_standing(inv.subscription, "Past Due")
 
 	# --- Day 14: suspend directive -> Agent stops --------------------------
-	if days >= settings.suspend_after_days() and sub:
+	if "Suspend" in reached and sub:
 		standing = _advance_standing(inv.subscription, "Suspended")
 		if standing == "Suspended" and not _active_directive(sub.team, "suspend"):
 			issue_token(sub.team, {}, suspend=True)
@@ -219,7 +270,7 @@ def process_invoice_dunning(invoice_name: str, now=None) -> dict:
 			actions.append("suspend")
 
 	# --- Day 44: terminate directive -> Agent terminates -------------------
-	if days >= settings.terminate_after_days() and sub and not _active_directive(sub.team, "terminate"):
+	if "Terminate" in reached and sub and not _active_directive(sub.team, "terminate"):
 		issue_token(sub.team, {}, suspend=True, terminate=True)
 		_notify(inv, f"Terminated after the suspension window (day {days}).")
 		actions.append("terminate")

--- a/central/billing/revenue/invoicing/__init__.py
+++ b/central/billing/revenue/invoicing/__init__.py
@@ -25,6 +25,8 @@ the public API so callers and the `billing.revenue.invoicing.*` enqueue paths ho
 from central.billing.revenue.invoicing.generate import (
 	generate_draft_invoice,
 	generate_team_invoice,
+	rate_subscription_period,
+	rate_team_period,
 	reconcile_subscription,
 )
 from central.billing.revenue.invoicing.lifecycle import (
@@ -70,6 +72,8 @@ __all__ = [
 	"open_and_collect",
 	"open_drafts",
 	"open_drafts",
+	"rate_subscription_period",
+	"rate_team_period",
 	"reconcile_subscription",
 	"reconcile_subscription",
 	"reissue_invoice",

--- a/central/billing/revenue/invoicing/generate.py
+++ b/central/billing/revenue/invoicing/generate.py
@@ -121,96 +121,29 @@ def generate_draft_invoice(subscription: str, period_start, period_end):
 	if existing:
 		return existing
 
-	from central.billing.catalog.trials import invoice_type_for
-	from central.billing.revenue.metering import metered_line_items
-
-	cluster = frappe.db.get_value("Asset", sub.asset_id, "cluster") if sub.asset_id else None
-	lines = compute_line_items(sub.team, cluster, period_start, period_end)
-	lines += metered_line_items(sub.team, cluster, period_start, period_end)
-	if not lines:
+	rated = rate_subscription_period(subscription, period_start, period_end)
+	if not rated:
 		return None
 
-	from central.billing.revenue.tax import resolve_tax
-
-	subtotal = frappe.utils.flt(sum(line["amount"] for line in lines), 2)
-	# Commitment (#30 discount / #31 clawback) adjusts the taxable base; subtotal
-	# stays gross. Discount reduces it; a breach clawback adds the repaid discount.
-	commitment = commitments.resolve_commitment(sub.team, lines, period_start)
-	discount = commitment["discount"]
-	clawback = commitment["clawback"]
-	taxable_base = frappe.utils.flt(subtotal - discount + clawback, 2)
-	currency = frappe.db.get_value("Billing Profile", sub.team, "currency")
-	tax = resolve_tax(sub.team, taxable_base)
-	total = frappe.utils.flt(taxable_base + tax["output_tax_amount"], 2)
-	# expected_collection = total - tds (credits reduce it further at open).
-	expected = frappe.utils.flt(total - tax["tds_amount"], 2)
-
-	# The single branch point: an entry-tier (free/trial) team's invoice is a
-	# cost_report — computed identically, but a true cost rather than a bill.
-	name = _insert_invoice(
-		{
-			"doctype": "Invoice",
-			"team": sub.team,
-			"subscription": subscription,
-			"invoice_type": invoice_type_for(sub.team),
-			"status": "Draft",
-			"period_start": period_start,
-			"period_end": period_end,
-			"currency": currency,
-			"items": lines,
-			"subtotal": subtotal,
-			"commitment_discount": discount,
-			"commitment_clawback": clawback,
-			"output_tax_type": tax["output_tax_type"],
-			"output_tax_rate": tax["output_tax_rate"],
-			"output_tax_amount": tax["output_tax_amount"],
-			"zero_rating_reason": tax["zero_rating_reason"],
-			"tds_applicable": tax["tds_applicable"],
-			"tds_rate": tax["tds_rate"],
-			"tds_amount": tax["tds_amount"],
-			"total": total,
-			"credit_applied": 0,
-			"expected_collection": expected,
-			"amount_paid": 0,
-		}
-	)
-	commitments.mark_breached(commitment)
+	name = _insert_invoice(rated.payload)
+	commitments.mark_breached(rated.commitment)
 	return name
 
 
-def _generate_team_invoice(team: str, period_start, period_end, subscription: str | None = None):
-	"""One consolidated invoice per team per period, across every cluster it runs in.
+def _rate(team: str, lines: list[dict], period_start, period_end, subscription: str | None):
+	"""Price a set of billable lines into an invoice payload. Reads only.
 
-	A team that runs instances in several regions should see a SINGLE monthly
-	invoice, not one per region — so this aggregates the day-weighted fixed lines
-	plus metered overage from all of the team's clusters into one Invoice.
-	Idempotent per (team, period) — including under concurrency, which the read below
-	cannot deliver on its own. `generate_draft_invoices` enqueues one job per team, so
-	two workers could both read "no invoice" and both insert; the unique index on
-	`period_key` is what stops the team being billed twice (ADR 0018).
+	The arithmetic every draft shares: gross subtotal, the commitment adjustment,
+	tax on the adjusted base, and what we expect to actually collect. Nothing here
+	writes, so the same call answers "what will this period cost?" for a period that
+	has not happened yet.
 
-	`subscription` is the primary subscription (its default payment method funds
-	the auto-charge in open_and_collect); defaults to any of the team's subs.
+	Returns the payload alongside the commitment verdict that shaped it. The verdict
+	is handed back rather than acted on because marking a commitment breached is a
+	write, and this function does not do those.
 	"""
-	existing = _live_invoice(team, period_start, period_end)
-	if existing:
-		return existing
-
 	from central.billing.catalog.trials import invoice_type_for
-	from central.billing.revenue.metering import metered_line_items_for_clusters
 	from central.billing.revenue.tax import resolve_tax
-
-	# Read the team once, not once per cluster: team_line_items pulls every
-	# subscription's fixed lines in one pass, and the metered rollups for all the
-	# team's clusters come back in a single query.
-	asset_ids = frappe.get_all("Subscription", filters={"team": team}, pluck="asset_id")
-	clusters = sorted(
-		{c for c in frappe.get_all("Asset", filters={"name": ["in", asset_ids]}, pluck="cluster") if c}
-	)
-	lines = team_line_items(team, period_start, period_end)
-	lines += metered_line_items_for_clusters(team, clusters, period_start, period_end)
-	if not lines:
-		return None
 
 	subtotal = frappe.utils.flt(sum(line["amount"] for line in lines), 2)
 	# Commitment (#30 discount / #31 clawback) adjusts the taxable base; subtotal
@@ -222,12 +155,14 @@ def _generate_team_invoice(team: str, period_start, period_end, subscription: st
 	currency = frappe.db.get_value("Billing Profile", team, "currency")
 	tax = resolve_tax(team, taxable_base)
 	total = frappe.utils.flt(taxable_base + tax["output_tax_amount"], 2)
+	# expected_collection = total - tds (credits reduce it further at open).
 	expected = frappe.utils.flt(total - tax["tds_amount"], 2)
-	if subscription is None:
-		subscription = primary_subscription(team)
 
-	name = _insert_invoice(
-		{
+	return frappe._dict(
+		commitment=commitment,
+		# The single branch point: an entry-tier (free/trial) team's invoice is a
+		# cost_report — computed identically, but a true cost rather than a bill.
+		payload={
 			"doctype": "Invoice",
 			"team": team,
 			"subscription": subscription,
@@ -251,9 +186,76 @@ def _generate_team_invoice(team: str, period_start, period_end, subscription: st
 			"credit_applied": 0,
 			"expected_collection": expected,
 			"amount_paid": 0,
-		}
+		},
 	)
-	commitments.mark_breached(commitment)
+
+
+def rate_subscription_period(subscription: str, period_start, period_end):
+	"""What one subscription's cluster would bill the team for the period. Reads only.
+
+	Returns None when there was no billable runtime.
+	"""
+	from central.billing.revenue.metering import metered_line_items
+
+	sub = frappe.get_doc("Subscription", subscription)
+	cluster = frappe.db.get_value("Asset", sub.asset_id, "cluster") if sub.asset_id else None
+	lines = compute_line_items(sub.team, cluster, period_start, period_end)
+	lines += metered_line_items(sub.team, cluster, period_start, period_end)
+	if not lines:
+		return None
+	return _rate(sub.team, lines, period_start, period_end, subscription)
+
+
+def rate_team_period(team: str, period_start, period_end, subscription: str | None = None):
+	"""What the team's whole book would bill for the period, across every cluster.
+	Reads only.
+
+	The rating half of `generate_team_invoice` — same lines, same commitment, same
+	tax, no insert. Returns None when the team has nothing billable.
+	"""
+	from central.billing.revenue.metering import metered_line_items_for_clusters
+
+	# Read the team once, not once per cluster: team_line_items pulls every
+	# subscription's fixed lines in one pass, and the metered rollups for all the
+	# team's clusters come back in a single query.
+	asset_ids = frappe.get_all("Subscription", filters={"team": team}, pluck="asset_id")
+	clusters = sorted(
+		{c for c in frappe.get_all("Asset", filters={"name": ["in", asset_ids]}, pluck="cluster") if c}
+	)
+	lines = team_line_items(team, period_start, period_end)
+	lines += metered_line_items_for_clusters(team, clusters, period_start, period_end)
+	if not lines:
+		return None
+
+	if subscription is None:
+		subscription = primary_subscription(team)
+	return _rate(team, lines, period_start, period_end, subscription)
+
+
+def _generate_team_invoice(team: str, period_start, period_end, subscription: str | None = None):
+	"""One consolidated invoice per team per period, across every cluster it runs in.
+
+	A team that runs instances in several regions should see a SINGLE monthly
+	invoice, not one per region — so this aggregates the day-weighted fixed lines
+	plus metered overage from all of the team's clusters into one Invoice.
+	Idempotent per (team, period) — including under concurrency, which the read below
+	cannot deliver on its own. `generate_draft_invoices` enqueues one job per team, so
+	two workers could both read "no invoice" and both insert; the unique index on
+	`period_key` is what stops the team being billed twice (ADR 0018).
+
+	`subscription` is the primary subscription (its default payment method funds
+	the auto-charge in open_and_collect); defaults to any of the team's subs.
+	"""
+	existing = _live_invoice(team, period_start, period_end)
+	if existing:
+		return existing
+
+	rated = rate_team_period(team, period_start, period_end, subscription)
+	if not rated:
+		return None
+
+	name = _insert_invoice(rated.payload)
+	commitments.mark_breached(rated.commitment)
 	return name
 
 

--- a/central/billing/tests/test_billing.py
+++ b/central/billing/tests/test_billing.py
@@ -676,3 +676,78 @@ class TestFanOutRun(IntegrationTestCase):
 				"Error Log", {"method": run.BILLING_RUN_FAILURE, "reference_name": "team-fanout-a"}
 			)
 		)
+
+
+class TestRatingIsSeparableFromWriting(BillingTestBase):
+	"""The rating half decides; the generate half acts. Nothing may leak across."""
+
+	MONEY = (
+		"subtotal",
+		"commitment_discount",
+		"commitment_clawback",
+		"output_tax_type",
+		"output_tax_rate",
+		"output_tax_amount",
+		"tds_applicable",
+		"tds_rate",
+		"tds_amount",
+		"total",
+		"expected_collection",
+		"currency",
+		"invoice_type",
+	)
+
+	def _segments(self):
+		add_segment(self.sub, "Created", 1000, "2026-06-01 00:00:00")
+		add_segment(self.sub, "Plan Changed", 2000, "2026-06-10 00:00:00")
+
+	def test_rated_payload_matches_the_invoice_that_gets_written(self):
+		self._segments()
+		rated = invoicing.rate_team_period(TEAM, "2026-06-01", "2026-06-30")
+		inv = frappe.get_doc(
+			"Invoice", invoicing.generate_team_invoice(TEAM, "2026-06-01", "2026-06-30")
+		)
+
+		for field in self.MONEY:
+			self.assertEqual(rated.payload[field], inv.get(field), field)
+		self.assertEqual(
+			sorted(li["amount"] for li in rated.payload["items"]),
+			sorted(li.amount for li in inv.items),
+		)
+
+	def test_rating_a_period_writes_nothing(self):
+		self._segments()
+		before = frappe.db.count("Invoice", {"team": TEAM})
+		self.assertIsNotNone(invoicing.rate_team_period(TEAM, "2026-06-01", "2026-06-30"))
+		self.assertEqual(frappe.db.count("Invoice", {"team": TEAM}), before)
+
+	def test_rating_never_marks_a_commitment_breached(self):
+		# mark_breached is the effect half. Reaching it from the rating half would let a
+		# projection change real commitments.
+		self._segments()
+		from central.billing.catalog import commitments
+
+		with patch.object(commitments, "mark_breached") as marked:
+			invoicing.rate_team_period(TEAM, "2026-06-01", "2026-06-30")
+			self.assertFalse(marked.called)
+			invoicing.generate_team_invoice(TEAM, "2026-06-01", "2026-06-30")
+			self.assertTrue(marked.called)
+
+	def test_a_period_with_no_runtime_rates_to_nothing(self):
+		self.assertIsNone(invoicing.rate_team_period(TEAM, "2026-06-01", "2026-06-30"))
+
+	def test_a_future_period_rates_at_the_locked_rate(self):
+		# Nothing has happened in the period yet; the open segment carries forward, which
+		# is what lets a projection price a month that has not started.
+		add_segment(self.sub, "Created", 3000, "2026-06-01 00:00:00")
+		rated = invoicing.rate_team_period(TEAM, "2026-09-01", "2026-09-30")
+		self.assertEqual(rated.payload["subtotal"], 3000.0)
+
+	def test_subscription_rating_matches_its_draft(self):
+		self._segments()
+		rated = invoicing.rate_subscription_period(self.sub, "2026-06-01", "2026-06-30")
+		inv = frappe.get_doc(
+			"Invoice", invoicing.generate_draft_invoice(self.sub, "2026-06-01", "2026-06-30")
+		)
+		for field in self.MONEY:
+			self.assertEqual(rated.payload[field], inv.get(field), field)

--- a/central/billing/tests/test_dunning.py
+++ b/central/billing/tests/test_dunning.py
@@ -313,3 +313,82 @@ class TestOurDelayIsNotTheirDelinquency(DunningTestBase):
 		inv = self._open_invoice(sub)
 		dunning.defer_dunning(inv, "the run backed up")
 		self.assertEqual(str(frappe.db.get_value("Invoice", inv, "due_date")), DUE)
+
+
+class TestTheLadderIsAList(IntegrationTestCase):
+	"""The schedule is date arithmetic over the policy, so it can be drawn without
+	being run — and the executor walks the same list."""
+
+	START = "2026-06-01"
+
+	def _policy(self, retries=(1, 3, 7), suspend=14, terminate=44):
+		return frappe._dict(
+			retry_days=list(retries),
+			overdue_after=list(retries)[-1] if retries else 0,
+			suspend_after=suspend,
+			terminate_after=terminate,
+		)
+
+	def _on(self, schedule, stage, attempt=None):
+		return [
+			s for s in schedule if s.stage == stage and (attempt is None or s.attempt == attempt)
+		][0]
+
+	def test_every_stage_lands_the_configured_number_of_days_out(self):
+		sched = dunning.dunning_schedule(self.START, self._policy())
+		self.assertEqual(str(self._on(sched, "Retry", 1).date), "2026-06-02")
+		self.assertEqual(str(self._on(sched, "Retry", 3).date), "2026-06-08")
+		self.assertEqual(str(self._on(sched, "Overdue").date), "2026-06-08")
+		self.assertEqual(str(self._on(sched, "Suspend").date), "2026-06-15")
+		self.assertEqual(str(self._on(sched, "Terminate").date), "2026-07-15")
+
+	def test_the_ladder_is_ordered_and_a_retry_precedes_the_overdue_it_shares_a_day_with(self):
+		sched = dunning.dunning_schedule(self.START, self._policy())
+		self.assertEqual([s.day for s in sched], sorted(s.day for s in sched))
+		last_retry = [i for i, s in enumerate(sched) if s.stage == "Retry"][-1]
+		overdue = [i for i, s in enumerate(sched) if s.stage == "Overdue"][0]
+		self.assertLess(last_retry, overdue)
+
+	def test_with_no_retries_the_invoice_is_overdue_immediately(self):
+		sched = dunning.dunning_schedule(self.START, self._policy(retries=()))
+		self.assertEqual(str(self._on(sched, "Overdue").date), self.START)
+		self.assertFalse([s for s in sched if s.stage == "Retry"])
+
+	def test_an_explicit_policy_is_used_instead_of_the_settings(self):
+		sched = dunning.dunning_schedule(
+			self.START, self._policy(retries=(2,), suspend=5, terminate=9)
+		)
+		self.assertEqual(str(self._on(sched, "Suspend").date), "2026-06-06")
+		self.assertEqual(str(self._on(sched, "Terminate").date), "2026-06-10")
+
+	def test_nothing_is_reached_before_the_clock_starts(self):
+		sched = dunning.dunning_schedule(self.START, self._policy())
+		self.assertEqual(dunning.stages_reached(sched, "2026-05-31"), set())
+		self.assertEqual(dunning.stages_reached(sched, self.START), set())
+
+	def test_stages_accumulate_as_the_dates_pass(self):
+		sched = dunning.dunning_schedule(self.START, self._policy())
+		self.assertEqual(dunning.stages_reached(sched, "2026-06-02"), {"Retry"})
+		self.assertEqual(dunning.stages_reached(sched, "2026-06-08"), {"Retry", "Overdue"})
+		self.assertEqual(
+			dunning.stages_reached(sched, "2026-06-15"), {"Retry", "Overdue", "Suspend"}
+		)
+		self.assertEqual(
+			dunning.stages_reached(sched, "2026-07-15"),
+			{"Retry", "Overdue", "Suspend", "Terminate"},
+		)
+
+	def test_the_policy_reads_the_settings(self):
+		with billing_settings(
+			dunning_retry_days="2, 5", suspend_after_days=9, terminate_after_days=20
+		):
+			policy = dunning.dunning_policy()
+		self.assertEqual(policy.retry_days, [2, 5])
+		self.assertEqual(policy.overdue_after, 5)
+		self.assertEqual(policy.suspend_after, 9)
+		self.assertEqual(policy.terminate_after, 20)
+
+	def test_drawing_the_ladder_touches_no_documents(self):
+		with patch.object(frappe.db, "get_value") as read:
+			dunning.dunning_schedule(self.START, self._policy())
+			self.assertFalse(read.called)

--- a/central/billing/tests/test_settlement.py
+++ b/central/billing/tests/test_settlement.py
@@ -217,3 +217,19 @@ class TestForecast(SettlementTestBase):
 		forecast = credit_forecast(TEAM, 130, notify=False)
 		self.assertTrue(forecast["notify"])
 		self.assertEqual(forecast["shortfall"], 30.0)
+
+	def test_forecasting_without_notify_reaches_neither_the_customer_nor_the_socket(self):
+		# The verdict still says a prompt is due; asking for the verdict must not send it.
+		credits.purchase(TEAM, 100, "INR")
+		with patch("central.billing.platform.notifications.notify") as notified, patch.object(
+			frappe, "publish_realtime"
+		) as published:
+			self.assertTrue(credit_forecast(TEAM, 130, notify=False)["notify"])
+			self.assertFalse(notified.called)
+			self.assertFalse(published.called)
+
+	def test_notify_true_still_sends(self):
+		credits.purchase(TEAM, 100, "INR")
+		with patch("central.billing.platform.notifications.notify") as notified:
+			credit_forecast(TEAM, 130, notify=True)
+			self.assertTrue(notified.called)


### PR DESCRIPTION
Billing currently welds each act's decision to its effect: rating a period is
inside the function that inserts the invoice, and the dunning ladder is computed
inline by the function that executes it. That makes the rules impossible to ask
about without also performing them.

This splits the two halves. Nothing changes behaviour.

**Rating**
`rate_team_period` and `rate_subscription_period` price a period and return the
invoice payload — lines, commitment adjustment, tax block, totals. They insert
nothing. `generate_team_invoice` and `generate_draft_invoice` are now that call
plus `_insert_invoice` plus the commitment breach mark. Idempotency and the
concurrency yield on `period_key` are untouched.

Marking a commitment breached stays firmly on the effect side, with a test
holding it there.

**Dunning**
`dunning_schedule` turns a clock start and a policy into dated stages. It does no
document reads and no writes, so the ladder can be drawn without being run.
`process_invoice_dunning` walks that list instead of recomputing the thresholds,
including the empty-retry-days case where an invoice goes overdue on day zero.
`dunning_policy` reads the knobs once and can be passed explicitly to ask what a
different ladder would do.

**Forecasting**
`credit_forecast` already took `notify`. There was no test holding it, so a
future edit could have started emailing customers from a read. There is now.