### PR TITLE
feat(admin): Say why collection will fail, when the data already knows

### DIFF
--- a/central/billing/api/admin/projection.py
+++ b/central/billing/api/admin/projection.py
@@ -22,6 +22,8 @@ def project_team(
 	period_start: str | None = None,
 	period_end: str | None = None,
 	today: str | None = None,
+	mode: str = "Derived",
+	assume: str | None = None,
 ) -> dict:
 	"""Project one team over one period.
 
@@ -38,4 +40,4 @@ def project_team(
 		f"projection: {frappe.session.user} projected {team} "
 		f"for {period_start}..{period_end} as of {today}"
 	)
-	return engine.project(team, period_start, period_end, today=today)
+	return engine.project(team, period_start, period_end, today=today, mode=mode, assume=assume)

--- a/central/billing/page/billing_simulator/billing_simulator.js
+++ b/central/billing/page/billing_simulator/billing_simulator.js
@@ -42,6 +42,14 @@ class BillingSimulator {
 			default: frappe.datetime.month_start(),
 			change: () => this.refresh(),
 		});
+		this.mode = this.page.add_field({
+			fieldname: "mode",
+			label: __("Outcomes"),
+			fieldtype: "Select",
+			options: ["Derived", "Optimistic", "Assumed"],
+			default: "Derived",
+			change: () => this.refresh(),
+		});
 		this.page.set_primary_action(__("Project"), () => this.refresh());
 	}
 
@@ -54,7 +62,7 @@ class BillingSimulator {
 		frappe
 			.call({
 				method: "central.billing.api.admin.projection.project_team",
-				args: { team, period_start: start },
+				args: { team, period_start: start, mode: this.mode.get_value() || "Derived" },
 			})
 			.then((r) => r.message && this.render(r.message))
 			.catch(() => this.show_empty(__("Could not project this team.")));
@@ -67,7 +75,8 @@ class BillingSimulator {
 	render(data) {
 		this.$body.empty();
 		this.$body.append(this.invoice_card(data));
-		this.$body.append(this.calendar_card(data.calendar));
+		if (data.outcome) this.$body.append(this.findings_card(data.outcome));
+		this.$body.append(this.calendar_card(data.calendar, data.outcome));
 		if (data.in_flight && data.in_flight.length) {
 			this.$body.append(this.in_flight_card(data.in_flight, data.as_of));
 		}
@@ -141,9 +150,47 @@ class BillingSimulator {
 			</div>`);
 	}
 
+	// ---- what the state already decides ------------------------------------
+
+	findings_card(outcome) {
+		// Derived mode with nothing to report is a real answer, not an empty state: the
+		// data does not settle whether the charge works, and saying so is the honest
+		// alternative to implying success.
+		if (outcome.mode !== "Derived") {
+			return $(`<div class="bs-card"><div class="bs-note">${__(
+				"Outcome is {0}, not derived from this team's state.",
+				[outcome.mode.toLowerCase()]
+			)}</div></div>`);
+		}
+
+		if (!outcome.findings.length) {
+			return $(`<div class="bs-card"><div class="bs-note bs-note-ok">${__(
+				"Nothing in this team's setup stops the charge. Whether it succeeds is not knowable from here."
+			)}</div></div>`);
+		}
+
+		const items = outcome.findings
+			.map(
+				(f) => `<li class="bs-finding">
+					<span class="bs-finding-summary">${frappe.utils.escape_html(f.summary)}</span>
+					<span class="bs-muted">${frappe.utils.escape_html(f.detail)}</span>
+				</li>`
+			)
+			.join("");
+
+		return $(`
+			<div class="bs-card">
+				<div class="bs-card-head">
+					<span class="bs-card-title">${__("Why this will not settle")}</span>
+					<span class="bs-muted">${__("Entailed by the team's state, not predicted")}</span>
+				</div>
+				<ul class="bs-findings">${items}</ul>
+			</div>`);
+	}
+
 	// ---- the fork ----------------------------------------------------------
 
-	calendar_card(calendar) {
+	calendar_card(calendar, outcome) {
 		const $card = $(`
 			<div class="bs-card">
 				<div class="bs-card-head">
@@ -154,7 +201,7 @@ class BillingSimulator {
 				</div>
 				<div class="bs-figure"></div>
 			</div>`);
-		$card.find(".bs-figure").append(timeline_svg(calendar));
+		$card.find(".bs-figure").append(timeline_svg(calendar, outcome));
 		return $card;
 	}
 
@@ -232,6 +279,16 @@ class BillingSimulator {
 			.bs-dot { width: 6px; height: 6px; border-radius: 50%; display: inline-block; }
 			.bs-dot-measured { background: var(--text-light); }
 			.bs-dot-estimated { background: var(--card-bg); border: 1.5px solid var(--gray-400, #c7c7c7); }
+			.bs-note { padding: 14px 13px; color: var(--text-light);
+				font-size: var(--text-base, 13px); }
+			.bs-note-ok { border-left: 2px solid var(--green-500, #59ba8b); }
+			.bs-findings { list-style: none; margin: 0; padding: 0; }
+			.bs-finding { padding: 10px 13px; border-bottom: 1px solid var(--border-color);
+				border-left: 2px solid var(--red-500, #e03636); display: flex;
+				flex-direction: column; gap: 2px; }
+			.bs-findings li:last-child { border-bottom: 0; }
+			.bs-finding-summary { font-weight: 500; color: var(--heading-color); }
+			.bs-dim { opacity: 0.35; }
 			.bs-figure { padding: 14px 13px; overflow-x: auto; }
 			.bs-figure svg { display: block; min-width: 620px; width: 100%; height: auto; }
 		</style>`).appendTo(document.head);
@@ -258,7 +315,13 @@ function basis_tag(line) {
 
 // Both branches on one axis. The fork is the point: an operator asking what happens to
 // this team wants settlement and escalation side by side, not one behind a toggle.
-function timeline_svg(calendar) {
+function timeline_svg(calendar, outcome) {
+	// Dim the arm the data rules out, so the entailed branch reads at a glance without
+	// the other one disappearing — an operator still needs to see what settling looks
+	// like even when it is not going to happen.
+	const entailed = outcome && outcome.entailed_branch;
+	const paid_dim = entailed === "if_never_paid" ? ' class="bs-dim"' : "";
+	const unpaid_dim = entailed === "if_paid_on_time" ? ' class="bs-dim"' : "";
 	const unpaid = calendar.if_never_paid || [];
 	const dates = [calendar.opens_on, calendar.due_on, ...unpaid.map((s) => s.date)];
 	const first = new Date(dates[0]);
@@ -310,9 +373,9 @@ function timeline_svg(calendar) {
 	return $(`
 		<svg viewBox="0 0 ${W} 176" role="img"
 			aria-label="${__("Both branches of what happens after the invoice falls due")}">
-			<text x="4" y="30" font-size="11" font-weight="600"
+			<text x="4" y="30" font-size="11" font-weight="600"${paid_dim}
 				fill="var(--green-600, #30a66d)">${__("If paid on time")}</text>
-			<text x="4" y="124" font-size="11" font-weight="600"
+			<text x="4" y="124" font-size="11" font-weight="600"${unpaid_dim}
 				fill="var(--red-600, #cc2929)">${__("If never paid")}</text>
 
 			<line x1="${LEFT}" y1="72" x2="${W - RIGHT}" y2="72"
@@ -331,6 +394,7 @@ function timeline_svg(calendar) {
 					calendar.due_on
 				)}</text>
 
+			<g${paid_dim}>
 			<path d="M ${fork} 72 C ${fork + 26} 72, ${fork + 26} 26, ${fork + 52} 26"
 				fill="none" stroke="var(--green-500, #59ba8b)" stroke-width="2"></path>
 			<circle cx="${fork + 52}" cy="26" r="4" fill="var(--green-500, #59ba8b)"></circle>
@@ -338,11 +402,14 @@ function timeline_svg(calendar) {
 				fill="var(--green-600, #30a66d)">${__("Settled")} ${frappe.datetime.str_to_user(
 					paid.date
 				)}</text>
+			</g>
 
+			<g${unpaid_dim}>
 			<path d="M ${fork} 72 C ${fork + 26} 72, ${fork + 26} 120, ${fork + 52} 120"
 				fill="none" stroke="var(--red-500, #e03636)" stroke-width="2"></path>
 			<line x1="${fork + 52}" y1="120" x2="${W - RIGHT}" y2="120"
 				stroke="var(--red-500, #e03636)" stroke-width="2"></line>
 			${marks}
+			</g>
 		</svg>`);
 }

--- a/central/billing/projection/engine.py
+++ b/central/billing/projection/engine.py
@@ -16,7 +16,7 @@ guarantee rather than a convention — see `guard`.
 import frappe
 
 from central.billing import settings
-from central.billing.projection import estimate
+from central.billing.projection import estimate, outcomes
 from central.billing.projection.basis import MEASURED, mark, split_totals
 from central.billing.projection.guard import read_only
 from central.billing.revenue.dunning import dunning_clock_start, dunning_policy, dunning_schedule
@@ -28,6 +28,8 @@ def project(
 	period_start,
 	period_end,
 	today=None,
+	mode: str = outcomes.DERIVED,
+	assume: str | None = None,
 	recorder=None,
 	source=None,
 ) -> dict:
@@ -40,10 +42,12 @@ def project(
 	engine.
 	"""
 	with read_only():
