### PR TITLE
feat(admin): Project a team's billing before it happens

### DIFF
--- a/central/billing/api/admin/__init__.py
+++ b/central/billing/api/admin/__init__.py
@@ -22,6 +22,7 @@ from central.billing.api.admin.catalog import (
 	get_trial_detail,
 	update_plan_rate,
 )
+from central.billing.api.admin.projection import project_team
 from central.billing.api.admin.revenue import (
 	get_cluster_breakdown,
 	get_free_trial_costs,
@@ -43,6 +44,7 @@ from central.billing.api.admin.teams import (
 )
 
 __all__ = [
+	"project_team",
 	"adjust_team_credits",
 	"create_configured_plan",
 	"get_catalog",

--- a/central/billing/api/admin/projection.py
+++ b/central/billing/api/admin/projection.py
@@ -2,6 +2,9 @@
 # For license information, please see license.txt
 """The operator-facing entry point onto projections.
 
+Lives in the API layer because that is where whitelisted endpoints belong — the
+projection package stays domain-only and exposes no HTTP surface.
+
 Cross-team by nature — an operator asks about somebody else's money — so this is
 gated on the operator capability rather than on team scoping, and every call is
 logged with who asked and about whom.

--- a/central/billing/page/billing_simulator/billing_simulator.js
+++ b/central/billing/page/billing_simulator/billing_simulator.js
@@ -53,7 +53,7 @@ class BillingSimulator {
 		this.show_empty(__("Projecting…"));
 		frappe
 			.call({
-				method: "central.billing.projection.api.project_team",
+				method: "central.billing.api.admin.projection.project_team",
 				args: { team, period_start: start },
 			})
 			.then((r) => r.message && this.render(r.message))

--- a/central/billing/page/billing_simulator/billing_simulator.js
+++ b/central/billing/page/billing_simulator/billing_simulator.js
@@ -1,0 +1,330 @@
+// Copyright (c) 2026, Frappe and contributors
+// For license information, please see license.txt
+
+// The operator's window onto a projection: what this team will be billed, and what
+// happens next whether or not they pay.
+//
+// Plain Desk — vanilla JS and jQuery, styled through Desk's own CSS variables. This is
+// not the customer dashboard, so there is no frappe-ui here and there cannot be: that
+// is a Vue library and a Desk page has no Vue.
+
+frappe.pages["billing-simulator"].on_page_load = function (wrapper) {
+	const page = frappe.ui.make_app_page({
+		parent: wrapper,
+		title: __("Billing simulator"),
+		single_column: true,
+	});
+	wrapper.simulator = new BillingSimulator(page);
+};
+
+class BillingSimulator {
+	constructor(page) {
+		this.page = page;
+		this.add_filters();
+		this.add_styles();
+		this.$body = $('<div class="billing-simulator"></div>').appendTo(this.page.main);
+		this.show_empty(__("Pick a team to project."));
+	}
+
+	add_filters() {
+		this.team = this.page.add_field({
+			fieldname: "team",
+			label: __("Team"),
+			fieldtype: "Link",
+			options: "Team",
+			reqd: 1,
+			change: () => this.refresh(),
+		});
+		this.period = this.page.add_field({
+			fieldname: "period_start",
+			label: __("Period starting"),
+			fieldtype: "Date",
+			default: frappe.datetime.month_start(),
+			change: () => this.refresh(),
+		});
+		this.page.set_primary_action(__("Project"), () => this.refresh());
+	}
+
+	refresh() {
+		const team = this.team.get_value();
+		if (!team) return;
+
+		const start = this.period.get_value() || frappe.datetime.month_start();
+		this.show_empty(__("Projecting…"));
+		frappe
+			.call({
+				method: "central.billing.projection.api.project_team",
+				args: { team, period_start: start },
+			})
+			.then((r) => r.message && this.render(r.message))
+			.catch(() => this.show_empty(__("Could not project this team.")));
+	}
+
+	show_empty(message) {
+		this.$body.html(`<div class="bs-empty">${frappe.utils.escape_html(message)}</div>`);
+	}
+
+	render(data) {
+		this.$body.empty();
+		this.$body.append(this.invoice_card(data));
+		this.$body.append(this.calendar_card(data.calendar));
+		if (data.in_flight && data.in_flight.length) {
+			this.$body.append(this.in_flight_card(data.in_flight, data.as_of));
+		}
+	}
+
+	// ---- projected invoice -------------------------------------------------
+
+	invoice_card(data) {
+		const invoice = data.invoice;
+		if (!invoice) {
+			return $(`<div class="bs-card"><div class="bs-empty">${__(
+				"Nothing billable in this period."
+			)}</div></div>`);
+		}
+
+		const money = (v) => format_currency(v, data.currency);
+		const rows = invoice.lines
+			.map(
+				(line) => `
+			<tr>
+				<td>${frappe.utils.escape_html(line.plan || line.resource_type || "—")}</td>
+				<td class="bs-muted">${frappe.utils.escape_html(describe_line(line))}</td>
+				<td class="bs-right">${money(line.amount)}</td>
+				<td>${basis_tag(line)}</td>
+			</tr>`
+			)
+			.join("");
+
+		// A total is never shown on its own when part of it was inferred — a bill that
+		// is half guesswork must not read like a bill.
+		const split = invoice.has_estimates
+			? `<div class="bs-total"><span>${__("Measured")}</span><span>${money(
+					invoice.measured
+			  )}</span></div>
+			   <div class="bs-total"><span>${__("Estimated")}</span><span>${money(
+					invoice.estimated
+			  )}</span></div>`
+			: "";
+
+		const tax = invoice.output_tax_amount
+			? `<div class="bs-total"><span>${frappe.utils.escape_html(
+					invoice.output_tax_type
+			  )} @ ${invoice.output_tax_rate}%</span><span>${money(
+					invoice.output_tax_amount
+			  )}</span></div>`
+			: "";
+
+		return $(`
+			<div class="bs-card">
+				<div class="bs-card-head">
+					<span class="bs-card-title">${__("Projected invoice")}</span>
+					<span class="bs-muted">${data.period_start} — ${data.period_end} · ${__(
+						"not yet issued"
+					)}</span>
+				</div>
+				<table class="bs-table">
+					<thead>
+						<tr>
+							<th>${__("Line")}</th><th>${__("Detail")}</th>
+							<th class="bs-right">${__("Amount")}</th><th>${__("Basis")}</th>
+						</tr>
+					</thead>
+					<tbody>${rows}</tbody>
+				</table>
+				<div class="bs-totals">
+					${split}${tax}
+					<div class="bs-total bs-grand"><span>${__("Projected total")}</span><span>${money(
+						invoice.total
+					)}</span></div>
+				</div>
+			</div>`);
+	}
+
+	// ---- the fork ----------------------------------------------------------
+
+	calendar_card(calendar) {
+		const $card = $(`
+			<div class="bs-card">
+				<div class="bs-card-head">
+					<span class="bs-card-title">${__("What happens next")}</span>
+					<span class="bs-muted">${__("Opens")} ${calendar.opens_on} · ${__("due")} ${
+						calendar.due_on
+					}</span>
+				</div>
+				<div class="bs-figure"></div>
+			</div>`);
+		$card.find(".bs-figure").append(timeline_svg(calendar));
+		return $card;
+	}
+
+	// ---- invoices already unpaid -------------------------------------------
+
+	in_flight_card(flights, as_of) {
+		const rows = flights
+			.map((f) => {
+				const next = (f.ladder || []).find((s) => s.date > as_of);
+				return `
+				<tr>
+					<td><a href="/desk/invoice/${encodeURIComponent(f.invoice)}">${frappe.utils.escape_html(
+						f.invoice
+					)}</a></td>
+					<td>${frappe.utils.escape_html(f.status)}</td>
+					<td class="bs-right">${format_currency(f.outstanding, f.currency)}</td>
+					<td>${f.due_date}</td>
+					<td>${f.clock_starts_on}${
+						f.clock_deferred
+							? ` <span class="bs-muted">(${__("deferred")})</span>`
+							: ""
+					}</td>
+					<td>${next ? `${next.stage} · ${next.date}` : "—"}</td>
+				</tr>`;
+			})
+			.join("");
+
+		return $(`
+			<div class="bs-card">
+				<div class="bs-card-head">
+					<span class="bs-card-title">${__("Already unpaid")}</span>
+					<span class="bs-muted">${__(
+						"A deferred clock means we failed to collect, so their escalation starts later."
+					)}</span>
+				</div>
+				<table class="bs-table">
+					<thead>
+						<tr>
+							<th>${__("Invoice")}</th><th>${__("Status")}</th>
+							<th class="bs-right">${__("Outstanding")}</th><th>${__("Due")}</th>
+							<th>${__("Clock starts")}</th><th>${__("Next action")}</th>
+						</tr>
+					</thead>
+					<tbody>${rows}</tbody>
+				</table>
+			</div>`);
+	}
+
+	add_styles() {
+		if (document.getElementById("billing-simulator-styles")) return;
+		$(`<style id="billing-simulator-styles">
+			.billing-simulator { padding: 0 0 40px; }
+			.bs-card { border: 1px solid var(--border-color); border-radius: var(--border-radius-md, 8px);
+				background: var(--card-bg); margin-bottom: 14px; overflow: hidden; }
+			.bs-card-head { display: flex; justify-content: space-between; align-items: center;
+				gap: 12px; padding: 10px 13px; border-bottom: 1px solid var(--border-color); }
+			.bs-card-title { font-weight: 600; color: var(--heading-color); }
+			.bs-muted { color: var(--text-muted); font-size: var(--text-sm, 12px); }
+			.bs-empty { padding: 28px 14px; text-align: center; color: var(--text-muted); }
+			.bs-table { width: 100%; border-collapse: collapse; font-size: var(--text-base, 13px); }
+			.bs-table th { text-align: left; font-weight: 500; color: var(--text-light);
+				padding: 8px 13px; background: var(--subtle-accent);
+				border-bottom: 1px solid var(--border-color); white-space: nowrap; }
+			.bs-table td { padding: 8px 13px; border-bottom: 1px solid var(--border-color);
+				vertical-align: middle; }
+			.bs-table tbody tr:last-child td { border-bottom: 0; }
+			.bs-right { text-align: right; font-variant-numeric: tabular-nums; }
+			.bs-totals { padding: 10px 13px; }
+			.bs-total { display: flex; justify-content: space-between; padding: 4px 0;
+				font-size: var(--text-base, 13px); font-variant-numeric: tabular-nums; }
+			.bs-grand { border-top: 1px solid var(--dark-border-color); margin-top: 5px;
+				padding-top: 8px; font-weight: 600; color: var(--heading-color); }
+			.bs-basis { display: inline-flex; align-items: center; gap: 6px;
+				color: var(--text-light); font-size: var(--text-sm, 12px); }
+			.bs-dot { width: 6px; height: 6px; border-radius: 50%; display: inline-block; }
+			.bs-dot-measured { background: var(--text-light); }
+			.bs-dot-estimated { background: var(--card-bg); border: 1.5px solid var(--gray-400, #c7c7c7); }
+			.bs-figure { padding: 14px 13px; overflow-x: auto; }
+			.bs-figure svg { display: block; min-width: 620px; width: 100%; height: auto; }
+		</style>`).appendTo(document.head);
+	}
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+function describe_line(line) {
+	if (line.estimated_from) return line.estimated_from;
+	if (line.days) return __("{0} days", [line.days]);
+	if (line.hours) return __("{0} hours", [line.hours]);
+	if (line.quantity) return `${line.quantity} ${line.unit || ""}`.trim();
+	return "";
+}
+
+function basis_tag(line) {
+	const estimated = line.basis && line.basis !== "Measured";
+	const cls = estimated ? "bs-dot-estimated" : "bs-dot-measured";
+	return `<span class="bs-basis"><span class="bs-dot ${cls}"></span>${frappe.utils.escape_html(
+		line.basis || "Measured"
+	)}</span>`;
+}
+
+// Both branches on one axis. The fork is the point: an operator asking what happens to
+// this team wants settlement and escalation side by side, not one behind a toggle.
+function timeline_svg(calendar) {
+	const unpaid = calendar.if_never_paid || [];
+	const dates = [calendar.opens_on, calendar.due_on, ...unpaid.map((s) => s.date)];
+	const first = new Date(dates[0]);
+	const last = new Date(dates[dates.length - 1]);
+	const span = Math.max(1, (last - first) / 86400000);
+
+	const W = 860;
+	const LEFT = 120;
+	const RIGHT = 40;
+	const x = (d) => LEFT + ((new Date(d) - first) / 86400000 / span) * (W - LEFT - RIGHT);
+
+	const paid = calendar.if_paid_on_time[0];
+	const fork = x(calendar.due_on);
+
+	const marks = unpaid
+		.map((s) => {
+			const px = x(s.date);
+			const label = s.attempt ? `${s.stage} ${s.attempt}` : s.stage;
+			const terminal = s.stage === "Suspend" || s.stage === "Terminate";
+			const glyph = terminal
+				? `<rect x="${px - 4}" y="181" width="8" height="26" fill="var(--red-500, #e03636)"></rect>`
+				: `<circle cx="${px}" cy="194" r="4" fill="var(--red-500, #e03636)"></circle>`;
+			return `${glyph}
+				<text x="${px}" y="176" font-size="10" text-anchor="middle"
+					fill="var(--text-color)">${frappe.datetime.str_to_user(s.date)}</text>
+				<text x="${px}" y="222" font-size="10" text-anchor="middle"
+					fill="var(--text-muted)">${label}</text>`;
+		})
+		.join("");
+
+	return $(`
+		<svg viewBox="0 0 ${W} 250" role="img"
+			aria-label="${__("Both branches of what happens after the invoice falls due")}">
+			<text x="4" y="100" font-size="11" font-weight="600"
+				fill="var(--green-600, #30a66d)">${__("If paid on time")}</text>
+			<text x="4" y="198" font-size="11" font-weight="600"
+				fill="var(--red-600, #cc2929)">${__("If never paid")}</text>
+
+			<line x1="${LEFT}" y1="146" x2="${W - RIGHT}" y2="146"
+				stroke="var(--border-color)"></line>
+			<line x1="${LEFT}" y1="146" x2="${fork}" y2="146"
+				stroke="var(--text-light)" stroke-width="2"></line>
+			<circle cx="${LEFT}" cy="146" r="4" fill="var(--text-light)"></circle>
+			<text x="${LEFT}" y="132" font-size="10" text-anchor="middle"
+				fill="var(--text-color)">${__("Opens")} ${frappe.datetime.str_to_user(
+					calendar.opens_on
+				)}</text>
+
+			<circle cx="${fork}" cy="146" r="4.5" fill="var(--text-color)"></circle>
+			<text x="${fork}" y="118" font-size="10.5" text-anchor="middle" font-weight="600"
+				fill="var(--text-color)">${__("Due")} ${frappe.datetime.str_to_user(
+					calendar.due_on
+				)}</text>
+
+			<path d="M ${fork} 146 C ${fork + 26} 146, ${fork + 26} 96, ${fork + 52} 96"
+				fill="none" stroke="var(--green-500, #59ba8b)" stroke-width="2"></path>
+			<circle cx="${fork + 52}" cy="96" r="4" fill="var(--green-500, #59ba8b)"></circle>
+			<text x="${fork + 64}" y="92" font-size="10.5"
+				fill="var(--green-600, #30a66d)">${__("Settled")} ${frappe.datetime.str_to_user(
+					paid.date
+				)}</text>
+
+			<path d="M ${fork} 146 C ${fork + 26} 146, ${fork + 26} 194, ${fork + 52} 194"
+				fill="none" stroke="var(--red-500, #e03636)" stroke-width="2"></path>
+			<line x1="${fork + 52}" y1="194" x2="${W - RIGHT}" y2="194"
+				stroke="var(--red-500, #e03636)" stroke-width="2"></line>
+			${marks}
+		</svg>`);
+}

--- a/central/billing/page/billing_simulator/billing_simulator.js
+++ b/central/billing/page/billing_simulator/billing_simulator.js
@@ -273,57 +273,75 @@ function timeline_svg(calendar) {
 	const paid = calendar.if_paid_on_time[0];
 	const fork = x(calendar.due_on);
 
-	const marks = unpaid
-		.map((s) => {
-			const px = x(s.date);
-			const label = s.attempt ? `${s.stage} ${s.attempt}` : s.stage;
-			const terminal = s.stage === "Suspend" || s.stage === "Terminate";
-			const glyph = terminal
-				? `<rect x="${px - 4}" y="181" width="8" height="26" fill="var(--red-500, #e03636)"></rect>`
-				: `<circle cx="${px}" cy="194" r="4" fill="var(--red-500, #e03636)"></circle>`;
+	// Stages routinely share a date — the last retry and the overdue flip are the same
+	// day by construction, since an invoice falls overdue once its retries are spent.
+	// Drawing them as separate marks stacks two labels on one pixel.
+	const by_date = new Map();
+	for (const s of unpaid) {
+		const label = s.attempt ? `${s.stage} ${s.attempt}` : s.stage;
+		const group = by_date.get(s.date) || { date: s.date, labels: [], terminal: false };
+		group.labels.push(label);
+		group.terminal = group.terminal || s.stage === "Suspend" || s.stage === "Terminate";
+		by_date.set(s.date, group);
+	}
+
+	// Neighbouring dates can still be a few pixels apart (day 1 and day 3 of a 44-day
+	// ladder), so alternate the labels between two rows rather than let them collide.
+	let previous_x = -Infinity;
+	let row = 0;
+	const marks = [...by_date.values()]
+		.map((g) => {
+			const px = x(g.date);
+			row = px - previous_x < 70 ? 1 - row : 0;
+			previous_x = px;
+			const date_y = 102 - row * 14;
+			const label_y = 148 + row * 14;
+			const glyph = g.terminal
+				? `<rect x="${px - 4}" y="107" width="8" height="26" fill="var(--red-500, #e03636)"></rect>`
+				: `<circle cx="${px}" cy="120" r="4" fill="var(--red-500, #e03636)"></circle>`;
 			return `${glyph}
-				<text x="${px}" y="176" font-size="10" text-anchor="middle"
-					fill="var(--text-color)">${frappe.datetime.str_to_user(s.date)}</text>
-				<text x="${px}" y="222" font-size="10" text-anchor="middle"
-					fill="var(--text-muted)">${label}</text>`;
+				<text x="${px}" y="${date_y}" font-size="10" text-anchor="middle"
+					fill="var(--text-color)">${frappe.datetime.str_to_user(g.date)}</text>
+				<text x="${px}" y="${label_y}" font-size="10" text-anchor="middle"
+					fill="var(--text-muted)">${g.labels.join(" · ")}</text>`;
 		})
 		.join("");
 
 	return $(`
-		<svg viewBox="0 0 ${W} 250" role="img"
+		<svg viewBox="0 0 ${W} 176" role="img"
 			aria-label="${__("Both branches of what happens after the invoice falls due")}">
-			<text x="4" y="100" font-size="11" font-weight="600"
+			<text x="4" y="30" font-size="11" font-weight="600"
 				fill="var(--green-600, #30a66d)">${__("If paid on time")}</text>
-			<text x="4" y="198" font-size="11" font-weight="600"
+			<text x="4" y="124" font-size="11" font-weight="600"
 				fill="var(--red-600, #cc2929)">${__("If never paid")}</text>
 
-			<line x1="${LEFT}" y1="146" x2="${W - RIGHT}" y2="146"
+			<line x1="${LEFT}" y1="72" x2="${W - RIGHT}" y2="72"
 				stroke="var(--border-color)"></line>
-			<line x1="${LEFT}" y1="146" x2="${fork}" y2="146"
+			<line x1="${LEFT}" y1="72" x2="${fork}" y2="72"
 				stroke="var(--text-light)" stroke-width="2"></line>
-			<circle cx="${LEFT}" cy="146" r="4" fill="var(--text-light)"></circle>
-			<text x="${LEFT}" y="132" font-size="10" text-anchor="middle"
+			<circle cx="${LEFT}" cy="72" r="4" fill="var(--text-light)"></circle>
+			<text x="${LEFT}" y="58" font-size="10" text-anchor="middle"
 				fill="var(--text-color)">${__("Opens")} ${frappe.datetime.str_to_user(
 					calendar.opens_on
 				)}</text>
 
-			<circle cx="${fork}" cy="146" r="4.5" fill="var(--text-color)"></circle>
-			<text x="${fork}" y="118" font-size="10.5" text-anchor="middle" font-weight="600"
+			<circle cx="${fork}" cy="72" r="4.5" fill="var(--text-color)"></circle>
+			<text x="${fork}" y="44" font-size="10.5" text-anchor="middle" font-weight="600"
 				fill="var(--text-color)">${__("Due")} ${frappe.datetime.str_to_user(
 					calendar.due_on
 				)}</text>
 
-			<path d="M ${fork} 146 C ${fork + 26} 146, ${fork + 26} 96, ${fork + 52} 96"
+			<path d="M ${fork} 72 C ${fork + 26} 72, ${fork + 26} 26, ${fork + 52} 26"
 				fill="none" stroke="var(--green-500, #59ba8b)" stroke-width="2"></path>
-			<circle cx="${fork + 52}" cy="96" r="4" fill="var(--green-500, #59ba8b)"></circle>
-			<text x="${fork + 64}" y="92" font-size="10.5"
+			<circle cx="${fork + 52}" cy="26" r="4" fill="var(--green-500, #59ba8b)"></circle>
+			<text x="${fork + 64}" y="30" font-size="10.5"
 				fill="var(--green-600, #30a66d)">${__("Settled")} ${frappe.datetime.str_to_user(
 					paid.date
 				)}</text>
 
-			<path d="M ${fork} 146 C ${fork + 26} 146, ${fork + 26} 194, ${fork + 52} 194"
+			<path d="M ${fork} 72 C ${fork + 26} 72, ${fork + 26} 120, ${fork + 52} 120"
 				fill="none" stroke="var(--red-500, #e03636)" stroke-width="2"></path>
-			<line x1="${fork + 52}" y1="194" x2="${W - RIGHT}" y2="194"
+			<line x1="${fork + 52}" y1="120" x2="${W - RIGHT}" y2="120"
 				stroke="var(--red-500, #e03636)" stroke-width="2"></line>
 			${marks}
 		</svg>`);

--- a/central/billing/page/billing_simulator/billing_simulator.json
+++ b/central/billing/page/billing_simulator/billing_simulator.json
@@ -1,0 +1,23 @@
+{
+ "content": null,
+ "creation": "2026-08-06 10:00:00.000000",
+ "docstatus": 0,
+ "doctype": "Page",
+ "idx": 0,
+ "modified": "2026-08-06 10:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Billing",
+ "name": "billing-simulator",
+ "owner": "Administrator",
+ "page_name": "billing-simulator",
+ "roles": [
+  {
+   "role": "System Manager"
+  }
+ ],
+ "script": null,
+ "standard": "Yes",
+ "style": null,
+ "system_page": 0,
+ "title": "Billing simulator"
+}

--- a/central/billing/projection/__init__.py
+++ b/central/billing/projection/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Billing asked what it *will* do, rather than run and observed afterwards.
+
+A **projection** is the output — what the engine says happens next. A **scenario**
+is the input it was computed under. Nothing here is a *run*: that word belongs to
+the monthly billing run, the job that moves money.
+
+The engine does not model billing. It calls the same decision functions the run
+calls (`rate_team_period`, `dunning_schedule`) and stops before the effects. If a
+projection ever needs a function the run does not call, that function is a bug.
+"""

--- a/central/billing/projection/api.py
+++ b/central/billing/projection/api.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""The operator-facing entry point onto projections.
+
+Cross-team by nature — an operator asks about somebody else's money — so this is
+gated on the operator capability rather than on team scoping, and every call is
+logged with who asked and about whom.
+"""
+
+import frappe
+
+from central.billing import authz
+from central.billing.projection import engine
+
+
+@frappe.whitelist()
+def project_team(
+	team: str,
+	period_start: str | None = None,
+	period_end: str | None = None,
+	today: str | None = None,
+) -> dict:
+	"""Project one team over one period.
+
+	Defaults to the month in flight, which is the question an operator usually has:
+	what is this team about to be billed, and what happens after that.
+	"""
+	authz.require_operator()
+
+	today = frappe.utils.getdate(today or frappe.utils.nowdate())
+	period_start = frappe.utils.getdate(period_start or frappe.utils.get_first_day(today))
+	period_end = frappe.utils.getdate(period_end or frappe.utils.get_last_day(period_start))
+
+	frappe.logger("billing").info(
+		f"projection: {frappe.session.user} projected {team} "
+		f"for {period_start}..{period_end} as of {today}"
+	)
+	return engine.project(team, period_start, period_end, today=today)

--- a/central/billing/projection/basis.py
+++ b/central/billing/projection/basis.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Where a projected line's quantity came from, and therefore how much to trust it.
+
+A projected invoice has two kinds of line and they must never be read as one number.
+A fixed bundle charge projects into a month that has not started as a plain fact —
+the rate is locked on the subscription's change row and the days are arithmetic. A
+metered charge cannot: nobody has used the bandwidth yet, so any figure is inferred.
+
+Reporting both under one total is how a bill that is half guesswork comes to read
+like a bill. So every line carries its basis, and totals are split by it.
+"""
+
+MEASURED = "Measured"  # already a fact: a locked rate over elapsed days, a landed rollup
+ESTIMATED = "Estimated"  # inferred from history, because the period has not happened
+ASSUMED = "Assumed"  # a human asserted it in the scenario
+
+
+def split_totals(lines: list[dict]) -> dict:
+	"""Sum the lines by basis, so a total is never quoted without its provenance."""
+	totals = {MEASURED: 0.0, ESTIMATED: 0.0, ASSUMED: 0.0}
+	for line in lines:
+		totals[line.get("basis", MEASURED)] += line.get("amount") or 0.0
+	return {
+		"measured": round(totals[MEASURED], 2),
+		"estimated": round(totals[ESTIMATED], 2),
+		"assumed": round(totals[ASSUMED], 2),
+		# True when any part of this figure is inferred rather than observed. The UI
+		# uses it to refuse to render a bare total.
+		"has_estimates": bool(totals[ESTIMATED] or totals[ASSUMED]),
+	}
+
+
+def mark(lines: list[dict], basis: str) -> list[dict]:
+	"""Stamp a basis onto lines that do not already carry one."""
+	for line in lines:
+		line.setdefault("basis", basis)
+	return lines

--- a/central/billing/projection/engine.py
+++ b/central/billing/projection/engine.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""What billing will do to one team, next period.
+
+The engine does not model billing. It calls the same two decision functions the
+monthly run calls — `rate_team_period` to price the period and `dunning_schedule` to
+lay out the escalation ladder — and stops before the effects. Whatever the run would
+charge, this reports; whatever the run would do about non-payment, this dates.
+
+Two things it deliberately does not do. It never asserts whether a card will succeed,
+so the collection calendar is given as *both* branches: settled on the due date, and
+the full ladder if nothing is ever paid. And it never writes, which is a database
+guarantee rather than a convention — see `guard`.
+"""
+
+import frappe
+
+from central.billing import settings
+from central.billing.projection import estimate
+from central.billing.projection.basis import MEASURED, mark, split_totals
+from central.billing.projection.guard import read_only
+from central.billing.revenue.dunning import dunning_clock_start, dunning_policy, dunning_schedule
+from central.billing.revenue.invoicing.generate import rate_team_period, team_clusters
+
+
+def project(
+	team: str,
+	period_start,
+	period_end,
+	today=None,
+	recorder=None,
+	source=None,
+) -> dict:
+	"""Project one team over one period. Reads only; returns plain data.
+
+	`recorder` and `source` are the record-and-replay seam: a recorder captures every
+	read so the projection can later be replayed against frozen inputs, and a source
+	answers reads from such a recording instead of the database. Both are accepted and
+	unused here so that adding the regression harness does not have to reshape the
+	engine.
+	"""
+	with read_only():
+		return _project(team, period_start, period_end, today)
+
+
+def _project(team: str, period_start, period_end, today=None) -> dict:
+	today = frappe.utils.getdate(today or frappe.utils.nowdate())
+	start = frappe.utils.getdate(period_start)
+	end = frappe.utils.getdate(period_end)
+
+	metered = estimate.metered_lines(team, team_clusters(team), start, end, today=today)
+	rated = rate_team_period(team, start, end, metered=metered)
+
+	invoice = _invoice(rated)
+	return {
+		"team": team,
+		"period_start": str(start),
+		"period_end": str(end),
+		"as_of": str(today),
+		"currency": frappe.db.get_value("Billing Profile", team, "currency"),
+		"invoice": invoice,
+		"calendar": _calendar(end, today),
+		"in_flight": _in_flight(team, today),
+	}
+
+
+def _invoice(rated) -> dict | None:
+	"""The projected invoice, with its lines' provenance carried into the totals."""
+	if not rated:
+		return None
+
+	# Fixed lines come off the real line engine as facts: the rate is locked and the
+	# days are arithmetic. Only metering had to be inferred, and it labelled itself.
+	lines = mark(rated.payload["items"], MEASURED)
+	totals = split_totals(lines)
+	payload = rated.payload
+	return {
+		"lines": lines,
+		"subtotal": payload["subtotal"],
+		"commitment_discount": payload["commitment_discount"],
+		"commitment_clawback": payload["commitment_clawback"],
+		"output_tax_type": payload["output_tax_type"],
+		"output_tax_rate": payload["output_tax_rate"],
+		"output_tax_amount": payload["output_tax_amount"],
+		"tds_amount": payload["tds_amount"],
+		"total": payload["total"],
+		"expected_collection": payload["expected_collection"],
+		"invoice_type": payload["invoice_type"],
+		# Never a bare total: a bill that is part guesswork must not read like a bill.
+		"measured": totals["measured"],
+		"estimated": totals["estimated"],
+		"has_estimates": totals["has_estimates"],
+	}
+
+
+def _opens_on(period_end):
+	"""The day the run would open this period's invoice.
+
+	Drafting fires on the 1st after the period closes, because a month billed in
+	arrears is not closed until it ends.
+	"""
+	return frappe.utils.add_days(frappe.utils.getdate(period_end), 1)
+
+
+def _calendar(period_end, today) -> dict:
+	"""Both branches of what happens next, dated.
+
+	The fork is the point of the thing: an operator asking "what happens to this team"
+	wants to see settlement *and* escalation side by side, not one of them behind a
+	mode switch. Neither branch is asserted here — deriving which one the team's state
+	entails is a later, separate job.
+	"""
+	opens_on = _opens_on(period_end)
+	due_on = frappe.utils.add_days(opens_on, settings.invoice_due_days())
+	return {
+		"opens_on": str(opens_on),
+		"due_on": str(due_on),
+		"if_paid_on_time": [{"date": str(due_on), "stage": "Settled"}],
+		"if_never_paid": _ladder(due_on),
+	}
+
+
+def _ladder(clock_start, policy=None) -> list[dict]:
+	"""The escalation ladder as plain dated rows."""
+	return [
+		{
+			"date": str(s.date),
+			"stage": s.stage,
+			"day": s.day,
+			**({"attempt": s.attempt} if s.get("attempt") else {}),
+		}
+		for s in dunning_schedule(clock_start, policy or dunning_policy())
+	]
+
+
+def _in_flight(team: str, today) -> list[dict]:
+	"""Invoices already unpaid, and where their ladders have got to.
+
+	A projection that only laddered the invoice it just priced would miss the urgent
+	case entirely — a team mid-escalation on last month's bill. These carry their real
+	`dunning_starts_on`, so a clock we deferred because *our* collection failed is
+	honoured rather than counted against the customer.
+	"""
+	unpaid = frappe.get_all(
+		"Invoice",
+		filters={
+			"team": team,
+			"invoice_type": "Billable",
+			"status": ["in", ["Open", "Overdue"]],
+			"expected_collection": [">", 0],
+		},
+		fields=["name", "status", "due_date", "dunning_starts_on", "expected_collection", "currency"],
+		order_by="due_date asc",
+	)
+
+	out = []
+	for inv in unpaid:
+		if not inv.due_date:
+			continue
+		clock_start = dunning_clock_start(inv)
+		out.append(
+			{
+				"invoice": inv.name,
+				"status": inv.status,
+				"currency": inv.currency,
+				"outstanding": inv.expected_collection,
+				"due_date": str(inv.due_date),
+				"clock_starts_on": str(clock_start),
+				"clock_deferred": bool(inv.dunning_starts_on),
+				"ladder": _ladder(clock_start),
+				"days_in": (today - frappe.utils.getdate(clock_start)).days,
+			}
+		)
+	return out

--- a/central/billing/projection/estimate.py
+++ b/central/billing/projection/estimate.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Metered usage for a period that has not happened yet.
+
+Fixed charges project into a future month for free: the rate is locked on the
+subscription's change row and the days are arithmetic, so the existing line engine
+answers a September question in August without being told anything new.
+
+Metering cannot. `metered_line_items_for_clusters` selects `Usage Rollup` rows *within
+the period*, and a future month has none — so left alone it returns an empty list and
+the projection quietly loses every metered charge. That failure is worse than a
+missing feature: it understates the bill, which is the direction that reassures, and a
+fixed-only invoice looks exactly like a complete one on screen.
+
+So usage is inferred, and the inference is labelled. Nothing here re-implements
+pricing — allowance, live-vs-grandfathered rates, prepaid-pack exclusion and the
+unpriced-overage guard all live in `metering`, and this drives that same code over a
+window that *did* happen, then scales the result.
+"""
+
+import frappe
+
+from central.billing.projection.basis import ESTIMATED, MEASURED, mark
+from central.billing.revenue.metering import metered_line_items_for_clusters
+
+TRAILING_MONTHS = 3
+
+# Identity of a metered line across periods — what we merge trailing history on.
+_KEY = ("subscription_resource", "resource_type", "cluster", "unit")
+
+
+def metered_lines(team: str, clusters, period_start, period_end, today=None) -> list[dict]:
+	"""The period's metered lines, measured where usage has landed and estimated where
+	it has not.
+
+	Three cases, and which one applies is decided by the calendar rather than by a flag:
+	a closed period is entirely fact; a period in flight is scaled from what has landed
+	so far; a period that has not started is inferred from the trailing window.
+	"""
+	today = frappe.utils.getdate(today or frappe.utils.nowdate())
+	start = frappe.utils.getdate(period_start)
+	end = frappe.utils.getdate(period_end)
+
+	if end < today:
+		return mark(metered_line_items_for_clusters(team, clusters, start, end), MEASURED)
+
+	if start <= today:
+		landed = metered_line_items_for_clusters(team, clusters, start, end)
+		elapsed = (today - start).days + 1
+		total = (end - start).days + 1
+		return _scaled(landed, elapsed, total)
+
+	return _from_trailing(team, clusters, start)
+
+
+def _scaled(lines: list[dict], elapsed: int, total: int) -> list[dict]:
+	"""Project a part-month's usage across the whole month.
+
+	The result is an estimate even when the arithmetic is exact, because the days it
+	covers have not happened — a customer who doubles their traffic tomorrow makes this
+	wrong, and the label is what says so.
+	"""
+	if not lines or elapsed <= 0:
+		return []
+	factor = total / elapsed
+	out = []
+	for line in lines:
+		projected = dict(line)
+		projected["quantity"] = frappe.utils.flt(line.get("quantity") * factor, 4)
+		projected["amount"] = frappe.utils.flt(line.get("amount") * factor, 2)
+		projected["basis"] = ESTIMATED
+		projected["estimated_from"] = f"run rate over {elapsed} of {total} days"
+		out.append(projected)
+	return out
+
+
+def _window(period_start, months: int = TRAILING_MONTHS):
+	"""The whole months immediately before the period being projected."""
+	end = frappe.utils.add_days(frappe.utils.get_first_day(period_start), -1)
+	start = frappe.utils.get_first_day(frappe.utils.add_months(end, -(months - 1)))
+	return start, end
+
+
+def _from_trailing(team: str, clusters, period_start, months: int = TRAILING_MONTHS) -> list[dict]:
+	"""Average the trailing window's real, priced metered lines into one projected month.
+
+	Averaging *amounts* rather than quantities is deliberate: the allowance is monthly, so
+	each historical month has already had its own allowance applied by the real pricing
+	path. Averaging raw quantity and deducting a single allowance would forgive usage the
+	customer was actually billed for.
+	"""
+	start, end = _window(period_start, months)
+	history = metered_line_items_for_clusters(team, clusters, start, end)
+	if not history:
+		# No history is not zero usage — it is silence. Projecting a zero line would
+		# assert something we do not know, so nothing is projected for this resource.
+		return []
+
+	merged: dict = {}
+	for line in history:
+		key = tuple(line.get(f) for f in _KEY)
+		agg = merged.setdefault(key, {**line, "quantity": 0.0, "amount": 0.0})
+		agg["quantity"] += frappe.utils.flt(line.get("quantity"))
+		agg["amount"] += frappe.utils.flt(line.get("amount"))
+
+	out = []
+	for line in merged.values():
+		line["quantity"] = frappe.utils.flt(line["quantity"] / months, 4)
+		line["amount"] = frappe.utils.flt(line["amount"] / months, 2)
+		line["basis"] = ESTIMATED
+		line["estimated_from"] = f"{months}-month average to {end}"
+		out.append(line)
+	return out

--- a/central/billing/projection/guard.py
+++ b/central/billing/projection/guard.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""The projection's licence to run against production data: it cannot write.
+
+That guarantee is a database one, not a code-review one. Every projection executes
+inside `START TRANSACTION READ ONLY`, so an `INSERT`/`UPDATE`/`DELETE` at *any* call
+depth fails in MariaDB (error 1792) instead of being caught by whoever reviews the
+diff. This matters because the engine deliberately calls into `revenue/`, `catalog/`
+and `payments/` — modules that do write — so a guard that only inspected this package
+would prove nothing about what runs three frames down.
+
+The transaction only sees the database. Redis and HTTP go around it — `enqueue` is
+the dangerous one, since the job it schedules runs later on a fresh, writable
+connection — so those are held by a separate test that greps for them.
+
+Scope: this wraps the *engine*, not the request. Saving a projection is a write, and
+it happens afterwards in an ordinary transaction.
+"""
+
+from contextlib import contextmanager
+
+import frappe
+
+
+class ProjectionWroteError(frappe.ValidationError):
+	"""A projection reached a write.
+
+	Not a user error and not a permissions problem — the decision half of some billing
+	act still has an effect welded to it, and the fix is in that seam.
+	"""
+
+
+@contextmanager
+def read_only():
+	"""Run a block inside a read-only transaction, and name what happens if it writes.
+
+	Assumes the caller has nothing uncommitted: `START TRANSACTION` implicitly commits
+	an open transaction, so this belongs at the top of a read endpoint rather than in
+	the middle of unfinished work.
+	"""
+	previous = frappe.flags.read_only
+	frappe.flags.read_only = True
+	frappe.db.begin(read_only=True)
+	try:
+		yield
+	except frappe.InReadOnlyMode as e:
+		raise ProjectionWroteError(
+			"A projection attempted to write. Projections read; the billing run writes."
+		) from e
+	finally:
+		# Clear the flag BEFORE rolling back, and not for tidiness: `rollback()` ends
+		# the transaction and immediately calls `begin()`, which reads this same flag.
+		# Restore it afterwards and the *next* transaction is read-only too — the guard
+		# leaks, and every write for the rest of the request fails somewhere unrelated.
+		frappe.flags.read_only = previous
+		# Releases the consistent snapshot. Rollback rather than commit: nothing was
+		# meant to change, so there is nothing to keep, and a long-held snapshot pins
+		# the undo log for every other query on the box.
+		frappe.db.rollback()

--- a/central/billing/projection/guard.py
+++ b/central/billing/projection/guard.py
@@ -30,14 +30,31 @@ class ProjectionWroteError(frappe.ValidationError):
 	"""
 
 
+class ProjectionBoundaryError(frappe.ValidationError):
+	"""A projection was asked for in the middle of unfinished work."""
+
+
 @contextmanager
 def read_only():
 	"""Run a block inside a read-only transaction, and name what happens if it writes.
 
-	Assumes the caller has nothing uncommitted: `START TRANSACTION` implicitly commits
-	an open transaction, so this belongs at the top of a read endpoint rather than in
-	the middle of unfinished work.
+	A projection is a transaction boundary. `START TRANSACTION` implicitly commits an
+	open one, so entering with pending writes would silently commit somebody else's
+	half-finished work — a side effect caused by asking a question, which is the exact
+	class of accident this guard exists to prevent. Frappe refuses the implicit commit
+	outright (`ImplicitCommitError`); we refuse earlier and say why. Deciding whether
+	that pending work should be kept or discarded belongs to the caller, never here.
+
+	In a request this never fires: a projection endpoint reads and writes nothing
+	before it starts.
 	"""
+	if frappe.db.transaction_writes:
+		raise ProjectionBoundaryError(
+			"A projection cannot start with unsaved changes pending — commit or roll "
+			"back first. Projections read a consistent snapshot and must not decide "
+			"the fate of someone else's transaction."
+		)
+
 	previous = frappe.flags.read_only
 	frappe.flags.read_only = True
 	frappe.db.begin(read_only=True)

--- a/central/billing/revenue/invoicing/generate.py
+++ b/central/billing/revenue/invoicing/generate.py
@@ -206,24 +206,44 @@ def rate_subscription_period(subscription: str, period_start, period_end):
 	return _rate(sub.team, lines, period_start, period_end, subscription)
 
 
-def rate_team_period(team: str, period_start, period_end, subscription: str | None = None):
+def team_clusters(team: str) -> list[str]:
+	"""Every cluster the team runs an asset in, resolved in one pass."""
+	asset_ids = frappe.get_all("Subscription", filters={"team": team}, pluck="asset_id")
+	return sorted(
+		{c for c in frappe.get_all("Asset", filters={"name": ["in", asset_ids]}, pluck="cluster") if c}
+	)
+
+
+def rate_team_period(
+	team: str,
+	period_start,
+	period_end,
+	subscription: str | None = None,
+	metered: list[dict] | None = None,
+):
 	"""What the team's whole book would bill for the period, across every cluster.
 	Reads only.
 
 	The rating half of `generate_team_invoice` — same lines, same commitment, same
 	tax, no insert. Returns None when the team has nothing billable.
+
+	`metered` replaces the metered lines rather than adding to them. The run leaves it
+	unset and bills the rollups that landed; a projection supplies estimated usage,
+	because a period that has not happened has no rollups and would otherwise be rated
+	as though the team used nothing.
 	"""
 	from central.billing.revenue.metering import metered_line_items_for_clusters
 
 	# Read the team once, not once per cluster: team_line_items pulls every
 	# subscription's fixed lines in one pass, and the metered rollups for all the
 	# team's clusters come back in a single query.
-	asset_ids = frappe.get_all("Subscription", filters={"team": team}, pluck="asset_id")
-	clusters = sorted(
-		{c for c in frappe.get_all("Asset", filters={"name": ["in", asset_ids]}, pluck="cluster") if c}
-	)
 	lines = team_line_items(team, period_start, period_end)
-	lines += metered_line_items_for_clusters(team, clusters, period_start, period_end)
+	if metered is None:
+		lines += metered_line_items_for_clusters(
+			team, team_clusters(team), period_start, period_end
+		)
+	else:
+		lines += list(metered)
 	if not lines:
 		return None
 

--- a/central/billing/tests/test_projection_api.py
+++ b/central/billing/tests/test_projection_api.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""The operator entry point onto projections."""
+
+import frappe
+from central.billing.projection import api
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+from central.billing.tests.utils import (
+	add_segment,
+	ensure_team,
+	make_billing_subscription,
+	make_plan,
+)
+
+TEAM = "team-projection-api"
+CLUSTER = "ap-south-1"
+PLAN = "bundle-projection-api"
+
+
+class ProjectionApiTestBase(IntegrationTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+		ensure_team(TEAM)
+		make_plan(PLAN)
+		self._purge()
+		self.sub = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
+		add_segment(self.sub, "Created", 9000, "2026-01-01 00:00:00")
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		self._purge()
+
+	def _purge(self):
+		frappe.db.delete("Invoice", {"team": TEAM})
+		for sub in frappe.get_all("Subscription", {"team": TEAM}, pluck="name"):
+			frappe.db.delete("Subscription Change", {"subscription": sub})
+			frappe.db.delete("Subscription", {"name": sub})
+		frappe.db.delete("Asset", {"team": TEAM})
+		frappe.db.commit()
+
+
+class TestGating(ProjectionApiTestBase):
+	def test_a_non_operator_cannot_project_another_team(self):
+		# A projection exposes somebody else's money, so it is operator-only rather than
+		# team-scoped.
+		user = f"proj-{frappe.generate_hash(6)}@example.com"
+		frappe.get_doc(
+			{"doctype": "User", "email": user, "first_name": "X", "send_welcome_email": 0}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+		frappe.set_user(user)
+		with self.assertRaises(frappe.PermissionError):
+			api.project_team(TEAM)
+
+	def test_an_operator_gets_a_projection(self):
+		out = api.project_team(TEAM, period_start="2026-09-01", period_end="2026-09-30")
+		self.assertEqual(out["team"], TEAM)
+		self.assertEqual(out["invoice"]["subtotal"], 9000.0)
+
+
+class TestDefaults(ProjectionApiTestBase):
+	def test_it_defaults_to_the_month_in_flight(self):
+		out = api.project_team(TEAM, today="2026-09-15")
+		self.assertEqual(out["period_start"], "2026-09-01")
+		self.assertEqual(out["period_end"], "2026-09-30")
+		self.assertEqual(out["as_of"], "2026-09-15")
+
+	def test_an_explicit_period_wins(self):
+		out = api.project_team(TEAM, period_start="2026-11-01", today="2026-09-15")
+		self.assertEqual(out["period_start"], "2026-11-01")
+		self.assertEqual(out["period_end"], "2026-11-30")
+
+	def test_projecting_through_the_api_still_writes_nothing(self):
+		before = frappe.db.count("Invoice", {"team": TEAM})
+		api.project_team(TEAM, period_start="2026-09-01")
+		self.assertEqual(frappe.db.count("Invoice", {"team": TEAM}), before)

--- a/central/billing/tests/test_projection_api.py
+++ b/central/billing/tests/test_projection_api.py
@@ -3,7 +3,7 @@
 """The operator entry point onto projections."""
 
 import frappe
-from central.billing.projection import api
+from central.billing.api.admin import projection as api
 from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
 from central.billing.tests.utils import (
 	add_segment,

--- a/central/billing/tests/test_projection_engine.py
+++ b/central/billing/tests/test_projection_engine.py
@@ -1,0 +1,202 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Projecting one team over one period."""
+
+import frappe
+from central.billing.projection import engine
+from central.billing.projection.basis import ESTIMATED, MEASURED
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+from central.billing.tests.utils import (
+	add_segment,
+	ensure_team,
+	make_billing_subscription,
+	make_metered_plan,
+	make_plan,
+)
+
+TEAM = "team-projection-engine"
+CLUSTER = "ap-south-1"
+PLAN = "bundle-projection-engine"
+
+
+class ProjectionTestBase(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		make_plan(PLAN, includes=[{"resource_type": "Transfer", "quantity": 100, "unit": "GB"}])
+		make_metered_plan(
+			"meter-transfer-engine",
+			resource_type="Transfer",
+			rates=[{"cluster": "", "currency": "INR", "rate": 0.5}],
+		)
+		self._purge()
+		self.sub = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
+		frappe.db.commit()
+
+	def tearDown(self):
+		self._purge()
+
+	def _purge(self):
+		for dt in ("Invoice", "Usage Rollup"):
+			frappe.db.delete(dt, {"team": TEAM})
+		for sub in frappe.get_all("Subscription", {"team": TEAM}, pluck="name"):
+			frappe.db.delete("Subscription Change", {"subscription": sub})
+			frappe.db.delete("Subscription", {"name": sub})
+		frappe.db.delete("Asset", {"team": TEAM})
+		frappe.db.commit()
+
+
+class TestProjectingAPeriod(ProjectionTestBase):
+	def test_a_future_month_is_priced_from_the_locked_rate(self):
+		add_segment(self.sub, "Created", 12000, "2026-06-01 00:00:00")
+		frappe.db.commit()
+		out = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")
+
+		self.assertEqual(out["invoice"]["subtotal"], 12000.0)
+		self.assertEqual(out["invoice"]["measured"], 12000.0)
+		self.assertEqual(out["invoice"]["estimated"], 0.0)
+		self.assertFalse(out["invoice"]["has_estimates"])
+
+	def test_fixed_lines_are_measured_even_for_a_month_that_has_not_started(self):
+		add_segment(self.sub, "Created", 12000, "2026-06-01 00:00:00")
+		frappe.db.commit()
+		out = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")
+		self.assertTrue(all(li["basis"] == MEASURED for li in out["invoice"]["lines"]))
+
+	def test_a_team_with_nothing_running_projects_no_invoice(self):
+		frappe.db.commit()
+		out = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")
+		self.assertIsNone(out["invoice"])
+
+	def test_projecting_writes_nothing(self):
+		add_segment(self.sub, "Created", 12000, "2026-06-01 00:00:00")
+		frappe.db.commit()
+		before = frappe.db.count("Invoice", {"team": TEAM})
+		engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")
+		self.assertEqual(frappe.db.count("Invoice", {"team": TEAM}), before)
+
+	def test_the_period_and_the_asking_date_are_reported_back(self):
+		add_segment(self.sub, "Created", 12000, "2026-06-01 00:00:00")
+		frappe.db.commit()
+		out = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")
+		self.assertEqual(out["period_start"], "2026-09-01")
+		self.assertEqual(out["as_of"], "2026-08-06")
+		self.assertEqual(out["currency"], "INR")
+
+
+class TestEstimatedUsageReachesTheInvoice(ProjectionTestBase):
+	def _rollup(self, month, quantity):
+		frappe.get_doc(
+			{
+				"doctype": "Usage Rollup",
+				"resource_id": frappe.db.get_value("Subscription", self.sub, "asset_id"),
+				"team": TEAM,
+				"cluster": CLUSTER,
+				"resource_type": "Transfer",
+				"meter_type": "Counter",
+				"period_start": f"{month}-01 00:00:00",
+				"period_end": f"{month}-28 23:59:59",
+				"quantity": quantity,
+				"unit": "GB",
+				"currency": "INR",
+				"locked_allowance": 100,
+				"locked_rate": 0.5,
+				"idempotency_key": f"proj:{month}",
+				"sequence": 0,
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	def test_projected_usage_is_billed_and_flagged_as_an_estimate(self):
+		# Without this the metered half of the bill silently vanishes for a future month.
+		add_segment(self.sub, "Created", 12000, "2026-05-01 00:00:00")
+		for month, qty in (("2026-06", 200), ("2026-07", 300), ("2026-08", 400)):
+			self._rollup(month, qty)
+
+		frappe.db.commit()
+		out = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-30")
+		invoice = out["invoice"]
+
+		self.assertEqual(invoice["measured"], 12000.0)
+		self.assertEqual(invoice["estimated"], 100.0)  # (50 + 100 + 150) / 3
+		self.assertEqual(invoice["subtotal"], 12100.0)
+		self.assertTrue(invoice["has_estimates"])
+		bases = {li["basis"] for li in invoice["lines"]}
+		self.assertEqual(bases, {MEASURED, ESTIMATED})
+
+
+class TestTheCalendar(ProjectionTestBase):
+	def test_the_invoice_opens_the_day_after_the_period_closes(self):
+		add_segment(self.sub, "Created", 12000, "2026-06-01 00:00:00")
+		frappe.db.commit()
+		cal = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")["calendar"]
+		self.assertEqual(cal["opens_on"], "2026-10-01")
+
+	def test_both_branches_are_returned_together(self):
+		add_segment(self.sub, "Created", 12000, "2026-06-01 00:00:00")
+		frappe.db.commit()
+		cal = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")["calendar"]
+
+		self.assertEqual(cal["if_paid_on_time"][0]["stage"], "Settled")
+		self.assertEqual(cal["if_paid_on_time"][0]["date"], cal["due_on"])
+
+		stages = [s["stage"] for s in cal["if_never_paid"]]
+		self.assertIn("Retry", stages)
+		self.assertIn("Overdue", stages)
+		self.assertIn("Suspend", stages)
+		self.assertIn("Terminate", stages)
+
+	def test_the_ladder_is_dated_from_the_due_date(self):
+		add_segment(self.sub, "Created", 12000, "2026-06-01 00:00:00")
+		frappe.db.commit()
+		cal = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")["calendar"]
+		suspend = [s for s in cal["if_never_paid"] if s["stage"] == "Suspend"][0]
+		expected = frappe.utils.add_days(cal["due_on"], suspend["day"])
+		self.assertEqual(suspend["date"], str(expected))
+
+
+class TestInvoicesAlreadyInFlight(ProjectionTestBase):
+	def _open_invoice(self, due, dunning_starts_on=None):
+		return frappe.get_doc(
+			{
+				"doctype": "Invoice",
+				"team": TEAM,
+				"subscription": self.sub,
+				"status": "Open",
+				"period_start": "2026-07-01",
+				"period_end": "2026-07-31",
+				"currency": "INR",
+				"subtotal": 5000,
+				"total": 5000,
+				"expected_collection": 5000,
+				"due_date": due,
+				"dunning_starts_on": dunning_starts_on,
+			}
+		).insert(ignore_permissions=True).name
+
+	def test_an_unpaid_invoice_carries_its_own_ladder(self):
+		name = self._open_invoice("2026-08-01")
+		frappe.db.commit()
+		out = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")
+
+		flight = out["in_flight"]
+		self.assertEqual(len(flight), 1)
+		self.assertEqual(flight[0]["invoice"], name)
+		self.assertEqual(flight[0]["clock_starts_on"], "2026-08-01")
+		self.assertEqual(flight[0]["days_in"], 5)
+		self.assertTrue(flight[0]["ladder"])
+
+	def test_a_deferred_clock_is_honoured_and_marked(self):
+		# We failed to collect, so their escalation restarts later. Counting from the due
+		# date instead would charge the customer for our outage.
+		self._open_invoice("2026-08-01", dunning_starts_on="2026-08-20")
+		frappe.db.commit()
+		flight = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")["in_flight"]
+
+		self.assertEqual(flight[0]["clock_starts_on"], "2026-08-20")
+		self.assertTrue(flight[0]["clock_deferred"])
+		self.assertLess(flight[0]["days_in"], 0)
+
+	def test_a_team_with_nothing_outstanding_has_an_empty_flight(self):
+		frappe.db.commit()
+		out = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")
+		self.assertEqual(out["in_flight"], [])

--- a/central/billing/tests/test_projection_estimate.py
+++ b/central/billing/tests/test_projection_estimate.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Metered usage for periods that have not happened, and saying so."""
+
+import frappe
+from central.billing.projection import estimate
+from central.billing.projection.basis import ESTIMATED, MEASURED, split_totals
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+from central.billing.tests.utils import (
+	ensure_team,
+	make_metered_plan,
+	make_plan,
+	seed_running_resource,
+)
+
+TEAM = "team-projection-estimate"
+CLUSTER = "ap-south-1"
+PLAN = "bundle-projection-estimate"
+RESOURCE = "srv-projection-estimate"
+
+
+class EstimateTestBase(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		make_plan(PLAN, includes=[{"resource_type": "Transfer", "quantity": 100, "unit": "GB"}])
+		make_metered_plan(
+			"meter-transfer-projection",
+			resource_type="Transfer",
+			rates=[{"cluster": "", "currency": "INR", "rate": 0.5}],
+		)
+		self._purge()
+		seed_running_resource(TEAM, RESOURCE, CLUSTER, PLAN, rate=1000, currency="INR")
+		frappe.db.commit()
+
+	def tearDown(self):
+		self._purge()
+
+	def _purge(self):
+		frappe.db.delete("Usage Rollup", {"team": TEAM})
+		for sub in frappe.get_all("Subscription", {"team": TEAM}, pluck="name"):
+			frappe.db.delete("Subscription Change", {"subscription": sub})
+			frappe.db.delete("Subscription", {"name": sub})
+		frappe.db.delete("Asset", {"team": TEAM})
+		frappe.db.commit()
+
+	def _rollup(self, month: str, quantity: float):
+		"""One grandfathered transfer rollup for `month` (YYYY-MM), 100 GB allowance."""
+		frappe.get_doc(
+			{
+				"doctype": "Usage Rollup",
+				"resource_id": RESOURCE,
+				"team": TEAM,
+				"cluster": CLUSTER,
+				"resource_type": "Transfer",
+				"meter_type": "Counter",
+				"period_start": f"{month}-01 00:00:00",
+				"period_end": f"{month}-28 23:59:59",
+				"quantity": quantity,
+				"unit": "GB",
+				"currency": "INR",
+				"locked_allowance": 100,
+				"locked_rate": 0.5,
+				"idempotency_key": f"{RESOURCE}:Counter:{month}-01",
+				"sequence": 0,
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+
+class TestFuturePeriods(EstimateTestBase):
+	def test_a_month_that_has_not_started_is_inferred_from_the_trailing_window(self):
+		# 200 / 300 / 400 GB against a 100 GB allowance at 0.5/GB → 50 / 100 / 150.
+		for month, qty in (("2026-03", 200), ("2026-04", 300), ("2026-05", 400)):
+			self._rollup(month, qty)
+
+		lines = estimate.metered_lines(
+			TEAM, [CLUSTER], "2026-06-01", "2026-06-30", today="2026-05-20"
+		)
+		self.assertEqual(len(lines), 1)
+		self.assertEqual(lines[0]["basis"], ESTIMATED)
+		self.assertEqual(lines[0]["amount"], 100.0)  # (50 + 100 + 150) / 3
+		self.assertIn("3-month average", lines[0]["estimated_from"])
+
+	def test_no_history_projects_no_line_rather_than_a_zero_one(self):
+		# Silence is not evidence of zero usage; asserting zero would be a claim we
+		# cannot support, and it is the claim that reassures.
+		lines = estimate.metered_lines(
+			TEAM, [CLUSTER], "2026-06-01", "2026-06-30", today="2026-05-20"
+		)
+		self.assertEqual(lines, [])
+
+	def test_usage_inside_the_allowance_leaves_nothing_to_project(self):
+		for month in ("2026-03", "2026-04", "2026-05"):
+			self._rollup(month, 80)  # under the 100 GB allowance
+		lines = estimate.metered_lines(
+			TEAM, [CLUSTER], "2026-06-01", "2026-06-30", today="2026-05-20"
+		)
+		self.assertEqual(lines, [])
+
+
+class TestPeriodsInFlight(EstimateTestBase):
+	def test_a_part_elapsed_month_is_scaled_to_its_full_length(self):
+		# 150 GB landed by the 10th of a 30-day month → 50 GB over allowance → ₹25,
+		# projected across 30/10 = 3x.
+		self._rollup("2026-06", 150)
+		lines = estimate.metered_lines(
+			TEAM, [CLUSTER], "2026-06-01", "2026-06-30", today="2026-06-10"
+		)
+		self.assertEqual(len(lines), 1)
+		self.assertEqual(lines[0]["basis"], ESTIMATED)
+		self.assertEqual(lines[0]["amount"], 75.0)
+		self.assertIn("10 of 30 days", lines[0]["estimated_from"])
+
+
+class TestClosedPeriods(EstimateTestBase):
+	def test_a_finished_month_is_measured_not_estimated(self):
+		self._rollup("2026-06", 300)
+		lines = estimate.metered_lines(
+			TEAM, [CLUSTER], "2026-06-01", "2026-06-30", today="2026-07-05"
+		)
+		self.assertEqual(len(lines), 1)
+		self.assertEqual(lines[0]["basis"], MEASURED)
+		self.assertEqual(lines[0]["amount"], 100.0)  # (300 - 100) * 0.5
+		self.assertNotIn("estimated_from", lines[0])
+
+
+class TestSplitTotals(IntegrationTestCase):
+	def test_totals_are_reported_by_provenance(self):
+		totals = split_totals(
+			[
+				{"amount": 12000.0, "basis": MEASURED},
+				{"amount": 4800.0, "basis": MEASURED},
+				{"amount": 1120.0, "basis": ESTIMATED},
+			]
+		)
+		self.assertEqual(totals["measured"], 16800.0)
+		self.assertEqual(totals["estimated"], 1120.0)
+		self.assertTrue(totals["has_estimates"])
+
+	def test_a_wholly_measured_invoice_is_flagged_as_such(self):
+		totals = split_totals([{"amount": 500.0, "basis": MEASURED}])
+		self.assertFalse(totals["has_estimates"])
+		self.assertEqual(totals["estimated"], 0.0)
+
+	def test_a_line_with_no_basis_counts_as_measured(self):
+		# Fixed lines come off the real line engine without a basis; they are facts.
+		self.assertEqual(split_totals([{"amount": 300.0}])["measured"], 300.0)

--- a/central/billing/tests/test_projection_guard.py
+++ b/central/billing/tests/test_projection_guard.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""A projection cannot write, and the database is what stops it."""
+
+import frappe
+from central.billing.projection.guard import ProjectionWroteError, read_only
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+from central.billing.tests.utils import ensure_team
+
+TEAM = "team-projection-guard"
+
+
+class TestReadOnlyGuard(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_reads_work_inside_the_guard(self):
+		with read_only():
+			self.assertTrue(frappe.db.exists("Team", TEAM))
+
+	def test_a_direct_write_is_refused_by_the_database(self):
+		with self.assertRaises(ProjectionWroteError):
+			with read_only():
+				frappe.db.set_value("Team", TEAM, "team_name", "Nope")
+
+	def test_an_insert_is_refused_too(self):
+		with self.assertRaises(ProjectionWroteError):
+			with read_only():
+				frappe.get_doc(
+					{
+						"doctype": "Credit Ledger Entry",
+						"team": TEAM,
+						"currency": "INR",
+						"amount": 1,
+						"entry_type": "Credit",
+					}
+				).insert(ignore_permissions=True)
+
+	def test_a_write_buried_in_a_callee_is_refused(self):
+		# The guarantee has to be transitive: the engine calls into modules that write,
+		# so a guard that only inspected the projection package would prove nothing.
+		def three_frames_down():
+			def deeper():
+				frappe.db.set_value("Team", TEAM, "team_name", "Nope")
+
+			deeper()
+
+		with self.assertRaises(ProjectionWroteError):
+			with read_only():
+				three_frames_down()
+
+	def test_nothing_the_refused_write_touched_survives(self):
+		before = frappe.db.get_value("Team", TEAM, "team_name")
+		with self.assertRaises(ProjectionWroteError):
+			with read_only():
+				frappe.db.set_value("Team", TEAM, "team_name", "Nope")
+		self.assertEqual(frappe.db.get_value("Team", TEAM, "team_name"), before)
+
+	def test_writing_works_again_afterwards(self):
+		with read_only():
+			pass
+		frappe.db.set_value("Team", TEAM, "team_name", "Fine")
+		frappe.db.commit()
+		self.assertEqual(frappe.db.get_value("Team", TEAM, "team_name"), "Fine")
+
+	def test_the_flag_is_restored_even_when_a_write_is_refused(self):
+		with self.assertRaises(ProjectionWroteError):
+			with read_only():
+				frappe.db.set_value("Team", TEAM, "team_name", "Nope")
+		self.assertFalse(frappe.flags.read_only)
+
+	def test_an_unrelated_error_is_not_disguised_as_a_write(self):
+		with self.assertRaises(ZeroDivisionError):
+			with read_only():
+				1 / 0

--- a/central/billing/tests/test_projection_guard.py
+++ b/central/billing/tests/test_projection_guard.py
@@ -3,7 +3,11 @@
 """A projection cannot write, and the database is what stops it."""
 
 import frappe
-from central.billing.projection.guard import ProjectionWroteError, read_only
+from central.billing.projection.guard import (
+	ProjectionBoundaryError,
+	ProjectionWroteError,
+	read_only,
+)
 from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
 from central.billing.tests.utils import ensure_team
 
@@ -77,3 +81,28 @@ class TestReadOnlyGuard(IntegrationTestCase):
 		with self.assertRaises(ZeroDivisionError):
 			with read_only():
 				1 / 0
+
+
+class TestTransactionBoundary(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_projecting_mid_transaction_is_refused_rather_than_committing_it(self):
+		# Starting a read-only transaction implicitly commits the open one. Asking a
+		# question must never decide the fate of somebody else's unfinished work.
+		frappe.db.set_value("Team", TEAM, "team_name", "Half done")
+		with self.assertRaises(ProjectionBoundaryError):
+			with read_only():
+				pass
+
+	def test_the_pending_work_is_left_exactly_as_it_was(self):
+		frappe.db.set_value("Team", TEAM, "team_name", "Half done")
+		with self.assertRaises(ProjectionBoundaryError):
+			with read_only():
+				pass
+		# Neither committed nor discarded — still pending, still the caller's to resolve.
+		self.assertEqual(frappe.db.get_value("Team", TEAM, "team_name"), "Half done")

--- a/central/billing/tests/test_projection_purity.py
+++ b/central/billing/tests/test_projection_purity.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""What the read-only transaction cannot see.
+
+The database refuses writes at any call depth, which is the strong half of the
+guarantee. It has no opinion about redis or HTTP, so the side effects that leave by
+those routes are held here instead — by a grep, which is crude but is the thing that
+will still be working in a year.
+
+`enqueue` is the one that matters most: the job it schedules runs later, on a fresh
+and fully writable connection, long after the read-only transaction has closed.
+"""
+
+from pathlib import Path
+
+import frappe
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+
+BANNED = (
+	"publish_realtime",
+	"frappe.enqueue",
+	"enqueue_doc",
+	"sendmail",
+	"frappe.db.commit",
+)
+
+# Modules whose decision half a projection calls. A ban on the projection package
+# alone would prove nothing about what runs three frames down.
+GUARDED = (
+	"billing/projection",
+	"billing/revenue/dunning.py",
+	"billing/revenue/invoicing/generate.py",
+)
+
+
+def _sources():
+	root = Path(frappe.get_app_path("central"))
+	for rel in GUARDED:
+		target = root / rel
+		if target.is_dir():
+			yield from sorted(target.rglob("*.py"))
+		else:
+			yield target
+
+
+class TestNoSideEffectsTheDatabaseCannotSee(IntegrationTestCase):
+	def test_guarded_modules_reach_neither_redis_nor_the_mail_queue(self):
+		offences = []
+		for path in _sources():
+			source = path.read_text()
+			for line_no, line in enumerate(source.splitlines(), start=1):
+				code = line.split("#", 1)[0]
+				for banned in BANNED:
+					if banned in code:
+						offences.append(f"{path.name}:{line_no} {banned}")
+		self.assertEqual(offences, [], f"side effects outside the transaction: {offences}")
+
+	def test_the_projection_package_imports_no_gateway_adapter(self):
+		offences = [
+			path.name
+			for path in _sources()
+			if "billing/projection" in str(path) and "gateways" in path.read_text()
+		]
+		self.assertEqual(offences, [], "a projection must never reach a payment gateway")

--- a/central/billing/workspace/billing/billing.json
+++ b/central/billing/workspace/billing/billing.json
@@ -17,6 +17,16 @@
   {
    "hidden": 0,
    "is_query_report": 0,
+   "label": "Billing Simulator",
+   "link_count": 0,
+   "link_to": "billing-simulator",
+   "link_type": "Page",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
    "label": "Revenue & AR Reports",
    "link_count": 3,
    "link_type": "DocType",
@@ -387,8 +397,8 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-    "label": "Notifications",
-    "link_count": 2,
+   "label": "Notifications",
+   "link_count": 2,
    "link_type": "DocType",
    "onboard": 0,
    "type": "Card Break"


### PR DESCRIPTION
Adds the Billing simulator: pick a team and a period, see the invoice they will be sent and what happens next whether or not they pay.

<img width="1440" height="1000" alt="simulator-full" src="https://github.com/user-attachments/assets/9352e7f1-6cd7-44bd-97a9-9e096937739c" />

## One engine, two callers

The engine does not model billing. It calls the same decision functions the monthly run calls and stops before the effects, so the number on screen and the number the run will charge cannot drift apart. There is no `simulate` flag anywhere — a flag would scatter `if not simulating:` across every effect site and make safety depend on remembering it.

```mermaid
flowchart LR
    RATE["rate_team_period()"]
    LADDER["dunning_schedule()"]

    RUN["Monthly billing run"]
    SIM["Billing simulator"]

    RATE --> RUN
    LADDER --> RUN
    RATE --> SIM
    LADDER --> SIM

    RUN --> W1["insert invoice"]
    RUN --> W2["charge the card"]
    RUN --> W3["issue directives"]
    SIM --> R1["render it"]

    style SIM fill:#e4f5e9,stroke:#30a66d
    style RUN fill:#fff1e7,stroke:#bd3e0c
```

## It cannot write, and that is the database's opinion

Every projection runs inside `START TRANSACTION READ ONLY`, so a write at any call depth fails in MariaDB rather than in review. That matters because the engine deliberately calls into modules that *do* write — a guard that only inspected the projection package would prove nothing about what runs three frames down.

The transaction only sees the database. Redis and HTTP go around it, so those are held by a grep instead.

```mermaid
flowchart LR
    E["Projection engine"]
    E -->|blocked: grep| G["Payment gateways"]
    E -->|blocked: grep| Q["Redis: publish, enqueue, sendmail"]
    E -->|blocked: MariaDB 1792| W["Any INSERT / UPDATE / DELETE"]
    E ==>|the only open path| R["Reads: segments, rollups, wallet, invoices"]

    style R fill:#e4f5e9,stroke:#30a66d
    style G fill:#fff0f0,stroke:#b52a2a
    style Q fill:#fff0f0,stroke:#b52a2a
    style W fill:#fff0f0,stroke:#b52a2a
```

`enqueue` is the one that matters most on that list: the job it schedules would run later, on a fresh and fully writable connection, long after the transaction closed.

A projection is also a transaction boundary. Entering with pending writes would implicitly commit somebody else's unfinished work, so it refuses instead and leaves that decision to the caller.

## Metering had to be estimated, and says so

Usage rollups only exist for periods that have happened, so a future month would have projected **zero** metered charges — understating the bill, invisibly, in the direction that reassures. Nothing here re-implements pricing: allowance, live-vs-grandfathered rates and the prepaid-pack rules stay in `metering`, driven over a window that did happen.

```mermaid
flowchart TD
    P{"Where is the period?"}
    P -->|already closed| M["Measured — real rollups"]
    P -->|in flight| S["Estimated — scaled from what has landed"]
    P -->|not started| T["Estimated — trailing 3-month average"]
    M & S & T --> SPLIT["Totals split by basis"]
    SPLIT --> OUT["No bare total when any part was inferred"]

    style M fill:#e4f5e9,stroke:#30a66d
    style S fill:#fff7d3,stroke:#bb6f0c
    style T fill:#fff7d3,stroke:#bb6f0c
```

No history projects **no line** rather than a zero one — silence is not evidence of zero usage.

<img width="1220" height="278" alt="1-projected-invoice" src="https://github.com/user-attachments/assets/7f031e56-8089-46f7-87b5-cd3c56218d1a" />



## Both branches, not one

The collection calendar gives settlement and escalation together, dated, because the fork is what an operator came to see — not one arm behind a mode switch.

```mermaid
stateDiagram-v2
    [*] --> Open: invoice opens
    Open --> Due: due date
    Due --> Settled: paid on time
    Due --> Retrying: not paid
    Retrying --> Overdue: retries spent
    Overdue --> Suspended: grace elapsed
    Suspended --> Terminated: no recovery
    Retrying --> Settled: paid
    Overdue --> Settled: paid
    Suspended --> Settled: paid
    Settled --> [*]
```

<img width="1220" height="317" alt="2-what-happens-next" src="https://github.com/user-attachments/assets/afc5822e-ca3d-4022-8343-6f980d5fab7d" />


Invoices already unpaid carry their own ladders from their real clocks, so a deferred clock, one we pushed because *our* collection failed, is honoured rather than counted against the customer.

<img width="1220" height="120" alt="3-already-unpaid" src="https://github.com/user-attachments/assets/b85bb9f2-3e9d-4684-976c-17d25d3f830a" />