### PR TITLE
feat(admin): Show how each line reached its amount

### DIFF
--- a/central/billing/page/billing_simulator/billing_simulator.js
+++ b/central/billing/page/billing_simulator/billing_simulator.js
@@ -207,12 +207,17 @@ class BillingSimulator {
 		const money = (v) => format_currency(v, data.currency);
 		const rows = invoice.lines
 			.map(
-				(line) => `
-			<tr>
-				<td>${frappe.utils.escape_html(line.plan || line.resource_type || "—")}</td>
+				(line, i) => `
+			<tr class="bs-line" data-line="${i}">
+				<td>${line.derivation ? '<span class="bs-caret">▸</span>' : ""}${frappe.utils.escape_html(
+					line.plan || line.resource_type || "—"
+				)}</td>
 				<td class="bs-muted">${frappe.utils.escape_html(describe_line(line))}</td>
 				<td class="bs-right">${money(line.amount)}</td>
 				<td>${basis_tag(line)}</td>
+			</tr>
+			<tr class="bs-why" data-why="${i}" hidden>
+				<td colspan="4">${derivation_html(line, money)}</td>
 			</tr>`
 			)
 			.join("");
@@ -236,7 +241,7 @@ class BillingSimulator {
 			  )}</span></div>`
 			: "";
 
-		return $(`
+		const $card = $(`
 			<div class="bs-card">
 				<div class="bs-card-head">
 					<span class="bs-card-title">${__("Projected invoice")}</span>
@@ -260,6 +265,16 @@ class BillingSimulator {
 					)}</span></div>
 				</div>
 			</div>`);
+
+		$card.on("click", ".bs-line", function () {
+			const i = $(this).data("line");
+			const $why = $card.find(`[data-why="${i}"]`);
+			if (!$why.length) return;
+			const open = !$why.prop("hidden");
+			$why.prop("hidden", open);
+			$(this).find(".bs-caret").text(open ? "▸" : "▾");
+		});
+		return $card;
 	}
 
 	// ---- what the state already decides ------------------------------------
@@ -402,6 +417,20 @@ class BillingSimulator {
 			.bs-finding-summary { font-weight: 500; color: var(--heading-color); }
 			.bs-dim { opacity: 0.35; }
 			.bs-short { color: var(--red-600, #cc2929); font-weight: 500; }
+			.bs-line { cursor: pointer; }
+			.bs-line:hover { background: var(--subtle-accent); }
+			.bs-caret { display: inline-block; width: 14px; color: var(--text-muted);
+				font-size: 10px; }
+			.bs-why td { background: var(--subtle-accent); padding: 12px 13px 12px 27px; }
+			.bs-why-why { color: var(--text-light); margin-bottom: 8px;
+				font-size: var(--text-sm, 12px); }
+			.bs-why-sum { font-family: var(--font-stack-mono, ui-monospace, monospace);
+				font-size: var(--text-sm, 12px); color: var(--heading-color);
+				margin-bottom: 10px; }
+			.bs-why-tbl { width: 100%; border-collapse: collapse; font-size: var(--text-sm, 12px); }
+			.bs-why-tbl th { text-align: left; font-weight: 500; color: var(--text-muted);
+				padding: 4px 10px 4px 0; }
+			.bs-why-tbl td { padding: 3px 10px 3px 0; color: var(--text-color); }
 			.bs-stopped td { color: var(--text-muted); font-style: italic; }
 			.bs-figure { padding: 14px 13px; overflow-x: auto; }
 			.bs-figure svg { display: block; min-width: 620px; width: 100%; height: auto; }
@@ -417,6 +446,64 @@ function describe_line(line) {
 	if (line.hours) return __("{0} hours", [line.hours]);
 	if (line.quantity) return `${line.quantity} ${line.unit || ""}`.trim();
 	return "";
+}
+
+// The drill: the same numbers the engine used, laid out so the arithmetic is
+// checkable by eye. Nothing here recomputes anything — it renders what the line
+// builder recorded while it was working the amount out.
+function derivation_html(line, money) {
+	const d = line.derivation;
+	if (!d) return "";
+
+	const rows = [];
+	const add = (label, value) =>
+		value !== undefined && value !== null && value !== "" &&
+		rows.push(`<tr><th>${label}</th><td>${value}</td></tr>`);
+
+	if (d.mode === "Daily" || d.mode === "Hourly") {
+		add(__("Config ran"), `${d.segment_from} → ${d.segment_to}`);
+		add(__("Locked rate"), money(d.locked_rate));
+		if (d.mode === "Daily") {
+			add(__("Days billed"), `${d.days} ${__("of")} ${d.day_units}`);
+		} else {
+			add(__("Hours on this date"), `${d.hours} ${__("of")} ${d.hour_units}`);
+			add(__("Date"), d.charge_date);
+		}
+	} else if (d.mode === "Metered") {
+		add(__("Measured"), `${d.measured_quantity} ${d.unit || ""}`.trim());
+		add(__("Allowance"), `${d.allowance} ${d.unit || ""}`.trim());
+		add(__("Billable"), `${d.billable_quantity} ${d.unit || ""}`.trim());
+		add(__("Rate"), `${money(d.rate)} · ${d.rate_source}`);
+	} else if (d.mode === "Estimated") {
+		add(__("Window"), d.window_from ? `${d.window_from} → ${d.window_to}` : null);
+		add(__("Months averaged"), d.months);
+		add(__("Observed over the window"), d.observed_total ? money(d.observed_total) : null);
+		add(__("Elapsed"), d.elapsed_days ? `${d.elapsed_days} ${__("of")} ${d.period_days}` : null);
+	}
+
+	// A date billed hourly is the confusing one, so name every config that shared it.
+	let shared = "";
+	if (d.configs_on_this_date && d.configs_on_this_date.length) {
+		const items = d.configs_on_this_date
+			.map(
+				(c) =>
+					`<tr><td>${c.from} → ${c.to}</td><td>${money(c.rate)}</td><td>${
+						c.held_under_24h ? __("held under 24h") : ""
+					}</td></tr>`
+			)
+			.join("");
+		shared = `<table class="bs-why-tbl">
+			<thead><tr><th>${__("Configs sharing this date")}</th><th>${__("Rate")}</th><th></th></tr></thead>
+			<tbody>${items}</tbody></table>`;
+	}
+
+	return `
+		<div class="bs-why-why">${frappe.utils.escape_html(d.why || "")}</div>
+		<div class="bs-why-sum">${frappe.utils.escape_html(d.arithmetic || "")} = ${money(
+			line.amount
+		)}</div>
+		<table class="bs-why-tbl">${rows.join("")}</table>
+		${shared}`;
 }
 
 function basis_tag(line) {

--- a/central/billing/projection/engine.py
+++ b/central/billing/projection/engine.py
@@ -53,7 +53,7 @@ def _project(
 	end = frappe.utils.getdate(period_end)
 
 	metered = estimate.metered_lines(team, team_clusters(team), start, end, today=today)
-	rated = rate_team_period(team, start, end, metered=metered)
+	rated = rate_team_period(team, start, end, metered=metered, explain=True)
 
 	invoice = _invoice(rated)
 	currency = frappe.db.get_value("Billing Profile", team, "currency")
@@ -260,7 +260,7 @@ def _roll_one(team, carried, period_start, period_end, today, mode, assume) -> d
 		}
 
 	metered = estimate.metered_lines(team, team_clusters(team), period_start, period_end, today=today)
-	rated = rate_team_period(team, period_start, period_end, metered=metered)
+	rated = rate_team_period(team, period_start, period_end, metered=metered, explain=True)
 	invoice = _invoice(rated)
 	calendar = _calendar(period_end, today)
 

--- a/central/billing/projection/estimate.py
+++ b/central/billing/projection/estimate.py
@@ -42,10 +42,12 @@ def metered_lines(team: str, clusters, period_start, period_end, today=None) -> 
 	end = frappe.utils.getdate(period_end)
 
 	if end < today:
-		return mark(metered_line_items_for_clusters(team, clusters, start, end), MEASURED)
+		return mark(
+			metered_line_items_for_clusters(team, clusters, start, end, explain=True), MEASURED
+		)
 
 	if start <= today:
-		landed = metered_line_items_for_clusters(team, clusters, start, end)
+		landed = metered_line_items_for_clusters(team, clusters, start, end, explain=True)
 		elapsed = (today - start).days + 1
 		total = (end - start).days + 1
 		return _scaled(landed, elapsed, total)
@@ -70,6 +72,15 @@ def _scaled(lines: list[dict], elapsed: int, total: int) -> list[dict]:
 		projected["amount"] = frappe.utils.flt(line.get("amount") * factor, 2)
 		projected["basis"] = ESTIMATED
 		projected["estimated_from"] = f"run rate over {elapsed} of {total} days"
+		projected["derivation"] = {
+			"mode": "Estimated",
+			"why": "the month is part elapsed, so what has landed is projected across it",
+			"observed_amount": frappe.utils.flt(line.get("amount"), 2),
+			"elapsed_days": elapsed,
+			"period_days": total,
+			"arithmetic": f"{frappe.utils.flt(line.get('amount'), 2)} × {total} ÷ {elapsed}",
+			"measured_basis": line.get("derivation"),
+		}
 		out.append(projected)
 	return out
 
@@ -90,24 +101,35 @@ def _from_trailing(team: str, clusters, period_start, months: int = TRAILING_MON
 	customer was actually billed for.
 	"""
 	start, end = _window(period_start, months)
-	history = metered_line_items_for_clusters(team, clusters, start, end)
+	history = metered_line_items_for_clusters(team, clusters, start, end, explain=True)
 	if not history:
 		# No history is not zero usage — it is silence. Projecting a zero line would
 		# assert something we do not know, so nothing is projected for this resource.
 		return []
 
 	merged: dict = {}
+	observed: dict = {}
 	for line in history:
 		key = tuple(line.get(f) for f in _KEY)
 		agg = merged.setdefault(key, {**line, "quantity": 0.0, "amount": 0.0})
 		agg["quantity"] += frappe.utils.flt(line.get("quantity"))
 		agg["amount"] += frappe.utils.flt(line.get("amount"))
+		observed[key] = observed.get(key, 0.0) + frappe.utils.flt(line.get("amount"))
 
 	out = []
-	for line in merged.values():
+	for key, line in merged.items():
 		line["quantity"] = frappe.utils.flt(line["quantity"] / months, 4)
 		line["amount"] = frappe.utils.flt(line["amount"] / months, 2)
 		line["basis"] = ESTIMATED
 		line["estimated_from"] = f"{months}-month average to {end}"
+		line["derivation"] = {
+			"mode": "Estimated",
+			"why": "the period has not started, so usage is inferred from what did happen",
+			"window_from": str(start),
+			"window_to": str(end),
+			"months": months,
+			"observed_total": frappe.utils.flt(observed[key], 2),
+			"arithmetic": f"{frappe.utils.flt(observed[key], 2)} ÷ {months}",
+		}
 		out.append(line)
 	return out

--- a/central/billing/revenue/invoicing/generate.py
+++ b/central/billing/revenue/invoicing/generate.py
@@ -190,7 +190,7 @@ def _rate(team: str, lines: list[dict], period_start, period_end, subscription: 
 	)
 
 
-def rate_subscription_period(subscription: str, period_start, period_end):
+def rate_subscription_period(subscription: str, period_start, period_end, explain: bool = False):
 	"""What one subscription's cluster would bill the team for the period. Reads only.
 
 	Returns None when there was no billable runtime.
@@ -199,8 +199,8 @@ def rate_subscription_period(subscription: str, period_start, period_end):
 
 	sub = frappe.get_doc("Subscription", subscription)
 	cluster = frappe.db.get_value("Asset", sub.asset_id, "cluster") if sub.asset_id else None
-	lines = compute_line_items(sub.team, cluster, period_start, period_end)
-	lines += metered_line_items(sub.team, cluster, period_start, period_end)
+	lines = compute_line_items(sub.team, cluster, period_start, period_end, explain=explain)
+	lines += metered_line_items(sub.team, cluster, period_start, period_end, explain=explain)
 	if not lines:
 		return None
 	return _rate(sub.team, lines, period_start, period_end, subscription)
@@ -220,6 +220,7 @@ def rate_team_period(
 	period_end,
 	subscription: str | None = None,
 	metered: list[dict] | None = None,
+	explain: bool = False,
 ):
 	"""What the team's whole book would bill for the period, across every cluster.
 	Reads only.
@@ -237,10 +238,10 @@ def rate_team_period(
 	# Read the team once, not once per cluster: team_line_items pulls every
 	# subscription's fixed lines in one pass, and the metered rollups for all the
 	# team's clusters come back in a single query.
-	lines = team_line_items(team, period_start, period_end)
+	lines = team_line_items(team, period_start, period_end, explain=explain)
 	if metered is None:
 		lines += metered_line_items_for_clusters(
-			team, team_clusters(team), period_start, period_end
+			team, team_clusters(team), period_start, period_end, explain=explain
 		)
 	else:
 		lines += list(metered)

--- a/central/billing/revenue/invoicing/lines.py
+++ b/central/billing/revenue/invoicing/lines.py
@@ -38,7 +38,9 @@ def _dates_touched(start_dt: datetime, end_dt: datetime) -> list:
 	return out
 
 
-def compute_line_items(team: str, cluster: str, period_start, period_end) -> list[dict]:
+def compute_line_items(
+	team: str, cluster: str, period_start, period_end, explain: bool = False
+) -> list[dict]:
 	"""Time-weighted fixed line items for one (team, cluster) over the billing month.
 
 	Each `Created`/`Plan Changed` Subscription-Change row opens a segment at its
@@ -66,11 +68,13 @@ def compute_line_items(team: str, cluster: str, period_start, period_end) -> lis
 	bounds = _period_bounds(period_start, period_end)
 	lines = []
 	for sub in subscriptions:
-		lines += _subscription_lines(sub, cluster, changes_by_sub.get(sub.name, []), bounds)
+		lines += _subscription_lines(sub, cluster, changes_by_sub.get(sub.name, []), bounds, explain)
 	return lines
 
 
-def team_line_items(team: str, period_start, period_end) -> list[dict]:
+def team_line_items(
+	team: str, period_start, period_end, explain: bool = False
+) -> list[dict]:
 	"""Every fixed line item for a team across all the clusters it runs in, from ONE
 	read of its subscriptions, their asset clusters and their changes.
 
@@ -89,7 +93,7 @@ def team_line_items(team: str, period_start, period_end) -> list[dict]:
 		cluster = clusters.get(sub.asset_id)
 		if not cluster:
 			continue  # no live asset cluster — nothing to bill this subscription against
-		lines += _subscription_lines(sub, cluster, changes_by_sub.get(sub.name, []), bounds)
+		lines += _subscription_lines(sub, cluster, changes_by_sub.get(sub.name, []), bounds, explain)
 	return lines
 
 
@@ -109,7 +113,7 @@ def _period_bounds(period_start, period_end):
 	)
 
 
-def _subscription_lines(sub, cluster: str, changes: list, b) -> list[dict]:
+def _subscription_lines(sub, cluster: str, changes: list, b, explain: bool = False) -> list[dict]:
 	"""The daily/hourly fixed lines for one subscription in one cluster.
 
 	Splits the subscription's rate-snapshot changes into billable segments, marks the
@@ -159,14 +163,14 @@ def _subscription_lines(sub, cluster: str, changes: list, b) -> list[dict]:
 		# mid-day resize still sends the whole transition day to one plan.
 		d0 = max(s["start"].date(), b.ps)
 		d1 = min(s["end"].date(), b.pe + timedelta(days=1))  # exclusive
-		days = 0
+		billed_dates = []
 		d = d0
 		while d < d1:
 			if d not in churn_dates:
-				days += 1
+				billed_dates.append(d)
 			d += timedelta(days=1)
-		if days:
-			lines.append(_daily_line(s, days, b.day_units))
+		if billed_dates:
+			lines.append(_daily_line(s, len(billed_dates), b.day_units, explain, billed_dates))
 
 		# Hourly pass — this segment's real hours on each churn date it touches.
 		for cd in _dates_touched(s["start"], s["end"]):
@@ -176,7 +180,20 @@ def _subscription_lines(sub, cluster: str, changes: list, b) -> list[dict]:
 			day_end = min(s["end"], datetime.combine(cd + timedelta(days=1), time.min))
 			hours = (day_end - day_start).total_seconds() / 3600.0
 			if hours > 0:
-				lines.append(_hourly_line(s, hours, b.hour_units, cd))
+				# Which configs shared this date is the whole explanation for why it went
+				# hourly, so carry them rather than leaving the reader to infer it.
+				touching = [
+					{
+						"from": str(other["start"]),
+						"to": str(other["end"]),
+						"rate": other["rate"],
+						"plan": other["plan"],
+						"held_under_24h": other["churn"],
+					}
+					for other in segs
+					if cd in _dates_touched(other["start"], other["end"])
+				]
+				lines.append(_hourly_line(s, hours, b.hour_units, cd, explain, touching))
 	return lines
 
 
@@ -204,8 +221,10 @@ def _changes_by_subscription(subscription_names: list[str]) -> dict:
 	return grouped
 
 
-def _daily_line(seg: dict, days: int, day_units: int) -> dict:
-	return {
+def _daily_line(
+	seg: dict, days: int, day_units: int, explain: bool = False, billed_dates=None
+) -> dict:
+	line = {
 		"subscription_resource": seg["asset"],
 		"plan": seg["plan"],
 		"cluster": seg["cluster"],
@@ -217,10 +236,25 @@ def _daily_line(seg: dict, days: int, day_units: int) -> dict:
 		"hours": None,
 		"amount": frappe.utils.flt(days * seg["rate"] / day_units, 2),
 	}
+	if explain:
+		line["derivation"] = {
+			"mode": "Daily",
+			"why": "the config was held for a day or more, so whole days are billed",
+			"segment_from": str(seg["start"]),
+			"segment_to": str(seg["end"]),
+			"locked_rate": seg["rate"],
+			"days": days,
+			"day_units": day_units,
+			"dates": [str(d) for d in (billed_dates or [])],
+			"arithmetic": f"{days} ÷ {day_units} × {seg['rate']}",
+		}
+	return line
 
 
-def _hourly_line(seg: dict, hours: float, hour_units: int, charge_date) -> dict:
-	return {
+def _hourly_line(
+	seg: dict, hours: float, hour_units: int, charge_date, explain: bool = False, touching=None
+) -> dict:
+	line = {
 		"subscription_resource": seg["asset"],
 		"plan": seg["plan"],
 		"cluster": seg["cluster"],
@@ -233,3 +267,21 @@ def _hourly_line(seg: dict, hours: float, hour_units: int, charge_date) -> dict:
 		"charge_date": charge_date,
 		"amount": frappe.utils.flt(hours * seg["rate"] / hour_units, 2),
 	}
+	if explain:
+		line["derivation"] = {
+			"mode": "Hourly",
+			"why": (
+				"a config on this date was held for less than 24 hours, so the whole "
+				"date bills by the hour"
+			),
+			"charge_date": str(charge_date),
+			"segment_from": str(seg["start"]),
+			"segment_to": str(seg["end"]),
+			"locked_rate": seg["rate"],
+			"hours": frappe.utils.flt(hours, 2),
+			"hour_units": hour_units,
+			"dates": [str(charge_date)],
+			"configs_on_this_date": touching or [],
+			"arithmetic": f"{frappe.utils.flt(hours, 2)} ÷ {hour_units} × {seg['rate']}",
+		}
+	return line

--- a/central/billing/revenue/metering.py
+++ b/central/billing/revenue/metering.py
@@ -305,7 +305,9 @@ def _insert_rollup(meter: dict, terms: dict, qty: float, seq: int, key: str) -> 
 	).insert(ignore_permissions=True)
 
 
-def metered_line_items(team: str, cluster: str, period_start, period_end) -> list[dict]:
+def metered_line_items(
+	team: str, cluster: str, period_start, period_end, explain: bool = False
+) -> list[dict]:
 	"""Metered line items for one (team, cluster) over the billing month.
 
 	One line per rollup whose period falls in the billing month:
@@ -313,10 +315,12 @@ def metered_line_items(team: str, cluster: str, period_start, period_end) -> lis
 	within the allowance contributes no line. Single-cluster entry point — the monthly
 	run bills a whole team at once via `metered_line_items_for_clusters`.
 	"""
-	return _metered_lines(team, [cluster], period_start, period_end)
+	return _metered_lines(team, [cluster], period_start, period_end, explain)
 
 
-def metered_line_items_for_clusters(team: str, clusters, period_start, period_end) -> list[dict]:
+def metered_line_items_for_clusters(
+	team: str, clusters, period_start, period_end, explain: bool = False
+) -> list[dict]:
 	"""Metered line items for a team across several clusters, from ONE rollup query.
 
 	The monthly run consolidates a team's clusters into a single invoice; scanning
@@ -324,10 +328,12 @@ def metered_line_items_for_clusters(team: str, clusters, period_start, period_en
 	N+1. This fetches every cluster's rollups in one query and resolves each metered
 	family once. The billed set is exactly the per-cluster union.
 	"""
-	return _metered_lines(team, list(clusters), period_start, period_end)
+	return _metered_lines(team, list(clusters), period_start, period_end, explain)
 
 
-def _metered_lines(team: str, clusters: list, period_start, period_end) -> list[dict]:
+def _metered_lines(
+	team: str, clusters: list, period_start, period_end, explain: bool = False
+) -> list[dict]:
 	"""One line per overage rollup for `team` in any of `clusters` (see the two public
 	wrappers). The rollup carries its own cluster, so a multi-cluster run tags each line
 	correctly and prices Live plans against the rollup's cluster."""
@@ -424,19 +430,41 @@ def _metered_lines(team: str, clusters: list, period_start, period_end) -> list[
 			continue
 
 		amount = frappe.utils.flt(billable_qty * rate, 2)
-		lines.append(
-			{
-				"subscription_resource": r.resource_id,
-				"plan": None,
-				"cluster": r.cluster,
-				"resource_type": r.resource_type,
+		line = {
+			"subscription_resource": r.resource_id,
+			"plan": None,
+			"cluster": r.cluster,
+			"resource_type": r.resource_type,
+			"unit": r.unit,
+			"quantity": billable_qty,
+			"rate": rate,
+			"days": 0,
+			"amount": amount,
+		}
+		if explain:
+			live = bool(plan and plan.pricing_mode == "Live")
+			line["derivation"] = {
+				"mode": "Metered",
+				"why": (
+					"only usage past the allowance is billed"
+					if allowance
+					else "this family carries no allowance, so every unit is billed"
+				),
+				"measured_quantity": frappe.utils.flt(r.quantity),
+				"allowance": frappe.utils.flt(allowance),
+				"billable_quantity": billable_qty,
 				"unit": r.unit,
-				"quantity": billable_qty,
 				"rate": rate,
-				"days": 0,
-				"amount": amount,
+				# Where the rate came from matters: a live-priced family follows today's
+				# catalog, a grandfathered one is held at the terms locked when the usage
+				# was ingested.
+				"rate_source": "current catalog rate" if live else "locked at ingest",
+				"arithmetic": (
+					f"max(0, {frappe.utils.flt(r.quantity)} − {frappe.utils.flt(allowance)})"
+					f" × {rate}"
+				),
 			}
-		)
+		lines.append(line)
 
 	if unpriced:
 		frappe.throw(

--- a/central/billing/tests/test_projection_derivation.py
+++ b/central/billing/tests/test_projection_derivation.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Why a line is the amount it is.
+
+The derivation has to come from the computation that produced the amount, not from a
+second pass that re-derives it — a second pass is just a parallel model with a shorter
+life expectancy. So the line builders emit it, and only when asked.
+"""
+
+import frappe
+from central.billing.projection import engine
+from central.billing.revenue.invoicing.lines import compute_line_items
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+from central.billing.tests.utils import (
+	add_segment,
+	ensure_team,
+	make_billing_subscription,
+	make_metered_plan,
+	make_plan,
+)
+
+TEAM = "team-derivation"
+CLUSTER = "ap-south-1"
+PLAN = "bundle-derivation"
+JUNE = ("2026-06-01", "2026-06-30")
+
+
+class DerivationTestBase(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		make_plan(PLAN, includes=[{"resource_type": "Transfer", "quantity": 100, "unit": "GB"}])
+		make_metered_plan(
+			"meter-transfer-derivation",
+			resource_type="Transfer",
+			rates=[{"cluster": "", "currency": "INR", "rate": 0.5}],
+		)
+		self._purge()
+		self.sub = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
+		frappe.db.commit()
+
+	def tearDown(self):
+		self._purge()
+
+	def _purge(self):
+		for dt in ("Invoice", "Usage Rollup"):
+			frappe.db.delete(dt, {"team": TEAM})
+		for sub in frappe.get_all("Subscription", {"team": TEAM}, pluck="name"):
+			frappe.db.delete("Subscription Change", {"subscription": sub})
+			frappe.db.delete("Subscription", {"name": sub})
+		frappe.db.delete("Asset", {"team": TEAM})
+		frappe.db.commit()
+
+	def _lines(self, explain=True):
+		return compute_line_items(TEAM, CLUSTER, *JUNE, explain=explain)
+
+
+class TestItIsOptIn(DerivationTestBase):
+	def test_the_run_gets_exactly_what_it_always_got(self):
+		# The billing run must not start carrying an explanation into Invoice Line Item.
+		add_segment(self.sub, "Created", 3000, "2026-06-01 00:00:00")
+		self.assertTrue(all("derivation" not in line for line in self._lines(explain=False)))
+
+	def test_asking_changes_no_amount(self):
+		add_segment(self.sub, "Created", 3000, "2026-06-01 00:00:00")
+		plain = [li["amount"] for li in self._lines(explain=False)]
+		explained = [li["amount"] for li in self._lines(explain=True)]
+		self.assertEqual(plain, explained)
+
+
+class TestDailyLines(DerivationTestBase):
+	def test_a_stable_month_shows_its_arithmetic(self):
+		add_segment(self.sub, "Created", 3000, "2026-06-01 00:00:00")
+		line = self._lines()[0]
+		d = line["derivation"]
+
+		self.assertEqual(d["mode"], "Daily")
+		self.assertEqual(d["days"], 30)
+		self.assertEqual(d["day_units"], 30)
+		self.assertEqual(d["locked_rate"], 3000.0)
+		self.assertEqual(d["arithmetic"], "30 ÷ 30 × 3000.0")
+		self.assertEqual(line["amount"], 3000.0)
+
+	def test_the_dates_it_billed_are_named(self):
+		add_segment(self.sub, "Created", 3000, "2026-06-01 00:00:00")
+		d = self._lines()[0]["derivation"]
+		self.assertEqual(len(d["dates"]), 30)
+		self.assertEqual(d["dates"][0], "2026-06-01")
+		self.assertEqual(d["dates"][-1], "2026-06-30")
+
+	def test_a_mid_month_change_splits_into_two_explained_segments(self):
+		add_segment(self.sub, "Created", 3000, "2026-06-01 00:00:00")
+		add_segment(self.sub, "Plan Changed", 6000, "2026-06-16 00:00:00")
+		lines = sorted(self._lines(), key=lambda li: li["derivation"]["segment_from"])
+
+		self.assertEqual([li["derivation"]["days"] for li in lines], [15, 15])
+		self.assertEqual([li["derivation"]["locked_rate"] for li in lines], [3000.0, 6000.0])
+
+
+class TestChurnDates(DerivationTestBase):
+	def setUp(self):
+		super().setUp()
+		# 2000 all month, bumped to 4000 for nine hours on the 15th.
+		add_segment(self.sub, "Created", 2000, "2026-06-01 00:00:00")
+		add_segment(self.sub, "Plan Changed", 4000, "2026-06-15 09:00:00")
+		add_segment(self.sub, "Plan Changed", 2000, "2026-06-15 18:00:00")
+
+	def test_an_hourly_line_says_why_the_date_went_hourly(self):
+		hourly = [li for li in self._lines() if li["unit"] == "hour"]
+		self.assertTrue(hourly)
+		why = hourly[0]["derivation"]["why"]
+		self.assertIn("less than 24 hours", why)
+
+	def test_it_names_every_config_that_shared_the_date(self):
+		# This is the answer to "why is my bill itemised by the hour on the 15th".
+		hourly = [li for li in self._lines() if li["unit"] == "hour"]
+		configs = hourly[0]["derivation"]["configs_on_this_date"]
+		self.assertEqual(len(configs), 3)
+		self.assertTrue(any(c["held_under_24h"] for c in configs))
+
+	def test_the_two_passes_partition_the_month_without_overlap(self):
+		# Daily and hourly must tile the period exactly: no date billed twice, none
+		# missed. This is the property that keeps the total exact.
+		lines = self._lines()
+		daily_dates = [d for li in lines if li["unit"] == "day" for d in li["derivation"]["dates"]]
+		hourly_dates = {
+			d for li in lines if li["unit"] == "hour" for d in li["derivation"]["dates"]
+		}
+
+		self.assertEqual(len(daily_dates), len(set(daily_dates)), "a date was billed twice daily")
+		self.assertFalse(set(daily_dates) & hourly_dates, "a date was billed daily and hourly")
+		self.assertEqual(len(set(daily_dates) | hourly_dates), 30, "the month was not covered")
+
+	def test_the_hourly_arithmetic_is_shown_against_the_hour_denominator(self):
+		hourly = [li for li in self._lines() if li["unit"] == "hour"]
+		d = hourly[0]["derivation"]
+		self.assertEqual(d["hour_units"], 720)  # 30 days × 24
+		self.assertIn("÷ 720 ×", d["arithmetic"])
+
+
+class TestMeteredLines(DerivationTestBase):
+	def _rollup(self, quantity):
+		frappe.get_doc(
+			{
+				"doctype": "Usage Rollup",
+				"resource_id": frappe.db.get_value("Subscription", self.sub, "asset_id"),
+				"team": TEAM,
+				"cluster": CLUSTER,
+				"resource_type": "Transfer",
+				"meter_type": "Counter",
+				"period_start": "2026-06-01 00:00:00",
+				"period_end": "2026-06-30 23:59:59",
+				"quantity": quantity,
+				"unit": "GB",
+				"currency": "INR",
+				"locked_allowance": 100,
+				"locked_rate": 0.5,
+				"idempotency_key": "deriv:2026-06",
+				"sequence": 0,
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	def test_overage_shows_measured_quantity_allowance_and_rate_source(self):
+		from central.billing.revenue.metering import metered_line_items
+
+		add_segment(self.sub, "Created", 1000, "2026-06-01 00:00:00")
+		self._rollup(340)
+		line = metered_line_items(TEAM, CLUSTER, *JUNE, explain=True)[0]
+		d = line["derivation"]
+
+		self.assertEqual(d["measured_quantity"], 340.0)
+		self.assertEqual(d["allowance"], 100.0)
+		self.assertEqual(d["billable_quantity"], 240.0)
+		self.assertEqual(d["rate_source"], "locked at ingest")
+		self.assertEqual(d["arithmetic"], "max(0, 340.0 − 100.0) × 0.5")
+
+
+class TestThroughTheProjection(DerivationTestBase):
+	def test_every_projected_line_carries_its_derivation(self):
+		add_segment(self.sub, "Created", 3000, "2026-06-01 00:00:00")
+		frappe.db.commit()
+		out = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")
+		self.assertTrue(all("derivation" in li for li in out["invoice"]["lines"]))
+
+	def test_a_grandfathered_rate_is_visible_as_the_locked_one(self):
+		# The drill is where an operator learns that raising a catalog rate would not
+		# reach this subscription.
+		add_segment(self.sub, "Created", 3000, "2026-03-14 00:00:00")
+		frappe.db.commit()
+		out = engine.project(TEAM, "2026-09-01", "2026-09-30", today="2026-08-06")
+		self.assertEqual(out["invoice"]["lines"][0]["derivation"]["locked_rate"], 3000.0)


### PR DESCRIPTION
A projected invoice could say what a team owes. It could not say why. This adds the drill, and it is also the answer to "why was I charged this" when a customer asks.

<img width="1220" height="741" alt="6-line-derivation" src="https://github.com/user-attachments/assets/7c99c7a1-7d34-4991-85df-bf18fa70c521" />


## It comes from the computation, not from a second pass

The derivation is emitted by the line builders themselves, at the moment they work out the amount. A separate function that re-derived the figure would be a parallel model with a shorter life expectancy than the code it explains.

```mermaid
flowchart LR
    SEG["Subscription Change segments"] --> B{"Held 24h or more?"}
    B -->|yes| D["Daily line<br/>days ÷ day_units × locked_rate"]
    B -->|no| H["Every date it touches bills hourly<br/>hours ÷ hour_units × locked_rate"]
    D --> P["Amount + derivation, together"]
    H --> P
    M["Usage rollup"] --> MM["max(0, qty − allowance) × rate"] --> P
```

It is opt-in. The billing run does not ask for it, so its payload is unchanged and no explanation ever reaches an Invoice Line Item — the property #91 worked to establish.

## What it answers

For a team that resized twice on one day, the hourly line explains itself and names **every config that shared the date**, which is the actual reason the date left daily billing. Without that, an operator is left inferring a 24-hour window rule from a
number.

The two passes are shown to partition the period: daily and hourly date sets are disjoint and cover the month exactly, so no date is billed twice and none is missed. There is a test on that property, not just on the totals.

Metered lines show measured quantity against allowance, the billable remainder, and **where the rate came from** — locked at ingest, or today's catalogue. That distinction is grandfathering made visible one line at a time.