### PR TITLE
feat(admin): Roll a team forward, month by month

### DIFF
--- a/central/billing/api/admin/__init__.py
+++ b/central/billing/api/admin/__init__.py
@@ -22,7 +22,7 @@ from central.billing.api.admin.catalog import (
 	get_trial_detail,
 	update_plan_rate,
 )
-from central.billing.api.admin.projection import project_team
+from central.billing.api.admin.projection import project_team, project_team_months
 from central.billing.api.admin.revenue import (
 	get_cluster_breakdown,
 	get_free_trial_costs,
@@ -45,6 +45,7 @@ from central.billing.api.admin.teams import (
 
 __all__ = [
 	"project_team",
+	"project_team_months",
 	"adjust_team_credits",
 	"create_configured_plan",
 	"get_catalog",

--- a/central/billing/api/admin/projection.py
+++ b/central/billing/api/admin/projection.py
@@ -41,3 +41,30 @@ def project_team(
 		f"for {period_start}..{period_end} as of {today}"
 	)
 	return engine.project(team, period_start, period_end, today=today, mode=mode, assume=assume)
+
+
+@frappe.whitelist()
+def project_team_months(
+	team: str,
+	start: str | None = None,
+	months: int = 6,
+	today: str | None = None,
+	mode: str = "Derived",
+	assume: str | None = None,
+) -> dict:
+	"""Roll a team forward over several months, carrying what each one changes.
+
+	The question a single period cannot answer: not what September costs, but when the
+	credits run out and what happens after.
+	"""
+	authz.require_operator()
+
+	today = frappe.utils.getdate(today or frappe.utils.nowdate())
+	start = frappe.utils.getdate(start or frappe.utils.get_first_day(today))
+	months = max(1, min(frappe.utils.cint(months), 24))
+
+	frappe.logger("billing").info(
+		f"projection: {frappe.session.user} rolled {team} forward {months} months "
+		f"from {start} as of {today}"
+	)
+	return engine.project_months(team, start, months=months, today=today, mode=mode, assume=assume)

--- a/central/billing/page/billing_simulator/billing_simulator.js
+++ b/central/billing/page/billing_simulator/billing_simulator.js
@@ -42,6 +42,14 @@ class BillingSimulator {
 			default: frappe.datetime.month_start(),
 			change: () => this.refresh(),
 		});
+		this.months = this.page.add_field({
+			fieldname: "months",
+			label: __("Months"),
+			fieldtype: "Select",
+			options: ["1", "3", "6", "12"],
+			default: "1",
+			change: () => this.refresh(),
+		});
 		this.mode = this.page.add_field({
 			fieldname: "mode",
 			label: __("Outcomes"),
@@ -58,13 +66,26 @@ class BillingSimulator {
 		if (!team) return;
 
 		const start = this.period.get_value() || frappe.datetime.month_start();
+		const months = cint(this.months.get_value()) || 1;
+		const mode = this.mode.get_value() || "Derived";
 		this.show_empty(__("Projecting…"));
+
+		// One month is the detailed view; several is the roll-forward, where what each
+		// month leaves behind is the whole point.
+		const single = months === 1;
 		frappe
 			.call({
-				method: "central.billing.api.admin.projection.project_team",
-				args: { team, period_start: start, mode: this.mode.get_value() || "Derived" },
+				method: single
+					? "central.billing.api.admin.projection.project_team"
+					: "central.billing.api.admin.projection.project_team_months",
+				args: single
+					? { team, period_start: start, mode }
+					: { team, start, months, mode },
 			})
-			.then((r) => r.message && this.render(r.message))
+			.then((r) => {
+				if (!r.message) return;
+				return single ? this.render(r.message) : this.render_months(r.message);
+			})
 			.catch(() => this.show_empty(__("Could not project this team.")));
 	}
 
@@ -80,6 +101,97 @@ class BillingSimulator {
 		if (data.in_flight && data.in_flight.length) {
 			this.$body.append(this.in_flight_card(data.in_flight, data.as_of));
 		}
+	}
+
+	render_months(data) {
+		this.$body.empty();
+		this.$body.append(this.trajectory_card(data));
+		if (data.events && data.events.length) {
+			this.$body.append(this.events_card(data.events));
+		}
+	}
+
+	// ---- the roll-forward --------------------------------------------------
+
+	trajectory_card(data) {
+		const money = (v) => format_currency(v, data.currency);
+		const rows = data.months
+			.map((m) => {
+				if (m.suspended) {
+					return `<tr class="bs-stopped">
+						<td>${m.period_start}</td>
+						<td colspan="4">${__("Suspended — nothing accrues")}</td>
+					</tr>`;
+				}
+				const s = m.settlement || {};
+				const short = s.shortfall > 0;
+				return `<tr>
+					<td>${m.period_start}</td>
+					<td class="bs-right">${m.invoice ? money(m.invoice.total) : "—"}</td>
+					<td class="bs-right">${s.from_credits != null ? money(s.from_credits) : "—"}</td>
+					<td class="bs-right ${short ? "bs-short" : ""}">${
+						short ? money(s.shortfall) : "—"
+					}</td>
+					<td class="bs-right">${m.balance_after != null ? money(m.balance_after) : "—"}</td>
+				</tr>`;
+			})
+			.join("");
+
+		const ends = data.ends || {};
+		return $(`
+			<div class="bs-card">
+				<div class="bs-card-head">
+					<span class="bs-card-title">${__("Month by month")}</span>
+					<span class="bs-muted">${__(
+						"Each month settles against what the ones before it left"
+					)}</span>
+				</div>
+				<table class="bs-table">
+					<thead>
+						<tr>
+							<th>${__("Month")}</th>
+							<th class="bs-right">${__("Billed")}</th>
+							<th class="bs-right">${__("From credits")}</th>
+							<th class="bs-right">${__("Shortfall")}</th>
+							<th class="bs-right">${__("Balance after")}</th>
+						</tr>
+					</thead>
+					<tbody>${rows}</tbody>
+				</table>
+				<div class="bs-totals">
+					<div class="bs-total"><span>${__("Ends with")}</span><span>${money(
+						ends.balance || 0
+					)}</span></div>
+					<div class="bs-total"><span>${__("Standing")}</span><span>${frappe.utils.escape_html(
+						ends.standing || "Current"
+					)}</span></div>
+					${
+						ends.suspended_on
+							? `<div class="bs-total"><span>${__(
+									"Suspends on"
+							  )}</span><span>${ends.suspended_on}</span></div>`
+							: ""
+					}
+				</div>
+			</div>`);
+	}
+
+	events_card(events) {
+		const rows = events
+			.map(
+				(e) => `<li class="bs-finding">
+					<span class="bs-finding-summary">${frappe.utils.escape_html(e.event)} · ${e.date}</span>
+					${e.amount ? `<span class="bs-muted">${e.amount}</span>` : ""}
+				</li>`
+			)
+			.join("");
+		return $(`
+			<div class="bs-card">
+				<div class="bs-card-head">
+					<span class="bs-card-title">${__("Along the way")}</span>
+				</div>
+				<ul class="bs-findings">${rows}</ul>
+			</div>`);
 	}
 
 	// ---- projected invoice -------------------------------------------------
@@ -289,6 +401,8 @@ class BillingSimulator {
 			.bs-findings li:last-child { border-bottom: 0; }
 			.bs-finding-summary { font-weight: 500; color: var(--heading-color); }
 			.bs-dim { opacity: 0.35; }
+			.bs-short { color: var(--red-600, #cc2929); font-weight: 500; }
+			.bs-stopped td { color: var(--text-muted); font-style: italic; }
 			.bs-figure { padding: 14px 13px; overflow-x: auto; }
 			.bs-figure svg { display: block; min-width: 620px; width: 100%; height: auto; }
 		</style>`).appendTo(document.head);

--- a/central/billing/payments/settlement.py
+++ b/central/billing/payments/settlement.py
@@ -22,16 +22,23 @@ from central.billing.revenue import credits
 AUTOPAY_METHODS = ("Card", "UPI Autopay")
 
 
-def settlement_sources(team: str) -> dict:
-	"""What the team can settle with: active autopay method and/or wallet credit."""
-	has_autopay = bool(
-		frappe.get_all(
-			"Payment Method",
-			filters={"team": team, "method_type": ["in", AUTOPAY_METHODS], "status": "Active"},
-			limit=1,
+def settlement_sources(team: str, source=None) -> dict:
+	"""What the team can settle with: active autopay method and/or wallet credit.
+
+	`source` defers the evolving parts — the wallet, and whether a method is still
+	active — to a projection's roll-forward state. Absent, everything is read live.
+	"""
+	if source is not None:
+		has_autopay = bool(source.has_autopay(team))
+	else:
+		has_autopay = bool(
+			frappe.get_all(
+				"Payment Method",
+				filters={"team": team, "method_type": ["in", AUTOPAY_METHODS], "status": "Active"},
+				limit=1,
+			)
 		)
-	)
-	has_credits = credits.get_balance(team)["balance"] > 0
+	has_credits = credits.get_balance(team, source=source)["balance"] > 0
 	return {
 		"has_autopay": has_autopay,
 		"has_credits": has_credits,
@@ -50,43 +57,46 @@ def ensure_settlement_source(team: str):
 		)
 
 
-def _tier_cap(team: str):
+def _tier_cap(team: str, source=None):
+	if source is not None:
+		return frappe.utils.flt(source.tier_cap(team))
+
 	from central.billing.catalog.entitlements import get_team_caps
 
 	return frappe.utils.flt(get_team_caps(team).max_spend)
 
 
-def effective_spend_cap(team: str):
+def effective_spend_cap(team: str, source=None):
 	"""The cap the team is actually held to.
 
 	Autopay teams follow the trust tier directly (the card is the backstop).
 	Credits-only teams are gated by the wallet: `min(tier cap, balance)` — a cap
 	enforced without a backstop would be unsecured in a postpaid system.
 	"""
-	tier_cap = _tier_cap(team)
-	sources = settlement_sources(team)
+	tier_cap = _tier_cap(team, source)
+	sources = settlement_sources(team, source)
 	if sources["credits_only"]:
-		return min(tier_cap, frappe.utils.flt(credits.get_balance(team)["balance"]))
+		return min(tier_cap, frappe.utils.flt(credits.get_balance(team, source=source)["balance"]))
 	return tier_cap
 
 
-def can_accept_spend(team: str, projected_spend) -> bool:
+def can_accept_spend(team: str, projected_spend, source=None) -> bool:
 	"""Whether a new provision's projected run-rate fits the effective cap.
 
 	For credits-only teams this denies provisioning beyond wallet coverage; for
 	autopay teams it is the plain tier check.
 	"""
-	return frappe.utils.flt(projected_spend) <= effective_spend_cap(team)
+	return frappe.utils.flt(projected_spend) <= effective_spend_cap(team, source)
 
 
-def credit_forecast(team: str, projected_spend, notify: bool = True) -> dict:
+def credit_forecast(team: str, projected_spend, notify: bool = True, source=None) -> dict:
 	"""Compare projected month-end spend to the wallet balance.
 
 	Returns the utilisation and whether a top-up prompt is due (projected spend
 	has reached ~80% of the balance). Fires the prompt as a side effect when
 	`notify` and the threshold is crossed; the #20 suite is the real sender.
 	"""
-	balance = frappe.utils.flt(credits.get_balance(team)["balance"])
+	balance = frappe.utils.flt(credits.get_balance(team, source=source)["balance"])
 	projected = frappe.utils.flt(projected_spend)
 	utilisation = (projected / balance) if balance > 0 else (1.0 if projected > 0 else 0.0)
 	should_notify = utilisation >= settings.forecast_notify_ratio()

--- a/central/billing/projection/engine.py
+++ b/central/billing/projection/engine.py
@@ -16,7 +16,7 @@ guarantee rather than a convention — see `guard`.
 import frappe
 
 from central.billing import settings
-from central.billing.projection import estimate, outcomes
+from central.billing.projection import estimate, outcomes, state
 from central.billing.projection.basis import MEASURED, mark, split_totals
 from central.billing.projection.guard import read_only
 from central.billing.revenue.dunning import dunning_clock_start, dunning_policy, dunning_schedule
@@ -189,3 +189,131 @@ def _in_flight(team: str, today) -> list[dict]:
 			}
 		)
 	return out
+
+
+def project_months(
+	team: str,
+	start,
+	months: int = 1,
+	today=None,
+	mode: str = outcomes.DERIVED,
+	assume: str | None = None,
+) -> dict:
+	"""Roll a team forward month by month, carrying what each month changes.
+
+	This is the question a single-period projection cannot answer: not "what is the
+	September bill" but "when does this team run out". Each month is priced, settled
+	against the wallet the previous months left behind, escalated if it goes unpaid,
+	and the consequences carried into the next — which is how a projection arrives at
+	"credits run dry in month three, suspended in month four" rather than reporting a
+	comfortable balance every month because it re-read today's.
+	"""
+	with read_only():
+		return _project_months(team, start, months, today, mode, assume)
+
+
+def _project_months(team, start, months, today=None, mode=outcomes.DERIVED, assume=None) -> dict:
+	today = frappe.utils.getdate(today or frappe.utils.nowdate())
+	carried = state.seed(team, today)
+	period_start = frappe.utils.get_first_day(start)
+
+	periods = []
+	for _ in range(max(1, frappe.utils.cint(months))):
+		period_end = frappe.utils.get_last_day(period_start)
+		periods.append(_roll_one(team, carried, period_start, period_end, today, mode, assume))
+		period_start = frappe.utils.add_days(period_end, 1)
+
+	return {
+		"team": team,
+		"as_of": str(today),
+		"currency": carried.currency,
+		"months": periods,
+		"ends": {
+			"balance": carried.wallet().balance,
+			"standing": carried.standing,
+			"suspended_on": str(carried.suspended_on) if carried.suspended_on else None,
+			"tier_cap": carried.tier_cap(team),
+		},
+		"events": carried.events,
+	}
+
+
+def _roll_one(team, carried, period_start, period_end, today, mode, assume) -> dict:
+	"""One month, against the state the months before it left behind."""
+	# Promotional credit dies on its date whether or not anyone spent it. Sweep at the
+	# start of the month, not the end: a grant expiring on the 30th is the customer's to
+	# spend right up to the 30th, and destroying it before the month it covers would
+	# under-credit them by a whole period.
+	carried.expire_credits(frappe.utils.add_days(period_start, -1))
+
+	# A suspended resource is stopped, and a stopped resource is not billed on. The
+	# accrual ends at the suspension, not at the end of the projection.
+	if carried.suspended:
+		return {
+			"period_start": str(period_start),
+			"period_end": str(period_end),
+			"suspended": True,
+			"invoice": None,
+			"settlement": None,
+			"calendar": None,
+			"outcome": None,
+		}
+
+	metered = estimate.metered_lines(team, team_clusters(team), period_start, period_end, today=today)
+	rated = rate_team_period(team, period_start, period_end, metered=metered)
+	invoice = _invoice(rated)
+	calendar = _calendar(period_end, today)
+
+	settlement_result = _settle(carried, invoice, calendar, mode, assume)
+	findings = (
+		outcomes.derive(team, settlement_result["shortfall"], carried.currency, calendar["due_on"], today)
+		if mode == outcomes.DERIVED and invoice
+		else []
+	)
+	verdict = outcomes.verdict(mode, findings, assume)
+
+	# Nothing recovered means the ladder runs, and the ladder ends in suspension.
+	if invoice and settlement_result["shortfall"] > 0 and verdict.entailed_branch == "if_never_paid":
+		suspend = next((s for s in calendar["if_never_paid"] if s["stage"] == "Suspend"), None)
+		if suspend:
+			carried.suspend(suspend["date"])
+
+	return {
+		"period_start": str(period_start),
+		"period_end": str(period_end),
+		"suspended": False,
+		"invoice": invoice,
+		"settlement": settlement_result,
+		"calendar": calendar,
+		"outcome": verdict,
+		"balance_after": carried.wallet().balance,
+		"standing": carried.standing,
+	}
+
+
+def _settle(carried, invoice, calendar, mode, assume) -> dict | None:
+	"""Draw the projected wallet down, then say what is left owing.
+
+	Credits first, then whatever a card would have to cover — the same waterfall the
+	real settlement follows. Only what credits actually cover is certain here; the card
+	leg is exactly the part a projection must not claim to know.
+	"""
+	if not invoice:
+		return None
+
+	owed = frappe.utils.flt(invoice["expected_collection"])
+	drawn = carried.settle(owed)
+	shortfall = frappe.utils.flt(owed - drawn, 2)
+
+	# An invoice the operator says is paid, or one credits covered outright, is money
+	# in — and settled invoices are what move a team up the trust ladder.
+	settled = shortfall <= 0 or (mode == outcomes.ASSUMED and assume == "pays_on_time")
+	if settled:
+		carried.record_paid(invoice["total"])
+
+	return {
+		"owed": owed,
+		"from_credits": drawn,
+		"shortfall": max(0.0, shortfall),
+		"settled_by_credits": shortfall <= 0,
+	}

--- a/central/billing/projection/state.py
+++ b/central/billing/projection/state.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""A team's billing state, seeded once and then advanced in memory.
+
+Projecting six months is not six independent projections. Month two is downstream of
+month one: the wallet was drawn, an invoice went overdue, standing moved to past due,
+a suspension stopped accrual mid-month, a settled invoice promoted the trust tier and
+with it the spend cap. Answering each month from the live database would refill the
+wallet every time and report a team as comfortable right up to the point it is cut off.
+
+So the database is read **once**, at t0, and everything after that is arithmetic. This
+object is what the evolving-state readers consult through their `source` parameter —
+it implements `balance`, `has_autopay` and `tier_cap`, which is the whole protocol.
+
+Reference data is deliberately absent. Tax profiles, commitment terms and catalog
+rates keep coming off the database, because projecting forward does not change them.
+The test for which side a datum falls on is one question: does my projection change it?
+"""
+
+import frappe
+
+from central.billing.catalog.entitlements import cap_for, evaluate_tier, get_ladder
+from central.billing.revenue import credits
+
+
+class ProjectedWallet:
+	"""One currency's balance, kept as the grants it came from rather than one number.
+
+	The lots matter because promotional credit expires and purchased credit does not,
+	so a wallet that is comfortably in the black today can be empty next month without
+	anyone spending a penny. Draws take the soonest-expiring lot first — the same order
+	the real ledger settles in, and the order that wastes the least of the customer's
+	money.
+	"""
+
+	def __init__(self, lots=None):
+		# [{"remaining": float, "expires_on": date|None}], soonest expiry first.
+		self.lots = list(lots or [])
+
+	@property
+	def balance(self) -> float:
+		return frappe.utils.flt(sum(lot["remaining"] for lot in self.lots), 2)
+
+	def credit(self, amount, expires_on=None):
+		self.lots.append({"remaining": frappe.utils.flt(amount), "expires_on": expires_on})
+		self._sort()
+
+	def draw(self, amount) -> float:
+		"""Spend up to `amount`; returns what was actually available and taken."""
+		wanted = frappe.utils.flt(amount)
+		taken = 0.0
+		for lot in self.lots:
+			if wanted <= 0:
+				break
+			from_lot = min(lot["remaining"], wanted)
+			lot["remaining"] -= from_lot
+			wanted -= from_lot
+			taken += from_lot
+		self.lots = [lot for lot in self.lots if lot["remaining"] > 0]
+		return frappe.utils.flt(taken, 2)
+
+	def expire(self, on_date) -> float:
+		"""Sweep grants whose date has passed; returns what was lost."""
+		on_date = frappe.utils.getdate(on_date)
+		lost = 0.0
+		kept = []
+		for lot in self.lots:
+			if lot["expires_on"] and frappe.utils.getdate(lot["expires_on"]) <= on_date:
+				lost += lot["remaining"]
+			else:
+				kept.append(lot)
+		self.lots = kept
+		return frappe.utils.flt(lost, 2)
+
+	def _sort(self):
+		import datetime
+
+		self.lots.sort(
+			key=lambda lot: frappe.utils.getdate(lot["expires_on"])
+			if lot["expires_on"]
+			else datetime.date.max
+		)
+
+
+class ProjectedState:
+	"""Everything about a team that a projection changes as it rolls forward."""
+
+	def __init__(
+		self, team, currency, wallets, autopay, paid_count, paid_total, standing, base_cap=0.0
+	):
+		self.team = team
+		self.currency = currency
+		self.wallets = wallets
+		self.autopay = autopay
+		self.paid_count = paid_count
+		self.paid_total = paid_total
+		self.standing = standing
+		# The floor the projected cap can never fall below: whichever is higher of the cap
+		# the profile grants today (a manual override, a pinned level) and the cap the
+		# team's history already earns. Computed once, at seed.
+		#
+		# This is load-bearing rather than defensive. Nothing guarantees the ladder's caps
+		# rise with its rungs — a higher tier priced lower in one currency is a
+		# configuration mistake, not an impossibility — and without a floor a projection
+		# would then *shrink* a paying customer's ceiling as reward for paying. A
+		# projection models promotion; it never demotes anyone.
+		self.base_cap = max(frappe.utils.flt(base_cap), self._earned_cap())
+		self.suspended_on = None
+		self.events = []
+
+	# ---- the source protocol the readers consult ---------------------------
+
+	def balance(self, team, currency) -> float:
+		return self.wallet(currency).balance
+
+	def has_autopay(self, team) -> bool:
+		return self.autopay
+
+	def tier_cap(self, team) -> float:
+		"""The cap the team's *projected* payment history earns it.
+
+		Re-evaluated rather than remembered: settling invoices is how a team climbs the
+		ladder, so a projection in which they pay every month must show the ceiling
+		rising with them.
+
+		It only ever rises. A projection models promotion, not demotion — and the team's
+		live cap may come from a manual override or a level above what its history alone
+		would score, neither of which paying more bills should take away.
+		"""
+		return max(self.base_cap, self._earned_cap())
+
+	def _earned_cap(self) -> float:
+		"""The cap this team's paid history scores on the live ladder."""
+		levels = get_ladder()
+		if not levels:
+			return 0.0
+		level = evaluate_tier(self.paid_count, self.paid_total, self.currency, levels)
+		return frappe.utils.flt(cap_for(level, self.currency)) if level else 0.0
+
+	# ---- evolution ---------------------------------------------------------
+
+	def wallet(self, currency=None) -> ProjectedWallet:
+		currency = currency or self.currency
+		return self.wallets.setdefault(currency, ProjectedWallet())
+
+	def settle(self, amount, currency=None) -> float:
+		"""Draw what credits can cover; the rest is somebody else's problem."""
+		return self.wallet(currency).draw(amount)
+
+	def record_paid(self, amount):
+		"""A settled invoice is what moves a team up the trust ladder."""
+		self.paid_count += 1
+		self.paid_total += frappe.utils.flt(amount)
+
+	def expire_credits(self, on_date):
+		lost = self.wallet().expire(on_date)
+		if lost:
+			self.events.append(
+				{"date": str(on_date), "event": "Credits expired", "amount": lost}
+			)
+		return lost
+
+	def suspend(self, on_date):
+		"""Stop the clock. Accrual ends here — a stopped resource is not billed on."""
+		if self.suspended_on:
+			return
+		self.suspended_on = frappe.utils.getdate(on_date)
+		self.standing = "Suspended"
+		self.events.append({"date": str(on_date), "event": "Suspended"})
+
+	@property
+	def suspended(self) -> bool:
+		return self.suspended_on is not None
+
+
+def seed(team: str, today=None) -> ProjectedState:
+	"""Read the team once. Everything after this is arithmetic.
+
+	Seeded from what is true now — including the paid history the trust ladder is
+	scored on, so a projection starts the team exactly where the real ladder has them.
+	"""
+	today = frappe.utils.getdate(today or frappe.utils.nowdate())
+	profile = frappe.db.get_value(
+		"Billing Profile", team, ["currency", "collection_mode"], as_dict=True
+	) or frappe._dict()
+	currency = profile.currency or "INR"
+
+	wallets = {}
+	for row in credits.get_balances(team):
+		lots = [
+			{"remaining": lot.remaining, "expires_on": lot.expires_on}
+			for lot in credits.credit_lots(team, row.currency)
+			if lot.remaining > 0
+		]
+		wallets[row.currency] = ProjectedWallet(lots)
+	wallets.setdefault(currency, ProjectedWallet())
+
+	autopay = bool(
+		frappe.get_all(
+			"Payment Method",
+			filters={
+				"team": team,
+				"method_type": ["in", ("Card", "UPI Autopay")],
+				"status": "Active",
+			},
+			limit=1,
+		)
+	)
+
+	paid = frappe.get_all(
+		"Invoice",
+		filters={"team": team, "status": "Paid", "invoice_type": "Billable"},
+		fields=["total"],
+	)
+	standings = frappe.get_all("Subscription", filters={"team": team}, pluck="account_standing")
+
+	from central.billing.catalog.entitlements import get_team_caps
+
+	return ProjectedState(
+		team=team,
+		currency=currency,
+		base_cap=frappe.utils.flt(get_team_caps(team).max_spend),
+		wallets=wallets,
+		autopay=autopay,
+		paid_count=len(paid),
+		paid_total=frappe.utils.flt(sum(frappe.utils.flt(p.total) for p in paid)),
+		# The worst standing across the team's subscriptions is the one that decides
+		# what happens next; a team is not "current" because one server still is.
+		standing=_worst(standings),
+	)
+
+
+_STANDING_ORDER = ("Current", "Past Due", "Suspended", "Terminated")
+
+
+def _worst(standings) -> str:
+	present = [s for s in standings if s in _STANDING_ORDER]
+	if not present:
+		return "Current"
+	return max(present, key=_STANDING_ORDER.index)

--- a/central/billing/revenue/credits.py
+++ b/central/billing/revenue/credits.py
@@ -404,8 +404,14 @@ def adjust_credits(
 	return {"ledger_entry": entry.name, "new_balance": new_balance}
 
 
-def get_balance(team: str, currency: str | None = None) -> dict:
+def get_balance(team: str, currency: str | None = None, source=None) -> dict:
 	"""The team's credit balance in one currency — read off that currency's anchor.
+
+	`source` is the projection seam. A projection that has already spent this wallet
+	down over three simulated months must not be answered with today's balance, or the
+	wallet silently refills every month and nobody is ever short. Pass an object with
+	`balance(team, currency)` and the reader defers to it; leave it out — as every
+	production caller does — and nothing changes.
 
 	`currency` defaults to the team's billing currency, so the common caller
 	("what are this team's credits?") gets the balance in the currency the team is
@@ -419,6 +425,8 @@ def get_balance(team: str, currency: str | None = None) -> dict:
 	reconciled by the C2 invariant check, not by disagreeing at read time.
 	"""
 	currency = _resolve_currency(team, currency)
+	if source is not None:
+		return {"balance": frappe.utils.flt(source.balance(team, currency)), "currency": currency}
 	balance = frappe.db.get_value("Credit Wallet", wallet_name(team, currency), "balance")
 	return {"balance": frappe.utils.flt(balance), "currency": currency}
 

--- a/central/billing/tests/test_projection_rollforward.py
+++ b/central/billing/tests/test_projection_rollforward.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Rolling a team forward: what each month leaves behind for the next."""
+
+import frappe
+from central.billing.projection import engine, state
+from central.billing.projection.state import ProjectedWallet
+from central.billing.revenue import credits
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+from central.billing.tests.utils import (
+	add_segment,
+	ensure_team,
+	make_billing_subscription,
+	make_plan,
+)
+
+TEAM = "team-rollforward"
+CLUSTER = "ap-south-1"
+PLAN = "bundle-rollforward"
+TODAY = "2026-08-06"
+
+
+class RollForwardTestBase(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		make_plan(PLAN)
+		self._purge()
+		self.sub = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
+		add_segment(self.sub, "Created", 1000, "2026-01-01 00:00:00")
+		frappe.db.commit()
+
+	def tearDown(self):
+		self._purge()
+
+	def _purge(self):
+		for dt in ("Invoice", "Credit Ledger Entry", "Payment Method"):
+			frappe.db.delete(dt, {"team": TEAM})
+		frappe.db.delete("Credit Wallet", {"team": TEAM})
+		for sub in frappe.get_all("Subscription", {"team": TEAM}, pluck="name"):
+			frappe.db.delete("Subscription Change", {"subscription": sub})
+			frappe.db.delete("Subscription", {"name": sub})
+		frappe.db.delete("Asset", {"team": TEAM})
+		frappe.db.commit()
+
+	def _project(self, months=1, **kw):
+		frappe.db.commit()
+		return engine.project_months(TEAM, "2026-09-01", months=months, today=TODAY, **kw)
+
+
+class TestTheWalletCarries(RollForwardTestBase):
+	def test_credits_are_drawn_down_month_after_month(self):
+		# 2,500 against a 1,000/month bill: two months covered, the third is short.
+		credits.purchase(TEAM, 2500, "INR")
+		out = self._project(months=3)
+
+		months = out["months"]
+		self.assertEqual(months[0]["settlement"]["from_credits"], 1000.0)
+		self.assertEqual(months[1]["settlement"]["from_credits"], 1000.0)
+		self.assertEqual(months[2]["settlement"]["from_credits"], 500.0)
+		self.assertEqual(months[2]["settlement"]["shortfall"], 500.0)
+
+	def test_the_balance_falls_across_the_projection(self):
+		credits.purchase(TEAM, 2500, "INR")
+		out = self._project(months=3)
+		balances = [m["balance_after"] for m in out["months"]]
+		self.assertEqual(balances, [1500.0, 500.0, 0.0])
+		self.assertEqual(out["ends"]["balance"], 0.0)
+
+	def test_the_wallet_does_not_refill_itself(self):
+		# The failure this whole seam exists to prevent: reading today's balance every
+		# month, so the team looks solvent forever.
+		credits.purchase(TEAM, 1000, "INR")
+		out = self._project(months=3)
+		self.assertEqual(out["months"][1]["settlement"]["from_credits"], 0.0)
+		self.assertEqual(out["months"][1]["settlement"]["shortfall"], 1000.0)
+
+
+class TestExpiringCredit(RollForwardTestBase):
+	def test_promotional_credit_dies_on_its_date_even_if_unspent(self):
+		credits.grant_promotional_credits(
+			TEAM, 5000, "INR", note="promo", expires_on="2026-09-30"
+		)
+		out = self._project(months=3)
+
+		# September may spend it right up to the 30th; October opens without it.
+		self.assertEqual(out["months"][0]["settlement"]["from_credits"], 1000.0)
+		self.assertEqual(out["months"][1]["settlement"]["from_credits"], 0.0)
+		self.assertEqual(out["months"][1]["settlement"]["shortfall"], 1000.0)
+		self.assertTrue(any(e["event"] == "Credits expired" for e in out["events"]))
+
+	def test_purchased_credit_survives(self):
+		credits.purchase(TEAM, 5000, "INR")
+		out = self._project(months=3)
+		self.assertEqual(out["months"][2]["settlement"]["from_credits"], 1000.0)
+		self.assertFalse(any(e["event"] == "Credits expired" for e in out["events"]))
+
+
+class TestSuspensionStopsTheClock(RollForwardTestBase):
+	def test_a_team_that_never_pays_is_suspended_and_stops_accruing(self):
+		out = self._project(months=6)  # no credits, no card
+		suspended = [m for m in out["months"] if m["suspended"]]
+
+		self.assertTrue(suspended, "a team with no way to pay should reach suspension")
+		self.assertIsNotNone(out["ends"]["suspended_on"])
+		self.assertEqual(out["ends"]["standing"], "Suspended")
+
+	def test_no_invoice_is_raised_after_suspension(self):
+		out = self._project(months=6)
+		after = [m for m in out["months"] if m["suspended"]]
+		self.assertTrue(all(m["invoice"] is None for m in after))
+
+
+class TestTierPromotion(RollForwardTestBase):
+	def test_settled_invoices_accumulate_into_the_paid_history(self):
+		# Paid history is what the trust ladder scores, so settling months has to move it.
+		credits.purchase(TEAM, 20000, "INR")
+		frappe.db.commit()
+		seeded = state.seed(TEAM, TODAY)
+		self.assertEqual(seeded.paid_count, 0)
+
+		self._project(months=6)
+		rolled = state.seed(TEAM, TODAY)
+		# The projection wrote nothing, so the real history is untouched...
+		self.assertEqual(rolled.paid_count, 0)
+
+		# ...while the projection's own copy advanced with every month it settled.
+		seeded.record_paid(1000)
+		seeded.record_paid(1000)
+		self.assertEqual(seeded.paid_count, 2)
+		self.assertEqual(seeded.paid_total, 2000.0)
+
+	def test_the_projected_cap_never_falls_below_where_the_team_started(self):
+		# Nothing guarantees a ladder prices higher rungs higher. If it does not, climbing
+		# it must not shrink a paying customer's ceiling.
+		credits.purchase(TEAM, 20000, "INR")
+		frappe.db.commit()
+		start_cap = state.seed(TEAM, TODAY).tier_cap(TEAM)
+
+		out = self._project(months=6)
+		self.assertGreaterEqual(out["ends"]["tier_cap"], start_cap)
+
+
+class TestASingleMonthIsUnchanged(RollForwardTestBase):
+	def test_one_month_rolled_matches_the_single_period_projection(self):
+		credits.purchase(TEAM, 5000, "INR")
+		frappe.db.commit()
+		rolled = engine.project_months(TEAM, "2026-09-01", months=1, today=TODAY)
+		single = engine.project(TEAM, "2026-09-01", "2026-09-30", today=TODAY)
+
+		self.assertEqual(
+			rolled["months"][0]["invoice"]["total"], single["invoice"]["total"]
+		)
+		self.assertEqual(
+			rolled["months"][0]["calendar"]["due_on"], single["calendar"]["due_on"]
+		)
+
+	def test_a_team_with_nothing_running_rolls_quietly(self):
+		self._purge()
+		frappe.db.commit()
+		out = engine.project_months(TEAM, "2026-09-01", months=3, today=TODAY)
+		self.assertTrue(all(m["invoice"] is None for m in out["months"]))
+
+
+class TestTheWalletModel(IntegrationTestCase):
+	def test_draws_take_the_soonest_expiring_lot_first(self):
+		# Spending credit that is about to die before credit that never will is what
+		# wastes the least of the customer's money.
+		wallet = ProjectedWallet(
+			[
+				{"remaining": 100.0, "expires_on": "2026-09-30"},
+				{"remaining": 100.0, "expires_on": None},
+			]
+		)
+		wallet.draw(120)
+		self.assertEqual(wallet.balance, 80.0)
+		self.assertEqual(wallet.lots[0]["expires_on"], None)
+
+	def test_a_draw_beyond_the_balance_takes_what_is_there(self):
+		wallet = ProjectedWallet([{"remaining": 40.0, "expires_on": None}])
+		self.assertEqual(wallet.draw(100), 40.0)
+		self.assertEqual(wallet.balance, 0.0)
+
+	def test_expiry_removes_only_what_is_past_its_date(self):
+		wallet = ProjectedWallet(
+			[
+				{"remaining": 60.0, "expires_on": "2026-09-30"},
+				{"remaining": 40.0, "expires_on": "2026-12-31"},
+			]
+		)
+		self.assertEqual(wallet.expire("2026-10-01"), 60.0)
+		self.assertEqual(wallet.balance, 40.0)
+
+	def test_new_credit_sorts_into_the_queue_by_expiry(self):
+		wallet = ProjectedWallet([{"remaining": 50.0, "expires_on": None}])
+		wallet.credit(25, expires_on="2026-09-30")
+		self.assertEqual(wallet.lots[0]["expires_on"], "2026-09-30")

--- a/central/billing/tests/test_projection_state_seam.py
+++ b/central/billing/tests/test_projection_state_seam.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""The evolving-state seam.
+
+A decision function can be free of writes and still be un-projectable, because it
+reads *now*. These readers take an optional source so a projection can answer them
+from its own roll-forward; every production caller leaves it out and gets the
+database, unchanged.
+"""
+
+import frappe
+from central.billing.payments import settlement
+from central.billing.revenue import credits
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+from central.billing.tests.utils import ensure_team, set_team_tier
+
+TEAM = "team-state-seam"
+
+
+class FakeState:
+	"""Stands in for a projection's roll-forward."""
+
+	def __init__(self, balance=0.0, has_autopay=False, tier_cap=0.0):
+		self._balance = balance
+		self._autopay = has_autopay
+		self._cap = tier_cap
+		self.asked = []
+
+	def balance(self, team, currency):
+		self.asked.append(("balance", team, currency))
+		return self._balance
+
+	def has_autopay(self, team):
+		return self._autopay
+
+	def tier_cap(self, team):
+		return self._cap
+
+
+class SeamTestBase(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		self._purge()
+		set_team_tier(TEAM, level="t0", max_spend=5000)
+		frappe.db.commit()
+
+	def tearDown(self):
+		self._purge()
+
+	def _purge(self):
+		frappe.db.delete("Credit Ledger Entry", {"team": TEAM})
+		frappe.db.delete("Credit Wallet", {"team": TEAM})
+		frappe.db.delete("Payment Method", {"team": TEAM})
+		frappe.db.delete("Billing Profile", {"team": TEAM})
+		frappe.db.commit()
+
+
+class TestProductionBehaviourIsUnchanged(SeamTestBase):
+	def test_the_balance_still_comes_off_the_wallet_anchor(self):
+		credits.purchase(TEAM, 700, "INR")
+		frappe.db.commit()
+		self.assertEqual(credits.get_balance(TEAM)["balance"], 700.0)
+
+	def test_the_cap_still_comes_off_the_tier(self):
+		self.assertEqual(settlement.effective_spend_cap(TEAM), 5000.0)
+
+	def test_settlement_sources_still_read_live(self):
+		credits.purchase(TEAM, 10, "INR")
+		frappe.db.commit()
+		sources = settlement.settlement_sources(TEAM)
+		self.assertTrue(sources["has_credits"])
+		self.assertTrue(sources["credits_only"])
+
+
+class TestASourceIsConsultedInstead(SeamTestBase):
+	def test_the_wallet_is_answered_by_the_projection(self):
+		credits.purchase(TEAM, 700, "INR")
+		frappe.db.commit()
+		state = FakeState(balance=42.0)
+		self.assertEqual(credits.get_balance(TEAM, source=state)["balance"], 42.0)
+		self.assertTrue(state.asked)
+
+	def test_the_currency_is_still_resolved_from_the_profile(self):
+		# Currency is reference data, not evolving state — it keeps coming off the profile.
+		credits.purchase(TEAM, 1, "INR")
+		frappe.db.commit()
+		self.assertEqual(credits.get_balance(TEAM, source=FakeState())["currency"], "INR")
+
+	def test_a_projected_wallet_drives_the_credits_only_cap(self):
+		# The whole point: month four must draw against what the projection has left,
+		# not against the balance the team happens to hold today.
+		credits.purchase(TEAM, 5000, "INR")
+		frappe.db.commit()
+		state = FakeState(balance=120.0, has_autopay=False, tier_cap=5000.0)
+		self.assertEqual(settlement.effective_spend_cap(TEAM, source=state), 120.0)
+
+	def test_an_autopay_team_follows_the_projected_tier_cap(self):
+		state = FakeState(balance=0.0, has_autopay=True, tier_cap=9000.0)
+		self.assertEqual(settlement.effective_spend_cap(TEAM, source=state), 9000.0)
+
+	def test_spend_acceptance_uses_the_projected_state(self):
+		state = FakeState(balance=100.0, has_autopay=False, tier_cap=5000.0)
+		self.assertTrue(settlement.can_accept_spend(TEAM, 90, source=state))
+		self.assertFalse(settlement.can_accept_spend(TEAM, 110, source=state))
+
+	def test_the_forecast_compares_against_the_projected_wallet(self):
+		out = settlement.credit_forecast(TEAM, 90, notify=False, source=FakeState(balance=100.0))
+		self.assertEqual(out["balance"], 100.0)
+		self.assertEqual(out["shortfall"], 0.0)
+
+
+class TestReferenceDataIsNotVirtualised(SeamTestBase):
+	def test_tax_resolution_takes_no_source(self):
+		# Projecting forward does not change a team's tax profile, so it keeps reading
+		# live. Only what the projection itself changes needs the seam.
+		import inspect
+
+		from central.billing.revenue.tax import resolve_tax
+
+		self.assertNotIn("source", inspect.signature(resolve_tax).parameters)
+
+	def test_commitment_resolution_takes_no_source(self):
+		import inspect
+
+		from central.billing.catalog.commitments import resolve_commitment
+
+		self.assertNotIn("source", inspect.signature(resolve_commitment).parameters)


### PR DESCRIPTION
The simulator could price one period. It could not answer the question ops actually has, which is not "what does September cost" but "when does this team run out".

Six months is not six independent projections. Month two is downstream of month one: the wallet was drawn, credit expired, a suspension stopped accrual. Answering each month from the live database refills the wallet every time and reports a team as comfortable right up to the point it is cut off.

```mermaid
flowchart LR
    SEED["Seed once at t0<br/>wallet · methods · paid history · standing"]
    SEED --> M1["Month 1<br/>price → settle → escalate"]
    M1 -->|balance, paid history, standing| M2["Month 2"]
    M2 -->|carried| M3["Month 3"]
    M3 -->|credits run dry| M4["Month 4<br/>shortfall"]
    M4 -->|ladder runs| SUSP["Suspended<br/>accrual stops"]

    style SEED fill:#edf6fd,stroke:#0070cc
    style SUSP fill:#fff0f0,stroke:#b52a2a
```
<img width="1440" height="900" alt="5-rollforward" src="https://github.com/user-attachments/assets/fb098abb-3624-441d-8d01-81fe744872ae" />


Credits cover three months, run dry in the fourth, suspend, and the months after it correctly bill nothing.

## The seam

A decision function can be free of writes and still be un-projectable, because it reads *now*. `credits.get_balance`, `settlement_sources`, `eeffective_spend_cap`, `can_accept_spend` and `credit_forecast` now take an optional `source`. Production leaves it out and reads the database exactly as before.

Tax and commitment resolution deliberately take no sourcenot change them. The test for which side a datum falls on is one question, does my projection change it?

## What the state carries

The wallet is held as the **grants it came from**, not one number, because promotional credit expires and purchased credit does not — so a wallet comfortably in the black today can be empty next month without anyone spending a penny. Draws take the soonest-expiring lot first, the same order the real ledger settles in.

Expiry is swept at the **start** of a month, not the end: a grant dated the 30th is the customer's to spend right up to the 30th.

The projected trust-tier cap has a **floor** at whatever the team holds when the projection starts. Nothing guarantees a ladder prices higher rungs higher, and where it does not, climbing it would otherwise shrink a paying customer's ceiling as reward for paying.