-		return _project(team, period_start, period_end, today)
+		return _project(team, period_start, period_end, today, mode, assume)
 
 
-def _project(team: str, period_start, period_end, today=None) -> dict:
+def _project(
+	team: str, period_start, period_end, today=None, mode: str = outcomes.DERIVED, assume=None
+) -> dict:
 	today = frappe.utils.getdate(today or frappe.utils.nowdate())
 	start = frappe.utils.getdate(period_start)
 	end = frappe.utils.getdate(period_end)
@@ -52,14 +56,27 @@ def _project(team: str, period_start, period_end, today=None) -> dict:
 	rated = rate_team_period(team, start, end, metered=metered)
 
 	invoice = _invoice(rated)
+	currency = frappe.db.get_value("Billing Profile", team, "currency")
+	calendar = _calendar(end, today)
+
+	# Derived findings are read off the amount we would actually try to collect, not the
+	# headline total: credits and withholding both change what the gateway is asked for.
+	collectable = invoice["expected_collection"] if invoice else 0.0
+	findings = (
+		outcomes.derive(team, collectable, currency, calendar["due_on"], today)
+		if mode == outcomes.DERIVED
+		else []
+	)
+
 	return {
 		"team": team,
 		"period_start": str(start),
 		"period_end": str(end),
 		"as_of": str(today),
-		"currency": frappe.db.get_value("Billing Profile", team, "currency"),
+		"currency": currency,
 		"invoice": invoice,
-		"calendar": _calendar(end, today),
+		"calendar": calendar,
+		"outcome": outcomes.verdict(mode, findings, assume),
 		"in_flight": _in_flight(team, today),
 	}
 
