### PR TITLE
feat(admin): Ask what a different configuration would do

### DIFF
--- a/central/billing/api/admin/__init__.py
+++ b/central/billing/api/admin/__init__.py
@@ -23,8 +23,11 @@ from central.billing.api.admin.catalog import (
 	update_plan_rate,
 )
 from central.billing.api.admin.projection import (
+	compare_scenario,
+	project_scenario,
 	project_team,
 	project_team_months,
+	save_scenario_result,
 	sample_cohort,
 	size_cohort,
 	start_cohort_projection,
@@ -50,7 +53,10 @@ from central.billing.api.admin.teams import (
 )
 
 __all__ = [
+	"compare_scenario",
+	"project_scenario",
 	"project_team",
+	"save_scenario_result",
 	"project_team_months",
 	"sample_cohort",
 	"size_cohort",

--- a/central/billing/api/admin/projection.py
+++ b/central/billing/api/admin/projection.py
@@ -150,3 +150,36 @@ def size_cohort(filters: str | None = None, months: int = 1) -> dict:
 	parsed = frappe.parse_json(filters) if filters else {}
 	sizing = cohort.estimate({k: v for k, v in (parsed or {}).items() if v}, months)
 	return dict(sizing)
+
+
+@frappe.whitelist()
+def project_scenario(scenario: str, today: str | None = None) -> dict:
+	"""Project a saved scenario — its team, its period, its overrides."""
+	authz.require_operator()
+
+	from central.billing.projection import scenario as scenarios
+
+	frappe.logger("billing").info(
+		f"projection: {frappe.session.user} projected scenario {scenario}"
+	)
+	return scenarios.project(scenario, today=today)
+
+
+@frappe.whitelist(methods=["POST"])
+def save_scenario_result(scenario: str, today: str | None = None) -> dict:
+	"""Project a scenario and record the answer on it."""
+	authz.require_operator()
+
+	from central.billing.projection import scenario as scenarios
+
+	return scenarios.project_and_save(scenario, today=today)
+
+
+@frappe.whitelist()
+def compare_scenario(scenario: str, today: str | None = None) -> dict:
+	"""The same team as configured and as the scenario pretends, side by side."""
+	authz.require_operator()
+
+	from central.billing.projection import scenario as scenarios
+
+	return scenarios.compare(scenario, today=today)

--- a/central/billing/doctype/billing_scenario/billing_scenario.json
+++ b/central/billing/doctype/billing_scenario/billing_scenario.json
@@ -1,0 +1,152 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:scenario_name",
+ "creation": "2026-08-07 00:00:00.000000",
+ "description": "A saved question: which configuration to project under, over what period, treating unknown payment outcomes how.",
+ "doctype": "DocType",
+ "editable_grid": 0,
+ "engine": "InnoDB",
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-08-07 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Billing",
+ "name": "Billing Scenario",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1,
+   "report": 1,
+   "role": "System Manager",
+   "export": 1,
+   "share": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "fields": [
+  {
+   "fieldname": "scenario_name",
+   "fieldtype": "Data",
+   "label": "Scenario",
+   "reqd": 1,
+   "in_list_view": 1,
+   "description": "What question this scenario asks."
+  },
+  {
+   "fieldname": "team",
+   "fieldtype": "Link",
+   "label": "Team",
+   "options": "Team",
+   "in_list_view": 1,
+   "description": "Leave blank for a cohort scenario."
+  },
+  {
+   "fieldname": "column_break_period",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "period_start",
+   "fieldtype": "Date",
+   "label": "Period Starting"
+  },
+  {
+   "fieldname": "months",
+   "fieldtype": "Int",
+   "label": "Months",
+   "default": "1"
+  },
+  {
+   "fieldname": "outcome_mode",
+   "fieldtype": "Select",
+   "label": "Outcomes",
+   "options": "Derived\nOptimistic\nAssumed",
+   "default": "Derived"
+  },
+  {
+   "fieldname": "assume",
+   "fieldtype": "Select",
+   "label": "Assume",
+   "options": "\npays_on_time\nnever_pays",
+   "depends_on": "eval:doc.outcome_mode=='Assumed'"
+  },
+  {
+   "fieldname": "section_break_overrides",
+   "fieldtype": "Section Break",
+   "label": "Instead of the live configuration",
+   "description": "Blank means use what is configured. Nothing here changes Billing Settings."
+  },
+  {
+   "fieldname": "dunning_retry_days",
+   "fieldtype": "Data",
+   "label": "Retry Days",
+   "description": "e.g. 2, 5, 10"
+  },
+  {
+   "fieldname": "invoice_due_days",
+   "fieldtype": "Int",
+   "label": "Invoice Due Days"
+  },
+  {
+   "fieldname": "column_break_ladder",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "suspend_after_days",
+   "fieldtype": "Int",
+   "label": "Suspend After Days"
+  },
+  {
+   "fieldname": "terminate_after_days",
+   "fieldtype": "Int",
+   "label": "Terminate After Days"
+  },
+  {
+   "fieldname": "promotional_credit_validity_days",
+   "fieldtype": "Int",
+   "label": "Promotional Credit Validity Days"
+  },
+  {
+   "fieldname": "section_break_result",
+   "fieldtype": "Section Break",
+   "label": "Last Result"
+  },
+  {
+   "fieldname": "projected_at",
+   "fieldtype": "Datetime",
+   "label": "Projected At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "result",
+   "fieldtype": "Code",
+   "label": "Result",
+   "options": "JSON",
+   "read_only": 1
+  }
+ ],
+ "field_order": [
+  "scenario_name",
+  "team",
+  "column_break_period",
+  "period_start",
+  "months",
+  "outcome_mode",
+  "assume",
+  "section_break_overrides",
+  "dunning_retry_days",
+  "invoice_due_days",
+  "column_break_ladder",
+  "suspend_after_days",
+  "terminate_after_days",
+  "promotional_credit_validity_days",
+  "section_break_result",
+  "projected_at",
+  "result"
+ ]
+}

--- a/central/billing/doctype/billing_scenario/billing_scenario.py
+++ b/central/billing/doctype/billing_scenario/billing_scenario.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""A saved question, not a saved answer.
+
+The overrides here never touch Billing Settings. They change what a projection *reads*,
+for the length of that projection — so asking what a 2/5/10 dunning ladder would do
+costs nobody their real configuration.
+"""
+
+import frappe
+from frappe.model.document import Document
+
+# The fields that stand in for Billing Settings while a projection runs.
+OVERRIDE_FIELDS = (
+	"dunning_retry_days",
+	"invoice_due_days",
+	"suspend_after_days",
+	"terminate_after_days",
+	"promotional_credit_validity_days",
+)
+
+
+class BillingScenario(Document):
+	def validate(self):
+		self.months = max(1, min(frappe.utils.cint(self.months) or 1, 24))
+		if self.outcome_mode != "Assumed":
+			self.assume = None
+
+	def overrides(self) -> dict:
+		"""Only the fields actually filled in — a blank one means "use what is live"."""
+		return {
+			field: self.get(field)
+			for field in OVERRIDE_FIELDS
+			if self.get(field) not in (None, "", 0)
+		}

--- a/central/billing/page/billing_simulator/billing_simulator.js
+++ b/central/billing/page/billing_simulator/billing_simulator.js
@@ -58,10 +58,91 @@ class BillingSimulator {
 			default: "Derived",
 			change: () => this.refresh(),
 		});
+		this.scenario = this.page.add_field({
+			fieldname: "scenario",
+			label: __("Scenario"),
+			fieldtype: "Link",
+			options: "Billing Scenario",
+			change: () => this.apply_scenario(),
+		});
 		this.page.set_primary_action(__("Project"), () => this.refresh());
+		this.page.add_menu_item(__("Save as scenario"), () => this.save_scenario());
+	}
+
+	// A saved scenario drives the projection itself: its overrides are read *instead of*
+	// Billing Settings for the length of the call, which is why it cannot just be
+	// unpacked into these filters.
+	apply_scenario() {
+		const name = this.scenario.get_value();
+		if (!name) return this.refresh();
+
+		// Reflecting the scenario's team back into the picker fires that field's own
+		// change handler, which would kick off a plain refresh and overwrite the very
+		// projection we are waiting for — with the default period, silently.
+		this.applying = true;
+		this.show_empty(__("Projecting…"));
+		frappe
+			.call({
+				method: "central.billing.api.admin.projection.project_scenario",
+				args: { scenario: name },
+			})
+			.then((r) => {
+				if (!r.message) return;
+				const out = r.message;
+				this.team.set_value(out.team);
+				if (out.scenario && out.scenario.months > 1) this.render_months(out);
+				else this.render(out);
+				if (out.scenario) this.$body.prepend(this.pretending_card(out.scenario));
+			})
+			.catch(() => this.show_empty(__("Could not project this scenario.")))
+			.finally(() => {
+				this.applying = false;
+			});
+	}
+
+	// A projection under an altered configuration that does not say so is a number
+	// waiting to be quoted as fact.
+	pretending_card(scenario) {
+		const overrides = Object.entries(scenario.overrides || {});
+		if (!overrides.length) return $();
+		const items = overrides
+			.map(
+				([field, value]) =>
+					`<li class="bs-finding"><span class="bs-finding-summary">${frappe.utils.escape_html(
+						frappe.unscrub(field)
+					)}</span><span class="bs-muted">${frappe.utils.escape_html(
+						String(value)
+					)} ${__("instead of what is configured")}</span></li>`
+			)
+			.join("");
+		return $(`
+			<div class="bs-card">
+				<div class="bs-card-head">
+					<span class="bs-card-title">${__("Projected under {0}", [
+						frappe.utils.escape_html(scenario.scenario_name || scenario.name),
+					])}</span>
+					<span class="bs-muted">${__("Billing Settings are unchanged")}</span>
+				</div>
+				<ul class="bs-findings">${items}</ul>
+			</div>`);
+	}
+
+	save_scenario() {
+		const team = this.team.get_value();
+		if (!team) {
+			frappe.show_alert({ message: __("Pick a team first."), indicator: "orange" });
+			return;
+		}
+		const doc = frappe.model.get_new_doc("Billing Scenario");
+		doc.team = team;
+		doc.period_start = this.period.get_value();
+		doc.months = cint(this.months.get_value()) || 1;
+		doc.outcome_mode = this.mode.get_value() || "Derived";
+		frappe.set_route("Form", "Billing Scenario", doc.name);
 	}
 
 	refresh() {
+		if (this.applying) return;
 		const team = this.team.get_value();
 		if (!team) return;
 

--- a/central/billing/projection/scenario.py
+++ b/central/billing/projection/scenario.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Projecting under a scenario, and saving one.
+
+A **scenario** is the input bundle: which configuration to read, over what period, and
+how to treat payment outcomes nobody can know. Varying it while holding the team fixed
+is how "what would this change do?" gets asked.
+
+The write boundary is the load-bearing part. The engine runs read-only — that is a
+database guarantee, not a convention — so it returns plain data and *then*, in an
+ordinary transaction, the result is stored on the scenario. Nothing else is written.
+That restriction is the only thing standing between "saves a scenario" and "saves an
+invoice", so it carries its own test.
+"""
+
+import frappe
+
+from central.billing import settings
+from central.billing.projection import engine
+
+# The only DocType this module may write. Asserted, because the whole safety argument
+# for running projections against production rests on it staying true.
+WRITABLE = ("Billing Scenario",)
+
+
+def project(scenario, today=None) -> dict:
+	"""Project a scenario's subject under its overrides. Reads only.
+
+	The overrides wrap the engine call rather than being passed into it: policy is read
+	several layers down — dunning, invoicing, credits — and threading a settings bundle
+	through all of them would push the simulator's concerns into code that has no
+	business knowing it exists.
+	"""
+	doc = _resolve(scenario)
+	if not doc.team:
+		frappe.throw(
+			"This scenario has no team. Cohort scenarios are projected from the "
+			"Billing Projection report.",
+			frappe.ValidationError,
+		)
+
+	overrides = doc.overrides()
+	today = frappe.utils.getdate(today or frappe.utils.nowdate())
+	period_start = frappe.utils.get_first_day(doc.period_start or today)
+	months = max(1, frappe.utils.cint(doc.months) or 1)
+
+	with settings.overridden(**overrides):
+		if months > 1:
+			out = engine.project_months(
+				doc.team, period_start, months=months, today=today,
+				mode=doc.outcome_mode, assume=doc.assume,
+			)
+		else:
+			out = engine.project(
+				doc.team, period_start, frappe.utils.get_last_day(period_start), today=today,
+				mode=doc.outcome_mode, assume=doc.assume,
+			)
+
+	# Say what was pretended. A projection under an altered ladder that does not
+	# announce it is a number waiting to be quoted as fact.
+	out["scenario"] = {
+		"name": doc.name,
+		"scenario_name": doc.scenario_name,
+		"overrides": overrides,
+		"outcome_mode": doc.outcome_mode,
+		"months": months,
+	}
+	return out
+
+
+def project_and_save(scenario, today=None) -> dict:
+	"""Project, then record the result on the scenario — two transactions, in order.
+
+	The projection happens read-only and finishes before anything is written. Storing
+	the answer is an ordinary write, and it touches the scenario and nothing else.
+	"""
+	out = project(scenario, today)
+	doc = _resolve(scenario)
+	doc.db_set("result", frappe.as_json(out), commit=False)
+	doc.db_set("projected_at", frappe.utils.now(), commit=False)
+	frappe.db.commit()
+	return out
+
+
+def compare(scenario, today=None) -> dict:
+	"""The same team, projected twice: as configured, and as the scenario pretends.
+
+	Both halves come from one engine, so a difference between them is the override and
+	nothing else — which is the only way the answer means anything.
+	"""
+	doc = _resolve(scenario)
+	overrides = doc.overrides()
+
+	live = project(_bare(doc), today)
+	altered = project(doc, today) if overrides else live
+	return {
+		"overrides": overrides,
+		"live": live,
+		"altered": altered,
+		"changed": bool(overrides),
+	}
+
+
+def _bare(doc):
+	"""The same scenario with its overrides dropped — the live-configuration control."""
+	clone = frappe.copy_doc(doc)
+	from central.billing.doctype.billing_scenario.billing_scenario import OVERRIDE_FIELDS
+
+	for field in OVERRIDE_FIELDS:
+		clone.set(field, None)
+	return clone
+
+
+def _resolve(scenario):
+	return scenario if hasattr(scenario, "overrides") else frappe.get_doc("Billing Scenario", scenario)

--- a/central/billing/settings.py
+++ b/central/billing/settings.py
@@ -13,9 +13,54 @@ as constants here. The one exception is the per-currency welcome grant: child ro
 can't have defaults, so `ensure_welcome_credit_amounts` seeds them on install.
 """
 
+from contextlib import contextmanager
+from contextvars import ContextVar
+
 import frappe
 
 SETTINGS = "Billing Settings"
+
+# What a projection is asking "what if" about. A context variable rather than a
+# parameter because the question is asked several layers down — dunning, invoicing and
+# credits all read policy — and threading a settings bundle through every one of them
+# would put the simulator's concerns into code that has no business knowing it exists.
+#
+# Nothing here writes. An override changes what a projection *reads*, never what the
+# document holds, so the answer to "what would a 2/5/10 ladder do" costs nobody their
+# real configuration.
+_overrides: ContextVar[dict] = ContextVar("billing_settings_overrides", default={})
+
+
+@contextmanager
+def overridden(**values):
+	"""Read Billing Settings as if these values were saved, for this block only.
+
+	Nests: an inner override wins for the fields it names and leaves the rest alone.
+	"""
+	merged = {**_overrides.get(), **{k: v for k, v in values.items() if v is not None}}
+	token = _overrides.set(merged)
+	try:
+		yield merged
+	finally:
+		_overrides.reset(token)
+
+
+def active_overrides() -> dict:
+	"""What is currently being pretended, if anything — for showing on the output."""
+	return dict(_overrides.get())
+
+
+def _override(field):
+	"""The overridden value for `field`, or `_MISSING` when it is not being pretended."""
+	return _overrides.get().get(field, _MISSING)
+
+
+class _Missing:
+	def __bool__(self):
+		return False
+
+
+_MISSING = _Missing()
 
 # The launch grant, seeded once onto a Billing Settings nobody has saved yet. It is
 # a starting point for the accounts team to edit, not a value the code depends on.
@@ -42,26 +87,41 @@ def welcome_credit_amount(currency: str) -> float:
 
 def promotional_credit_validity_days() -> int:
 	"""Days a welcome credit stays usable; 0 means it never expires."""
+	override = _override("promotional_credit_validity_days")
+	if override is not _MISSING:
+		return frappe.utils.cint(override)
 	return frappe.utils.cint(_settings().promotional_credit_validity_days)
 
 
 def invoice_due_days() -> int:
 	"""Days between an invoice opening and falling due."""
+	override = _override("invoice_due_days")
+	if override is not _MISSING:
+		return frappe.utils.cint(override)
 	return frappe.utils.cint(_settings().invoice_due_days)
 
 
 def dunning_retry_days() -> list[int]:
 	"""Days past due on which payment is retried, in order. Empty means no retries."""
+	override = _override("dunning_retry_days")
+	if override is not _MISSING:
+		return _parse_retry_days(override)
 	return _settings().retry_days()
 
 
 def suspend_after_days() -> int:
 	"""Days past due before a subscription is suspended."""
+	override = _override("suspend_after_days")
+	if override is not _MISSING:
+		return frappe.utils.cint(override)
 	return frappe.utils.cint(_settings().suspend_after_days)
 
 
 def terminate_after_days() -> int:
 	"""Days past due before a subscription is terminated."""
+	override = _override("terminate_after_days")
+	if override is not _MISSING:
+		return frappe.utils.cint(override)
 	return frappe.utils.cint(_settings().terminate_after_days)
 
 
@@ -72,6 +132,9 @@ def default_gst_rate() -> float:
 
 def forecast_notify_ratio() -> float:
 	"""Share of a team's cap at which its forecast spend warning fires (0.8 = 80%)."""
+	override = _override("forecast_notify_percent")
+	if override is not _MISSING:
+		return frappe.utils.flt(override) / 100.0
 	return frappe.utils.flt(_settings().forecast_notify_percent) / 100.0
 
 
@@ -95,3 +158,20 @@ def ensure_welcome_credit_amounts() -> None:
 	for currency, amount in LAUNCH_WELCOME_CREDITS.items():
 		settings.append("welcome_credit_amounts", {"currency": currency, "amount": amount})
 	settings.save(ignore_permissions=True)
+
+
+def _parse_retry_days(value) -> list[int]:
+	"""Accept a ladder as a list or as the comma string the document stores."""
+	if isinstance(value, str):
+		parts = [p.strip() for p in value.split(",") if p.strip()]
+	else:
+		parts = list(value or [])
+	days = []
+	for part in parts:
+		try:
+			day = int(part)
+		except (TypeError, ValueError):
+			continue
+		if day not in days:
+			days.append(day)
+	return sorted(days)

--- a/central/billing/tests/test_projection_scenario.py
+++ b/central/billing/tests/test_projection_scenario.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Scenarios: asking what a different configuration would do, without adopting it."""
+
+import frappe
+from central.billing import settings
+from central.billing.projection import scenario
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+from central.billing.tests.utils import (
+	add_segment,
+	billing_settings,
+	ensure_team,
+	make_billing_subscription,
+	make_plan,
+)
+
+TEAM = "team-scenario"
+CLUSTER = "ap-south-1"
+PLAN = "bundle-scenario"
+TODAY = "2026-08-06"
+
+
+class TestTheOverrideContext(IntegrationTestCase):
+	"""Overrides change what is read, never what is stored."""
+
+	def test_without_an_override_the_document_is_read(self):
+		with billing_settings(dunning_retry_days="1, 3, 7", suspend_after_days=14):
+			self.assertEqual(settings.dunning_retry_days(), [1, 3, 7])
+			self.assertEqual(settings.suspend_after_days(), 14)
+
+	def test_an_override_is_read_instead(self):
+		with billing_settings(dunning_retry_days="1, 3, 7", suspend_after_days=14):
+			with settings.overridden(dunning_retry_days="2, 5, 10", suspend_after_days=21):
+				self.assertEqual(settings.dunning_retry_days(), [2, 5, 10])
+				self.assertEqual(settings.suspend_after_days(), 21)
+
+	def test_the_document_is_untouched_by_an_override(self):
+		# The point of the whole seam: asking costs nobody their configuration.
+		with billing_settings(suspend_after_days=14):
+			with settings.overridden(suspend_after_days=21):
+				pass
+			self.assertEqual(settings.suspend_after_days(), 14)
+			self.assertEqual(
+				frappe.db.get_single_value("Billing Settings", "suspend_after_days"), 14
+			)
+
+	def test_the_override_lifts_when_the_block_ends(self):
+		with billing_settings(suspend_after_days=14):
+			with settings.overridden(suspend_after_days=21):
+				self.assertEqual(settings.suspend_after_days(), 21)
+			self.assertEqual(settings.suspend_after_days(), 14)
+
+	def test_overrides_nest_and_the_inner_one_wins_only_for_what_it_names(self):
+		with billing_settings(suspend_after_days=14, terminate_after_days=44):
+			with settings.overridden(suspend_after_days=21):
+				with settings.overridden(terminate_after_days=60):
+					self.assertEqual(settings.suspend_after_days(), 21)
+					self.assertEqual(settings.terminate_after_days(), 60)
+
+	def test_a_ladder_is_accepted_as_a_list_or_a_string(self):
+		with settings.overridden(dunning_retry_days=[5, 2, 5]):
+			self.assertEqual(settings.dunning_retry_days(), [2, 5])
+		with settings.overridden(dunning_retry_days="10, 3"):
+			self.assertEqual(settings.dunning_retry_days(), [3, 10])
+
+	def test_what_is_being_pretended_can_be_reported(self):
+		with settings.overridden(suspend_after_days=21):
+			self.assertEqual(settings.active_overrides(), {"suspend_after_days": 21})
+		self.assertEqual(settings.active_overrides(), {})
+
+
+class ScenarioTestBase(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		make_plan(PLAN)
+		self._purge()
+		self.sub = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
+		add_segment(self.sub, "Created", 5000, "2026-01-01 00:00:00")
+		frappe.db.commit()
+
+	def tearDown(self):
+		self._purge()
+
+	def _purge(self):
+		for name in frappe.get_all("Billing Scenario", pluck="name"):
+			frappe.delete_doc("Billing Scenario", name, force=True, ignore_permissions=True)
+		frappe.db.delete("Invoice", {"team": TEAM})
+		for sub in frappe.get_all("Subscription", {"team": TEAM}, pluck="name"):
+			frappe.db.delete("Subscription Change", {"subscription": sub})
+			frappe.db.delete("Subscription", {"name": sub})
+		frappe.db.delete("Asset", {"team": TEAM})
+		frappe.db.commit()
+
+	def _scenario(self, name="What if we dun harder", **kw):
+		doc = frappe.get_doc(
+			{
+				"doctype": "Billing Scenario",
+				"scenario_name": name,
+				"team": TEAM,
+				"period_start": "2026-09-01",
+				"months": 1,
+				"outcome_mode": "Derived",
+				**kw,
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+		return doc
+
+
+class TestProjectingUnderAScenario(ScenarioTestBase):
+	def test_an_altered_ladder_moves_the_projected_dates(self):
+		with billing_settings(
+			dunning_retry_days="1, 3, 7", suspend_after_days=14, terminate_after_days=44
+		):
+			live = scenario.project(self._scenario("Live"), today=TODAY)
+			altered = scenario.project(
+				self._scenario("Harsher", scenario_name="Harsher", suspend_after_days=5),
+				today=TODAY,
+			)
+
+		def suspend_on(out):
+			return next(
+				s["date"] for s in out["calendar"]["if_never_paid"] if s["stage"] == "Suspend"
+			)
+
+		self.assertNotEqual(suspend_on(live), suspend_on(altered))
+		self.assertLess(suspend_on(altered), suspend_on(live))
+
+	def test_a_scenario_reports_what_it_pretended(self):
+		out = scenario.project(self._scenario(suspend_after_days=5), today=TODAY)
+		self.assertEqual(out["scenario"]["overrides"], {"suspend_after_days": 5})
+
+	def test_a_scenario_with_no_overrides_pretends_nothing(self):
+		out = scenario.project(self._scenario(), today=TODAY)
+		self.assertEqual(out["scenario"]["overrides"], {})
+
+	def test_the_override_does_not_outlive_the_projection(self):
+		with billing_settings(suspend_after_days=14):
+			scenario.project(self._scenario(suspend_after_days=5), today=TODAY)
+			self.assertEqual(settings.suspend_after_days(), 14)
+
+	def test_a_multi_month_scenario_rolls_forward(self):
+		out = scenario.project(self._scenario(months=3), today=TODAY)
+		self.assertEqual(len(out["months"]), 3)
+
+	def test_a_cohort_scenario_is_refused_here_rather_than_guessed_at(self):
+		doc = self._scenario()
+		doc.db_set("team", None)
+		with self.assertRaises(frappe.ValidationError):
+			scenario.project(doc.name, today=TODAY)
+
+
+class TestSavingAScenario(ScenarioTestBase):
+	def test_the_result_is_stored_and_reloadable(self):
+		doc = self._scenario()
+		out = scenario.project_and_save(doc.name, today=TODAY)
+
+		reloaded = frappe.get_doc("Billing Scenario", doc.name)
+		self.assertTrue(reloaded.projected_at)
+		self.assertEqual(
+			frappe.parse_json(reloaded.result)["invoice"]["total"], out["invoice"]["total"]
+		)
+
+	def test_reprojecting_the_same_scenario_gives_the_same_answer(self):
+		doc = self._scenario()
+		first = scenario.project(doc.name, today=TODAY)
+		second = scenario.project(doc.name, today=TODAY)
+		self.assertEqual(first["invoice"]["total"], second["invoice"]["total"])
+		self.assertEqual(first["calendar"], second["calendar"])
+
+	def test_saving_a_projection_writes_only_the_scenario(self):
+		# The only thing between "saves a scenario" and "saves an invoice".
+		doc = self._scenario()
+		before = {
+			dt: frappe.db.count(dt)
+			for dt in ("Invoice", "Payment Attempt", "Credit Ledger Entry", "Subscription Change")
+		}
+		scenario.project_and_save(doc.name, today=TODAY)
+		for dt, count in before.items():
+			self.assertEqual(frappe.db.count(dt), count, dt)
+
+	def test_the_writable_surface_is_exactly_one_doctype(self):
+		self.assertEqual(set(scenario.WRITABLE), {"Billing Scenario"})
+
+	def test_nothing_here_is_called_a_run(self):
+		# "Run" means the monthly billing run. Nothing read-only borrows the word.
+		meta = frappe.get_meta("Billing Scenario")
+		names = [f.fieldname for f in meta.fields] + [meta.name]
+		self.assertFalse([n for n in names if "run" in n.lower()])
+
+
+class TestComparing(ScenarioTestBase):
+	def test_live_and_altered_are_projected_by_the_same_engine(self):
+		with billing_settings(suspend_after_days=14):
+			out = scenario.compare(self._scenario(suspend_after_days=5), today=TODAY)
+
+		self.assertTrue(out["changed"])
+		self.assertEqual(out["live"]["invoice"]["total"], out["altered"]["invoice"]["total"])
+
+		def suspend_on(side):
+			return next(
+				s["date"] for s in out[side]["calendar"]["if_never_paid"] if s["stage"] == "Suspend"
+			)
+
+		# Same bill, different consequence — which is exactly what the override changed.
+		self.assertNotEqual(suspend_on("live"), suspend_on("altered"))
+
+	def test_a_scenario_that_pretends_nothing_compares_to_itself(self):
+		out = scenario.compare(self._scenario(), today=TODAY)
+		self.assertFalse(out["changed"])
+		self.assertEqual(out["live"]["calendar"], out["altered"]["calendar"])

--- a/central/billing/workspace/billing/billing.json
+++ b/central/billing/workspace/billing/billing.json
@@ -27,6 +27,16 @@
   {
    "hidden": 0,
    "is_query_report": 0,
+   "label": "Billing Scenario",
+   "link_count": 0,
+   "link_to": "Billing Scenario",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
    "label": "Revenue & AR Reports",
    "link_count": 3,
    "link_type": "DocType",


### PR DESCRIPTION
The simulator could project what billing *will* do. It could not project what billing *would* do under a different policy — which is the question anyone actually has before changing one.

```mermaid
flowchart LR
    S["Billing Scenario<br/>team · period · overrides"] --> O["settings.overridden(...)"]
    O --> E["The same engine"]
    E --> P["Projection + what was pretended"]
    BS[("Billing Settings")] -.->|read, never written| O

    style BS fill:#edf6fd,stroke:#0070cc
    style P fill:#e4f5e9,stroke:#30a66d
```

## Overrides change what is read, not what is stored

Every Billing Settings accessor consults an override context. A projection under a 2/5/10 dunning ladder reads that ladder for the length of the call, and the document is untouched — there is a test asserting the stored value directly, because "asking costs nobody their configuration" is the property that makes this safe to run on production.

A context variable rather than a parameter, deliberately: policy is read several layers down, and threading a settings bundle through dunning, invoicing and credits would put the simulator's concerns into code that has no business knowing it exists.

<img width="1440" height="1000" alt="8-scenario-override" src="https://github.com/user-attachments/assets/9d09c2d5-c7f5-4d66-97bf-f607644b0378" />


The banner is not decoration. A projection under an altered ladder that does not say so is a number waiting to be quoted as fact.

## The write boundary

Projecting is read-only and returns plain data. Recording the answer on the scenario is a separate, ordinary transaction that touches `Billing Scenario` and nothing else — asserted by a test, because it is the only thing between "saves a scenario" and "saves an invoice".

## Comparing

`compare()` projects the same team twice, as configured and as the scenario pretends, through one engine — so any difference between the two halves is the override and nothing else.