@@ -107,8 +124,8 @@ def _calendar(period_end, today) -> dict:
 
 	The fork is the point of the thing: an operator asking "what happens to this team"
 	wants to see settlement *and* escalation side by side, not one of them behind a
-	mode switch. Neither branch is asserted here — deriving which one the team's state
-	entails is a later, separate job.
+	mode switch. Neither branch is asserted here — `outcomes.verdict` marks which arm
+	the team's state entails, if either, and both are rendered regardless.
 	"""
 	opens_on = _opens_on(period_end)
 	due_on = frappe.utils.add_days(opens_on, settings.invoice_due_days())

--- a/central/billing/projection/outcomes.py
+++ b/central/billing/projection/outcomes.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Why collection will fail — asserted only where the team's state entails it.
+
+Whether a card will succeed is unknowable, so a projection never pretends. But a
+great deal of failure is not a guess at all: a team with no active payment method
+will not be auto-charged, an INR bill over the silent-debit threshold lands in Action
+Required by design, a mandate whose ceiling sits below the invoice cannot be debited.
+Those are facts already in the database, and reporting only those is what turns the
+simulator from a picture into a pre-flight check on the book.
+
+Three modes, and the output always says which produced it:
+
+  Optimistic  everything settles on time.
+  Assumed     the operator declares the outcome; the calendar follows their word.
+  Derived     failure is reported only where state entails it, silence otherwise.
+
+Every rule below reuses the production helper that governs it — `silent_threshold`,
+`effective_cap`, `settlement_sources`, `ordered_methods` — so the simulator and the
+collector cannot disagree about who can be charged.
+
+One helper is deliberately *not* used. `collection_mode.evaluate()` decides the same
+threshold question but **trips the profile into Action Required as a side effect**,
+which is a write. A projection asks; it does not push the team into a new mode.
+"""
+
+import frappe
+
+from central.billing.payments import collection, collection_mode, mandates, settlement
+
+OPTIMISTIC = "Optimistic"
+ASSUMED = "Assumed"
+DERIVED = "Derived"
+MODES = (OPTIMISTIC, ASSUMED, DERIVED)
+
+# Modes in which nothing is charged off-session: the customer has to act. Dunning
+# knows this and escalates without retrying (ADR 0005).
+ON_SESSION_MODES = ("Manual Checkout", "Action Required")
+
+
+def derive(team: str, amount: float, currency: str, due_on, today) -> list[frappe._dict]:
+	"""Everything about this team's state that already decides the outcome.
+
+	Returns findings, worst first. An empty list is not a prediction of success — it
+	means nothing in the data settles the question, and the honest answer is that the
+	charge may or may not go through.
+	"""
+	amount = frappe.utils.flt(amount)
+	profile_mode = frappe.db.get_value("Billing Profile", team, "collection_mode")
+	sources = settlement.settlement_sources(team)
+	findings = []
+
+	if profile_mode in ON_SESSION_MODES:
+		findings.append(
+			_finding(
+				"on_session_mode",
+				f"Collection mode is {profile_mode}",
+				"Nothing is charged off-session in this mode — the customer has to act, "
+				"and dunning escalates without retrying.",
+			)
+		)
+
+	# An e-mandate bill at or over the silent-debit ceiling is never quietly taken; the
+	# real charge path trips the team into Action Required at exactly this point.
+	if profile_mode == "E-Mandate" and amount:
+		threshold = collection_mode.silent_threshold(team)
+		if amount >= threshold:
+			findings.append(
+				_finding(
+					"over_silent_threshold",
+					"Over the silent-debit threshold",
+					f"{_money(amount, currency)} is at or above {_money(threshold, currency)}, "
+					"so this lands in Action Required rather than being auto-charged.",
+				)
+			)
+
+	methods = collection.ordered_methods(team)
+	if not methods and not sources["has_credits"]:
+		findings.append(
+			_finding(
+				"no_settlement_source",
+				"No way to pay",
+				"No active payment method and no credit balance, so there is nothing to "
+				"charge and nothing to draw down.",
+			)
+		)
+	elif not methods:
+		findings.append(
+			_finding(
+				"no_active_method",
+				"No active payment method",
+				"Nothing to auto-charge. Anything credits cannot cover will go unpaid.",
+			)
+		)
+
+	if mandates.reauth_pending(team):
+		findings.append(
+			_finding(
+				"mandate_reauth_pending",
+				"A mandate is awaiting re-authorisation",
+				"Until the customer re-consents its ceiling stays where it was, and the "
+				"method is skipped by the charge loop.",
+			)
+		)
+
+	# The mandate ceiling is the amount the bank will actually let us take — but only
+	# where a mandate exists. `effective_cap` falls back to the trust-tier cap when
+	# there is none, and reporting that as "over the mandate cap" is wrong twice over:
+	# there is no mandate, and an unset tier reads as a ceiling of zero, which would
+	# flag every team that has not been tiered yet.
+	ceiling = mandates.active_mandate_ceiling(team)
+	cap = mandates.effective_cap(team)
+	if amount and ceiling is not None and frappe.utils.flt(cap) < amount:
+		findings.append(
+			_finding(
+				"over_mandate_cap",
+				"Over the mandate cap",
+				f"{_money(amount, currency)} exceeds the effective cap of "
+				f"{_money(cap, currency)}, so the debit would be refused.",
+			)
+		)
+
+	if sources["credits_only"] and amount:
+		balance = frappe.utils.flt(settlement.credits.get_balance(team, currency)["balance"])
+		if balance < amount:
+			findings.append(
+				_finding(
+					"credits_shortfall",
+					"Credits will not cover it",
+					f"{_money(balance, currency)} against {_money(amount, currency)} — "
+					f"short by {_money(amount - balance, currency)}, with no card behind it.",
+				)
+			)
+
+	findings += _expiring_cards(team, due_on)
+	return findings
+
+
+def _expiring_cards(team: str, due_on) -> list[frappe._dict]:
+	"""Cards whose printed expiry falls before we would charge them."""
+	due = frappe.utils.getdate(due_on)
+	out = []
+	for card in frappe.get_all(
+		"Payment Method",
+		filters={"team": team, "method_type": "Card", "status": "Active"},
+		fields=["name", "display_label", "expiry_month", "expiry_year"],
+	):
+		if not (card.expiry_month and card.expiry_year):
+			continue
+		# A card is good through the last day of its printed month.
+		expires = frappe.utils.get_last_day(f"{int(card.expiry_year)}-{int(card.expiry_month):02d}-01")
+		if frappe.utils.getdate(expires) < due:
+			out.append(
+				_finding(
+					"card_expires",
+					"A card expires before it would be charged",
+					f"{card.display_label or card.name} expires {expires}, before the "
+					f"{due} charge.",
+				)
+			)
+	return out
+
+
+def verdict(mode: str, findings: list, assume: str | None = None) -> frappe._dict:
+	"""What the projection claims about payment, and on what authority.
+
+	`entailed_branch` is the load-bearing field: it marks which arm of the calendar the
+	data already decides, so the UI can show both branches while saying which one is
+	not in doubt. None means genuinely open — the charge may work or it may not, and
+	nothing here knows which.
+	"""
+	if mode == OPTIMISTIC:
+		return frappe._dict(mode=mode, entailed_branch="if_paid_on_time", findings=[])
+
+	if mode == ASSUMED:
+		branch = "if_paid_on_time" if assume == "pays_on_time" else "if_never_paid"
+		return frappe._dict(mode=mode, assumed=assume, entailed_branch=branch, findings=[])
+
+	return frappe._dict(
+		mode=DERIVED,
+		# Any finding at all means the off-session charge does not simply go through.
+		entailed_branch="if_never_paid" if findings else None,
+		findings=findings,
+	)
+
+
+def _finding(code: str, summary: str, detail: str) -> frappe._dict:
+	return frappe._dict(finding=code, summary=summary, detail=detail)
+
+
+def _money(value, currency: str) -> str:
+	return frappe.utils.fmt_money(frappe.utils.flt(value), currency=currency)

--- a/central/billing/tests/test_projection_engine.py
+++ b/central/billing/tests/test_projection_engine.py
@@ -200,3 +200,51 @@ class TestInvoicesAlreadyInFlight(ProjectionTestBase):
 		frappe.db.commit()
 		out = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")
 		self.assertEqual(out["in_flight"], [])
+
+
+class TestOutcomeReachesTheProjection(ProjectionTestBase):
+	def test_a_team_with_no_way_to_pay_entails_the_unpaid_branch(self):
+		add_segment(self.sub, "Created", 12000, "2026-06-01 00:00:00")
+		frappe.db.commit()
+		out = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")
+
+		self.assertEqual(out["outcome"]["mode"], "Derived")
+		self.assertEqual(out["outcome"]["entailed_branch"], "if_never_paid")
+		self.assertIn(
+			"no_settlement_source", {f["finding"] for f in out["outcome"]["findings"]}
+		)
+
+	def test_both_branches_are_still_returned_when_one_is_entailed(self):
+		# Marking an arm must not hide the other: the fork is what the operator came for.
+		add_segment(self.sub, "Created", 12000, "2026-06-01 00:00:00")
+		frappe.db.commit()
+		cal = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")["calendar"]
+		self.assertTrue(cal["if_paid_on_time"])
+		self.assertTrue(cal["if_never_paid"])
+
+	def test_optimistic_mode_asserts_settlement_and_derives_nothing(self):
+		add_segment(self.sub, "Created", 12000, "2026-06-01 00:00:00")
+		frappe.db.commit()
+		out = engine.project(
+			TEAM, "2026-09-01", "2026-09-30", today="2026-08-06", mode="Optimistic"
+		)
+		self.assertEqual(out["outcome"]["entailed_branch"], "if_paid_on_time")
+		self.assertEqual(out["outcome"]["findings"], [])
+
+	def test_an_assumed_outcome_is_carried_through(self):
+		add_segment(self.sub, "Created", 12000, "2026-06-01 00:00:00")
+		frappe.db.commit()
+		out = engine.project(
+			TEAM, "2026-09-01", "2026-09-30", today="2026-08-06",
+			mode="Assumed", assume="never_pays",
+		)
+		self.assertEqual(out["outcome"]["assumed"], "never_pays")
+		self.assertEqual(out["outcome"]["entailed_branch"], "if_never_paid")
+
+	def test_findings_are_derived_from_what_we_would_actually_collect(self):
+		# Credits and withholding change the amount the gateway is asked for, so the
+		# threshold questions must be asked of that, not of the headline total.
+		add_segment(self.sub, "Created", 12000, "2026-06-01 00:00:00")
+		frappe.db.commit()
+		out = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")
+		self.assertEqual(out["invoice"]["expected_collection"], 12000.0)

--- a/central/billing/tests/test_projection_outcomes.py
+++ b/central/billing/tests/test_projection_outcomes.py
@@ -1,0 +1,277 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Derived outcomes: assert failure only where the state entails it."""
+
+import frappe
+from central.billing.projection import outcomes
+from central.billing.revenue import credits
+from central.billing.tests.test_stripe_adapter import make_stripe_gateway
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+from central.billing.tests.utils import ensure_atlas_instance, ensure_team, make_plan, set_team_tier
+
+TEAM = "team-projection-outcomes"
+CLUSTER = "ap-south-1"
+PLAN = "bundle-projection-outcomes"
+GATEWAY = "GW-Test-Stripe"
+DUE = "2026-10-08"
+TODAY = "2026-08-06"
+
+
+class OutcomeTestBase(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		ensure_atlas_instance(CLUSTER)
+		make_plan(PLAN)
+		make_stripe_gateway(GATEWAY)
+		self._purge()
+		set_team_tier(TEAM, level="t0", max_spend=50000)
+		frappe.db.commit()
+
+	def tearDown(self):
+		self._purge()
+
+	def _purge(self):
+		for dt in ("Invoice", "Payment Attempt", "Credit Ledger Entry"):
+			frappe.db.delete(dt, {"team": TEAM})
+		frappe.db.delete("Credit Wallet", {"team": TEAM})
+		frappe.db.delete("Payment Method", {"team": TEAM})
+		frappe.db.delete("Billing Profile", {"team": TEAM})
+		frappe.db.commit()
+
+	def _profile(self, mode="Stripe Auto", currency="INR"):
+		# set_team_tier already provisions a profile, so this adjusts rather than inserts.
+		if frappe.db.exists("Billing Profile", TEAM):
+			frappe.db.set_value(
+				"Billing Profile",
+				TEAM,
+				{"currency": currency, "country": "India", "collection_mode": mode},
+			)
+		else:
+			frappe.get_doc(
+				{
+					"doctype": "Billing Profile",
+					"team": TEAM,
+					"currency": currency,
+					"country": "India",
+					"collection_mode": mode,
+				}
+			).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	def _card(self, expiry_month=12, expiry_year=2030, status="Active"):
+		return (
+			frappe.get_doc(
+				{
+					"doctype": "Payment Method",
+					"team": TEAM,
+					"gateway": GATEWAY,
+					"method_type": "Card",
+					"status": status,
+					"gateway_method_id": "pm_card",
+					"gateway_customer_id": "cus_1",
+					"is_default": 1,
+					"display_label": "Visa 4242",
+					"expiry_month": expiry_month,
+					"expiry_year": expiry_year,
+				}
+			)
+			.insert(ignore_permissions=True)
+			.name
+		)
+
+	def _mandate(self, ceiling, reauth=0):
+		return (
+			frappe.get_doc(
+				{
+					"doctype": "Payment Method",
+					"team": TEAM,
+					"gateway": GATEWAY,
+					"method_type": "UPI Autopay",
+					"status": "Active",
+					"gateway_method_id": "mandate_1",
+					"mandate_max_amount": ceiling,
+					"mandate_currency": "INR",
+					"reauth_required": reauth,
+				}
+			)
+			.insert(ignore_permissions=True)
+			.name
+		)
+
+	def _derive(self, amount=10000.0):
+		return outcomes.derive(TEAM, amount, "INR", DUE, frappe.utils.getdate(TODAY))
+
+	def _codes(self, amount=10000.0):
+		return {f.finding for f in self._derive(amount)}
+
+
+class TestSilenceWhenNothingIsEntailed(OutcomeTestBase):
+	def test_a_healthy_autopay_team_yields_no_findings(self):
+		# Nothing in the data settles whether the charge works, so nothing is claimed.
+		self._profile()
+		self._card()
+		frappe.db.commit()
+		self.assertEqual(self._derive(), [])
+
+
+class TestNoWayToPay(OutcomeTestBase):
+	def test_no_method_and_no_credits_is_reported_once(self):
+		self._profile()
+		frappe.db.commit()
+		self.assertIn("no_settlement_source", self._codes())
+
+	def test_credits_without_a_card_is_a_missing_method_not_a_dead_end(self):
+		self._profile()
+		credits.purchase(TEAM, 50000, "INR")
+		frappe.db.commit()
+		codes = self._codes()
+		self.assertIn("no_active_method", codes)
+		self.assertNotIn("no_settlement_source", codes)
+
+	def test_an_expired_card_does_not_count_as_a_method(self):
+		self._profile()
+		self._card(status="Expired")
+		frappe.db.commit()
+		self.assertIn("no_settlement_source", self._codes())
+
+
+class TestTheIndianThreshold(OutcomeTestBase):
+	def test_an_emandate_bill_over_the_threshold_lands_in_action_required(self):
+		self._profile(mode="E-Mandate")
+		self._mandate(ceiling=100000)
+		frappe.db.commit()
+		self.assertIn("over_silent_threshold", self._codes(amount=15000.0))
+
+	def test_under_the_threshold_is_charged_silently(self):
+		self._profile(mode="E-Mandate")
+		self._mandate(ceiling=100000)
+		frappe.db.commit()
+		self.assertNotIn("over_silent_threshold", self._codes(amount=14999.0))
+
+	def test_the_threshold_does_not_apply_to_a_card_team(self):
+		self._profile(mode="Stripe Auto")
+		self._card()
+		frappe.db.commit()
+		self.assertNotIn("over_silent_threshold", self._codes(amount=99000.0))
+
+	def test_deriving_never_trips_the_profile_into_action_required(self):
+		# The real charge path trips the mode here as a side effect. Asking the question
+		# must not move the team into a new mode.
+		self._profile(mode="E-Mandate")
+		self._mandate(ceiling=100000)
+		frappe.db.commit()
+		self._derive(amount=40000.0)
+		self.assertEqual(
+			frappe.db.get_value("Billing Profile", TEAM, "collection_mode"), "E-Mandate"
+		)
+
+
+class TestOnSessionModes(OutcomeTestBase):
+	def test_manual_checkout_means_the_customer_must_act(self):
+		self._profile(mode="Manual Checkout")
+		self._card()
+		frappe.db.commit()
+		self.assertIn("on_session_mode", self._codes())
+
+	def test_action_required_is_reported_too(self):
+		self._profile(mode="Action Required")
+		self._card()
+		frappe.db.commit()
+		self.assertIn("on_session_mode", self._codes())
+
+
+class TestMandateCeiling(OutcomeTestBase):
+	def test_a_bill_above_the_mandate_cap_would_be_refused(self):
+		self._profile(mode="E-Mandate")
+		self._mandate(ceiling=5000)
+		frappe.db.commit()
+		self.assertIn("over_mandate_cap", self._codes(amount=8000.0))
+
+	def test_a_bill_within_the_cap_is_not_flagged(self):
+		self._profile(mode="E-Mandate")
+		self._mandate(ceiling=20000)
+		frappe.db.commit()
+		self.assertNotIn("over_mandate_cap", self._codes(amount=8000.0))
+
+	def test_a_team_with_no_mandate_is_never_over_a_mandate_cap(self):
+		# effective_cap falls back to the tier cap when no mandate exists, and an untiered
+		# team reads as a ceiling of zero — which would flag everyone.
+		self._profile()
+		frappe.db.delete("Billing Profile", {"team": TEAM})
+		self._profile()
+		frappe.db.commit()
+		self.assertNotIn("over_mandate_cap", self._codes(amount=99999.0))
+
+	def test_a_mandate_awaiting_reauthorisation_is_reported(self):
+		self._profile(mode="E-Mandate")
+		self._mandate(ceiling=100000, reauth=1)
+		frappe.db.commit()
+		self.assertIn("mandate_reauth_pending", self._codes(amount=1000.0))
+
+
+class TestExpiringCards(OutcomeTestBase):
+	def test_a_card_expiring_before_the_charge_is_flagged(self):
+		self._profile()
+		self._card(expiry_month=9, expiry_year=2026)  # good through 30 Sep; charged 8 Oct
+		frappe.db.commit()
+		self.assertIn("card_expires", self._codes())
+
+	def test_a_card_valid_through_the_charge_month_is_not_flagged(self):
+		self._profile()
+		self._card(expiry_month=10, expiry_year=2026)  # good through 31 Oct
+		frappe.db.commit()
+		self.assertNotIn("card_expires", self._codes())
+
+
+class TestCreditsOnly(OutcomeTestBase):
+	def test_a_wallet_that_cannot_cover_the_bill_is_a_shortfall(self):
+		self._profile()
+		credits.purchase(TEAM, 3000, "INR")
+		frappe.db.commit()
+		findings = {f.finding: f for f in self._derive(amount=10000.0)}
+		self.assertIn("credits_shortfall", findings)
+		self.assertIn("short by", findings["credits_shortfall"].detail)
+
+	def test_a_wallet_that_covers_it_is_not_a_shortfall(self):
+		self._profile()
+		credits.purchase(TEAM, 20000, "INR")
+		frappe.db.commit()
+		self.assertNotIn("credits_shortfall", self._codes(amount=10000.0))
+
+	def test_a_card_behind_the_wallet_means_no_shortfall_is_claimed(self):
+		# With a card as backstop the team is not credits-only, so an uncovered balance
+		# is not by itself a failure.
+		self._profile()
+		self._card()
+		credits.purchase(TEAM, 100, "INR")
+		frappe.db.commit()
+		self.assertNotIn("credits_shortfall", self._codes(amount=10000.0))
+
+
+class TestTheVerdict(OutcomeTestBase):
+	def test_optimistic_entails_settlement_and_finds_nothing(self):
+		v = outcomes.verdict(outcomes.OPTIMISTIC, [])
+		self.assertEqual(v.entailed_branch, "if_paid_on_time")
+		self.assertEqual(v.findings, [])
+
+	def test_derived_with_findings_entails_the_unpaid_branch(self):
+		v = outcomes.verdict(outcomes.DERIVED, [outcomes._finding("x", "y", "z")])
+		self.assertEqual(v.entailed_branch, "if_never_paid")
+
+	def test_derived_without_findings_entails_neither(self):
+		# Silence is not a prediction of success — the question is genuinely open.
+		self.assertIsNone(outcomes.verdict(outcomes.DERIVED, []).entailed_branch)
+
+	def test_an_assumed_outcome_follows_the_operator(self):
+		self.assertEqual(
+			outcomes.verdict(outcomes.ASSUMED, [], assume="pays_on_time").entailed_branch,
+			"if_paid_on_time",
+		)
+		self.assertEqual(
+			outcomes.verdict(outcomes.ASSUMED, [], assume="never_pays").entailed_branch,
+			"if_never_paid",
+		)
+
+	def test_the_mode_is_always_reported_back(self):
+		for mode in outcomes.MODES:
+			self.assertEqual(outcomes.verdict(mode, []).mode, mode)


### PR DESCRIPTION
The simulator could say what a team would be billed and when we would ask for it. It could not say whether the ask would work. This adds that, but only where the answer is a fact rather than a forecast.

Three modes, and the output always names which produced it:

- **Optimistic** — everything settles on time.
- **Assumed** — the operator declares the outcome; the calendar follows their word.
- **Derived** — failure is reported only where the team's state entails it.

Derived is the one that earns its keep, because every conclusion it reaches is already true in the database:

```mermaid
flowchart TD
    S["Team state"] --> A{"Anything decisive?"}
    A -->|no active method, no credits| F1["No way to pay"]
    A -->|Manual Checkout / Action Required| F2["Customer must act"]
    A -->|INR at or over silent threshold| F3["Lands in Action Required"]
    A -->|mandate ceiling below the bill| F4["Debit would be refused"]
    A -->|mandate awaiting re-consent| F5["Method is skipped"]
    A -->|card expires before the charge| F6["Expires mid-cycle"]
    A -->|credits-only, wallet short| F7["Shortfall"]
    A -->|nothing| OPEN["Open — not knowable from here"]

    style OPEN fill:#e4f5e9,stroke:#30a66d
```

An empty finding list is **not** a prediction of success. It means the data does not settle the question, and the page says exactly that rather than implying the charge will go through.

## It reuses the collector, and avoids the one helper that writes

Every rule delegates to the production helper that governs it — `silent_threshold`, `effective_cap`, `active_mandate_ceiling`, `reauth_pending`, `settlement_sources`, `ordered_methods` — so the simulator and the charge loop cannot drift apart on who is chargeable.

`collection_mode.evaluate()` answers the threshold question too, and **trips the profile into Action Required as a side effect**. A projection asks; it does not push a team into a new collection mode. There is a test holding that.

## Both branches stay visible

Marking the entailed arm must not hide the other one — an operator still needs to see what settling looks like even when it is not going to happen. The ruled-out branch is dimmed, not removed.
