### PR TITLE
feat(admin): Show what a price change actually reaches

### DIFF
--- a/central/billing/catalog/pricing.py
+++ b/central/billing/catalog/pricing.py
@@ -11,16 +11,74 @@ the flat price for a fixed bundle and the per-unit price for a metered
 single-resource Plan (ADR 0008).
 """
 
+from contextlib import contextmanager
+from contextvars import ContextVar
+
 import frappe
+
+# A projection asking "what if we raised this price". Every rate resolution in the
+# module comes through `get_catalog_rates`, so overriding here reaches plan rates, the
+# component rate card and live-priced metered plans alike — without any of them
+# learning that a simulator exists.
+#
+# It changes what is *read*. No Catalog Rate row is touched, which is what makes the
+# question safe to ask against production.
+_rate_overrides: ContextVar[tuple] = ContextVar("catalog_rate_overrides", default=())
+
+
+@contextmanager
+def overridden_rates(overrides):
+	"""Read catalog rates as if these were published, for this block only.
+
+	Each override names what it reprices — `priced_doctype` and `priced_for`, optionally
+	narrowed to a `cluster` and `currency` — and either a flat `rate` or a `percent`
+	change applied to whatever is configured.
+	"""
+	token = _rate_overrides.set(tuple(overrides or ()))
+	try:
+		yield
+	finally:
+		_rate_overrides.reset(token)
+
+
+def active_rate_overrides() -> tuple:
+	"""What is currently being pretended about prices, for showing on the output."""
+	return _rate_overrides.get()
+
+
+def _apply_overrides(priced_doctype: str, priced_for: str, rows: list) -> list:
+	"""Rewrite the rows a projection should see. Returns the rows unchanged when idle."""
+	overrides = _rate_overrides.get()
+	if not overrides:
+		return rows
+
+	for override in overrides:
+		if override.get("priced_doctype") != priced_doctype:
+			continue
+		if override.get("priced_for") and override["priced_for"] != priced_for:
+			continue
+		for row in rows:
+			if override.get("cluster") and row.cluster != override["cluster"]:
+				continue
+			if override.get("currency") and row.currency != override["currency"]:
+				continue
+			if override.get("rate") is not None:
+				row.rate = frappe.utils.flt(override["rate"])
+			elif override.get("percent"):
+				row.rate = frappe.utils.flt(
+					frappe.utils.flt(row.rate) * (1 + frappe.utils.flt(override["percent"]) / 100.0), 6
+				)
+	return rows
 
 
 def get_catalog_rates(priced_doctype: str, priced_for: str) -> list:
 	"""All `Catalog Rate` rows (cluster/currency/rate) for one priced plan."""
-	return frappe.get_all(
+	rows = frappe.get_all(
 		"Catalog Rate",
 		filters={"priced_doctype": priced_doctype, "priced_for": priced_for},
 		fields=["cluster", "currency", "rate"],
 	)
+	return _apply_overrides(priced_doctype, priced_for, rows)
 
 
 def set_catalog_rates(priced_doctype: str, priced_for: str, rates) -> None:

--- a/central/billing/doctype/billing_scenario/billing_scenario.json
+++ b/central/billing/doctype/billing_scenario/billing_scenario.json
@@ -112,6 +112,18 @@
    "label": "Promotional Credit Validity Days"
   },
   {
+   "fieldname": "section_break_rates",
+   "fieldtype": "Section Break",
+   "label": "Instead of the published prices",
+   "description": "A catalog change reaches new provisions and resizes. Existing resources keep the rate locked when they were provisioned."
+  },
+  {
+   "fieldname": "rate_overrides",
+   "fieldtype": "Table",
+   "label": "Rate Overrides",
+   "options": "Billing Scenario Rate"
+  },
+  {
    "fieldname": "section_break_result",
    "fieldtype": "Section Break",
    "label": "Last Result"
@@ -145,6 +157,8 @@
   "suspend_after_days",
   "terminate_after_days",
   "promotional_credit_validity_days",
+  "section_break_rates",
+  "rate_overrides",
   "section_break_result",
   "projected_at",
   "result"

--- a/central/billing/doctype/billing_scenario/billing_scenario.py
+++ b/central/billing/doctype/billing_scenario/billing_scenario.py
@@ -26,6 +26,26 @@ class BillingScenario(Document):
 		if self.outcome_mode != "Assumed":
 			self.assume = None
 
+	def rate_overrides_applied(self) -> list[dict]:
+		"""The pretended prices, as the pricing seam wants them."""
+		return [
+			{
+				"priced_doctype": row.priced_doctype,
+				"priced_for": row.priced_for,
+				"cluster": row.cluster,
+				"currency": row.currency,
+				"percent": row.percent,
+				"rate": row.rate or None,
+				"effective_from": row.effective_from,
+			}
+			for row in (self.rate_overrides or [])
+		]
+
+	def effective_from(self):
+		"""The earliest date any pretended price takes effect."""
+		dates = [r.effective_from for r in (self.rate_overrides or []) if r.effective_from]
+		return min(dates) if dates else None
+
 	def overrides(self) -> dict:
 		"""Only the fields actually filled in — a blank one means "use what is live"."""
 		return {

--- a/central/billing/doctype/billing_scenario_rate/billing_scenario_rate.json
+++ b/central/billing/doctype/billing_scenario_rate/billing_scenario_rate.json
@@ -1,0 +1,90 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "creation": "2026-08-07 00:00:00.000000",
+ "description": "One pretended catalog price, for a projection to read instead of the published one.",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "istable": 1,
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-08-07 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Billing",
+ "name": "Billing Scenario Rate",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "fields": [
+  {
+   "fieldname": "priced_doctype",
+   "fieldtype": "Select",
+   "label": "Prices",
+   "options": "Plan\nResource Type",
+   "default": "Plan",
+   "reqd": 1,
+   "in_list_view": 1,
+   "columns": 1
+  },
+  {
+   "fieldname": "priced_for",
+   "fieldtype": "Dynamic Link",
+   "label": "Which",
+   "options": "priced_doctype",
+   "in_list_view": 1,
+   "columns": 2,
+   "description": "Blank means every plan of this kind."
+  },
+  {
+   "fieldname": "cluster",
+   "fieldtype": "Link",
+   "label": "Cluster",
+   "options": "Atlas Instance",
+   "in_list_view": 1,
+   "columns": 1
+  },
+  {
+   "fieldname": "currency",
+   "fieldtype": "Link",
+   "label": "Currency",
+   "options": "Currency",
+   "in_list_view": 1,
+   "columns": 1
+  },
+  {
+   "fieldname": "percent",
+   "fieldtype": "Percent",
+   "label": "Change By",
+   "in_list_view": 1,
+   "columns": 1,
+   "description": "e.g. 20 for a 20% rise."
+  },
+  {
+   "fieldname": "rate",
+   "fieldtype": "Currency",
+   "label": "Or Set To",
+   "in_list_view": 1,
+   "columns": 1
+  },
+  {
+   "fieldname": "effective_from",
+   "fieldtype": "Date",
+   "label": "Effective From",
+   "in_list_view": 1,
+   "columns": 2,
+   "description": "Only segments opened on or after this date are priced from it."
+  }
+ ],
+ "field_order": [
+  "priced_doctype",
+  "priced_for",
+  "cluster",
+  "currency",
+  "percent",
+  "rate",
+  "effective_from"
+ ]
+}

--- a/central/billing/doctype/billing_scenario_rate/billing_scenario_rate.py
+++ b/central/billing/doctype/billing_scenario_rate/billing_scenario_rate.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class BillingScenarioRate(Document):
+	pass

--- a/central/billing/page/billing_simulator/billing_simulator.js
+++ b/central/billing/page/billing_simulator/billing_simulator.js
@@ -81,17 +81,23 @@ class BillingSimulator {
 		// projection we are waiting for — with the default period, silently.
 		this.applying = true;
 		this.show_empty(__("Projecting…"));
+		// Compare rather than project: a scenario's whole point is the difference it
+		// makes, and the difference needs the unaltered projection to sit beside.
 		frappe
 			.call({
-				method: "central.billing.api.admin.projection.project_scenario",
+				method: "central.billing.api.admin.projection.compare_scenario",
 				args: { scenario: name },
 			})
 			.then((r) => {
 				if (!r.message) return;
-				const out = r.message;
+				const comparison = r.message;
+				const out = comparison.altered;
+				out.repricing = comparison.repricing || out.repricing;
+				out.explanation = comparison.explanation;
 				this.team.set_value(out.team);
 				if (out.scenario && out.scenario.months > 1) this.render_months(out);
 				else this.render(out);
+				if (out.repricing) this.$body.prepend(this.repricing_card(out));
 				if (out.scenario) this.$body.prepend(this.pretending_card(out.scenario));
 			})
 			.catch(() => this.show_empty(__("Could not project this scenario.")))
@@ -124,6 +130,58 @@ class BillingSimulator {
 					<span class="bs-muted">${__("Billing Settings are unchanged")}</span>
 				</div>
 				<ul class="bs-findings">${items}</ul>
+			</div>`);
+	}
+
+	// The answer everyone expects to be a multiplication. Showing the two sides is the
+	// only way a zero reads as a finding rather than a bug.
+	repricing_card(out) {
+		const r = out.repricing;
+		const money = (v) => format_currency(v, r.currency);
+		const delta = r.delta === undefined ? null : r.delta;
+
+		return $(`
+			<div class="bs-card">
+				<div class="bs-card-head">
+					<span class="bs-card-title">${__("How this bill is priced")}</span>
+					<span class="bs-muted">${__("Effective {0}", [r.effective_from || "—"])}</span>
+				</div>
+				<table class="bs-table">
+					<thead>
+						<tr>
+							<th>${__("Priced")}</th>
+							<th class="bs-right">${__("Amount")}</th>
+							<th class="bs-right">${__("Resources")}</th>
+							<th>${__("Moves when")}</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>${__("Grandfathered")}</td>
+							<td class="bs-right">${money(r.grandfathered)}</td>
+							<td class="bs-right">${r.grandfathered_resources}</td>
+							<td class="bs-muted">${__("the resource is resized or replaced")}</td>
+						</tr>
+						<tr>
+							<td>${__("Repriced")}</td>
+							<td class="bs-right ${r.repriced ? "bs-short" : ""}">${money(r.repriced)}</td>
+							<td class="bs-right">${r.repriced_resources}</td>
+							<td class="bs-muted">${__("immediately — priced from today's catalog")}</td>
+						</tr>
+					</tbody>
+				</table>
+				<div class="bs-totals">
+					<div class="bs-total bs-grand"><span>${__("What this change does")}</span><span>${
+						delta === null ? "—" : money(delta)
+					}</span></div>
+					${
+						out.explanation
+							? `<p class="bs-muted" style="margin:8px 0 0; line-height:1.55; max-width:74ch">${frappe.utils.escape_html(
+									out.explanation
+							  )}</p>`
+							: ""
+					}
+				</div>
 			</div>`);
 	}
 

--- a/central/billing/projection/estimate.py
+++ b/central/billing/projection/estimate.py
@@ -109,8 +109,10 @@ def _from_trailing(team: str, clusters, period_start, months: int = TRAILING_MON
 
 	merged: dict = {}
 	observed: dict = {}
+	measured_basis: dict = {}
 	for line in history:
 		key = tuple(line.get(f) for f in _KEY)
+		measured_basis.setdefault(key, line.get("derivation"))
 		agg = merged.setdefault(key, {**line, "quantity": 0.0, "amount": 0.0})
 		agg["quantity"] += frappe.utils.flt(line.get("quantity"))
 		agg["amount"] += frappe.utils.flt(line.get("amount"))
@@ -130,6 +132,12 @@ def _from_trailing(team: str, clusters, period_start, months: int = TRAILING_MON
 			"months": months,
 			"observed_total": frappe.utils.flt(observed[key], 2),
 			"arithmetic": f"{frappe.utils.flt(observed[key], 2)} ÷ {months}",
+			# Keep how the underlying usage was priced. Estimating the *quantity* does not
+			# change where the *rate* comes from, and dropping it would make a live-priced
+			# family look grandfathered — reporting that a price change misses usage it
+			# actually reaches.
+			"measured_basis": measured_basis.get(key),
+			"rate_source": (measured_basis.get(key) or {}).get("rate_source"),
 		}
 		out.append(line)
 	return out

--- a/central/billing/projection/repricing.py
+++ b/central/billing/projection/repricing.py
@@ -42,15 +42,18 @@ def classify(line: dict, effective_from=None) -> str:
 	taken before the change existed.
 	"""
 	derivation = line.get("derivation") or {}
+	# An estimated line wraps the measured one it was inferred from. Estimating a
+	# quantity says nothing about where the rate came from, so look through.
+	measured = derivation.get("measured_basis") or {}
 
-	if derivation.get("rate_source") == _LIVE_RATE_SOURCE:
+	if _LIVE_RATE_SOURCE in (derivation.get("rate_source"), measured.get("rate_source")):
 		return REPRICED
 
 	# `rate_locked_at`, never `segment_from`. The latter is clamped to the billing window,
 	# so a resource provisioned in March reads as opening on the 1st of whatever month is
 	# being projected — which would classify every long-running subscription as newly
 	# priced and report the exact opposite of the truth.
-	locked_at = derivation.get("rate_locked_at")
+	locked_at = derivation.get("rate_locked_at") or measured.get("rate_locked_at")
 	if effective_from and locked_at:
 		if frappe.utils.getdate(locked_at) >= frappe.utils.getdate(effective_from):
 			return REPRICED
@@ -71,11 +74,26 @@ def split(lines: list, currency: str, effective_from=None) -> dict:
 
 	return {
 		"currency": currency,
+		# Structural: how this bill is priced, regardless of which change is being asked
+		# about. What a *particular* change did is the delta between the two projections —
+		# a different question, and conflating them would over-claim whenever an override
+		# touches one family and the bill contains another that merely happens to be
+		# live-priced.
 		"grandfathered": frappe.utils.flt(buckets[GRANDFATHERED], 2),
 		"repriced": frappe.utils.flt(buckets[REPRICED], 2),
 		"grandfathered_resources": len(resources[GRANDFATHERED]),
 		"repriced_resources": len(resources[REPRICED]),
 		"effective_from": str(effective_from) if effective_from else None,
+	}
+
+
+def with_delta(split_result: dict, live_total: float, altered_total: float) -> dict:
+	"""Attach what the change actually did to how the bill is priced."""
+	return {
+		**split_result,
+		"delta": frappe.utils.flt(altered_total - live_total, 2),
+		"live_total": frappe.utils.flt(live_total, 2),
+		"altered_total": frappe.utils.flt(altered_total, 2),
 	}
 
 

--- a/central/billing/projection/repricing.py
+++ b/central/billing/projection/repricing.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""What a price change actually reaches.
+
+This is the misconception the simulator exists to dispel. Ask anyone outside the team
+what raising VM prices 20% does to next month's revenue and they will multiply the book
+by 1.2. They will be wrong by roughly everything, because a bundle's rate is snapshotted
+as `locked_rate` on the Subscription Change row that opened its segment
+([ADR 0010](../../docs/adr/0010-price-lock-folded-into-subscription-change.md)). Billing
+reads that snapshot forever. Changing a Catalog Rate reaches new provisions and resizes
+— nothing else.
+
+So a projected line falls into one of two buckets, and the split is the answer:
+
+  **Grandfathered** — billed from a rate locked when the resource was provisioned. A
+  catalog change does not touch it, this month or any month, until the customer resizes.
+
+  **Repriced** — billed from whatever the catalog says today. Live-priced families
+  (depreciating storage, the deliberate exception to grandfathering) and any segment
+  opened after the change land here.
+
+A simulator that modelled a price rise as multiplication would encode the exact error it
+was built to correct, so the classification is read from the derivation each line already
+carries rather than guessed at.
+"""
+
+import frappe
+
+GRANDFATHERED = "Grandfathered"
+REPRICED = "Repriced"
+
+# `metering` records where a metered line's rate came from; this is the phrase it uses
+# for a family that reads the current catalog rather than terms locked at ingest.
+_LIVE_RATE_SOURCE = "current catalog rate"
+
+
+def classify(line: dict, effective_from=None) -> str:
+	"""Which bucket one projected line belongs to.
+
+	`effective_from` is the date a price change would take effect. A segment that opened
+	on or after it was priced under the new catalog; everything older carries a snapshot
+	taken before the change existed.
+	"""
+	derivation = line.get("derivation") or {}
+
+	if derivation.get("rate_source") == _LIVE_RATE_SOURCE:
+		return REPRICED
+
+	# `rate_locked_at`, never `segment_from`. The latter is clamped to the billing window,
+	# so a resource provisioned in March reads as opening on the 1st of whatever month is
+	# being projected — which would classify every long-running subscription as newly
+	# priced and report the exact opposite of the truth.
+	locked_at = derivation.get("rate_locked_at")
+	if effective_from and locked_at:
+		if frappe.utils.getdate(locked_at) >= frappe.utils.getdate(effective_from):
+			return REPRICED
+
+	return GRANDFATHERED
+
+
+def split(lines: list, currency: str, effective_from=None) -> dict:
+	"""Divide a projected invoice into what a price change reaches and what it does not."""
+	buckets = {GRANDFATHERED: 0.0, REPRICED: 0.0}
+	resources = {GRANDFATHERED: set(), REPRICED: set()}
+
+	for line in lines or []:
+		bucket = classify(line, effective_from)
+		buckets[bucket] += frappe.utils.flt(line.get("amount"))
+		if line.get("subscription_resource"):
+			resources[bucket].add(line["subscription_resource"])
+
+	return {
+		"currency": currency,
+		"grandfathered": frappe.utils.flt(buckets[GRANDFATHERED], 2),
+		"repriced": frappe.utils.flt(buckets[REPRICED], 2),
+		"grandfathered_resources": len(resources[GRANDFATHERED]),
+		"repriced_resources": len(resources[REPRICED]),
+		"effective_from": str(effective_from) if effective_from else None,
+	}
+
+
+def explain(live_total: float, altered_total: float, split_result: dict) -> str:
+	"""One sentence an operator can act on, in place of a number they will misread."""
+	delta = frappe.utils.flt(altered_total - live_total, 2)
+	currency = split_result["currency"]
+	grandfathered = split_result["grandfathered"]
+	repriced = split_result["repriced"]
+
+	if not delta:
+		return (
+			f"No change this period. {currency} {grandfathered:,.2f} is billed at rates locked "
+			f"when each resource was provisioned, and a catalog change does not reach a locked "
+			f"rate — only new provisions and resizes are priced from the new one."
+		)
+
+	return (
+		f"{currency} {delta:,.2f} this period, from the {currency} {repriced:,.2f} that is "
+		f"priced live. The other {currency} {grandfathered:,.2f} is grandfathered and moves "
+		f"only when those resources are resized or replaced."
+	)

--- a/central/billing/projection/scenario.py
+++ b/central/billing/projection/scenario.py
@@ -16,7 +16,8 @@ invoice", so it carries its own test.
 import frappe
 
 from central.billing import settings
-from central.billing.projection import engine
+from central.billing.catalog import pricing
+from central.billing.projection import engine, repricing
 
 # The only DocType this module may write. Asserted, because the whole safety argument
 # for running projections against production rests on it staying true.
@@ -44,7 +45,8 @@ def project(scenario, today=None) -> dict:
 	period_start = frappe.utils.get_first_day(doc.period_start or today)
 	months = max(1, frappe.utils.cint(doc.months) or 1)
 
-	with settings.overridden(**overrides):
+	rates = doc.rate_overrides_applied()
+	with settings.overridden(**overrides), pricing.overridden_rates(rates):
 		if months > 1:
 			out = engine.project_months(
 				doc.team, period_start, months=months, today=today,
@@ -56,16 +58,34 @@ def project(scenario, today=None) -> dict:
 				mode=doc.outcome_mode, assume=doc.assume,
 			)
 
+	# What a price change actually reaches — the part everyone gets wrong.
+	if rates:
+		out["repricing"] = repricing.split(
+			_all_lines(out), out.get("currency"), doc.effective_from()
+		)
+
 	# Say what was pretended. A projection under an altered ladder that does not
 	# announce it is a number waiting to be quoted as fact.
 	out["scenario"] = {
 		"name": doc.name,
 		"scenario_name": doc.scenario_name,
 		"overrides": overrides,
+		"rate_overrides": rates,
 		"outcome_mode": doc.outcome_mode,
 		"months": months,
 	}
 	return out
+
+
+def _all_lines(out) -> list:
+	"""Every projected line, whether the projection was one month or several."""
+	if out.get("months"):
+		return [
+			line
+			for month in out["months"]
+			for line in ((month.get("invoice") or {}).get("lines") or [])
+		]
+	return (out.get("invoice") or {}).get("lines") or []
 
 
 def project_and_save(scenario, today=None) -> dict:
@@ -91,14 +111,33 @@ def compare(scenario, today=None) -> dict:
 	doc = _resolve(scenario)
 	overrides = doc.overrides()
 
+	rates = doc.rate_overrides_applied()
 	live = project(_bare(doc), today)
-	altered = project(doc, today) if overrides else live
-	return {
+	altered = project(doc, today) if (overrides or rates) else live
+
+	result = {
 		"overrides": overrides,
+		"rate_overrides": rates,
 		"live": live,
 		"altered": altered,
-		"changed": bool(overrides),
+		"changed": bool(overrides or rates),
 	}
+	if rates:
+		# Say what the number means, because the number alone is the thing that gets
+		# misread: a catalog change does not reach a locked rate.
+		result["repricing"] = altered.get("repricing")
+		result["explanation"] = repricing.explain(
+			_total(live), _total(altered), altered["repricing"]
+		)
+	return result
+
+
+def _total(out) -> float:
+	if out.get("months"):
+		return frappe.utils.flt(
+			sum(frappe.utils.flt((m.get("invoice") or {}).get("total")) for m in out["months"]), 2
+		)
+	return frappe.utils.flt((out.get("invoice") or {}).get("total"), 2)
 
 
 def _bare(doc):
@@ -108,6 +147,7 @@ def _bare(doc):
 
 	for field in OVERRIDE_FIELDS:
 		clone.set(field, None)
+	clone.set("rate_overrides", [])
 	return clone
 
 

--- a/central/billing/projection/scenario.py
+++ b/central/billing/projection/scenario.py
@@ -125,7 +125,9 @@ def compare(scenario, today=None) -> dict:
 	if rates:
 		# Say what the number means, because the number alone is the thing that gets
 		# misread: a catalog change does not reach a locked rate.
-		result["repricing"] = altered.get("repricing")
+		result["repricing"] = repricing.with_delta(
+			altered["repricing"], _total(live), _total(altered)
+		)
 		result["explanation"] = repricing.explain(
 			_total(live), _total(altered), altered["repricing"]
 		)

--- a/central/billing/revenue/invoicing/lines.py
+++ b/central/billing/revenue/invoicing/lines.py
@@ -141,6 +141,11 @@ def _subscription_lines(sub, cluster: str, changes: list, b, explain: bool = Fal
 			{
 				"start": start,
 				"end": end,
+				# When the rate was actually locked, before any clamping to this billing
+				# window. `start` answers "what does this month bill"; this answers "when
+				# was this price set", which is what grandfathering turns on — and the two
+				# are the same only in the month a resource was provisioned.
+				"opened_at": seg_start_dt,
 				"rate": frappe.utils.flt(change.locked_rate),
 				"plan": change.new_value,
 				"asset": sub.asset_id,
@@ -242,6 +247,7 @@ def _daily_line(
 			"why": "the config was held for a day or more, so whole days are billed",
 			"segment_from": str(seg["start"]),
 			"segment_to": str(seg["end"]),
+			"rate_locked_at": str(seg["opened_at"]),
 			"locked_rate": seg["rate"],
 			"days": days,
 			"day_units": day_units,
@@ -277,6 +283,7 @@ def _hourly_line(
 			"charge_date": str(charge_date),
 			"segment_from": str(seg["start"]),
 			"segment_to": str(seg["end"]),
+			"rate_locked_at": str(seg["opened_at"]),
 			"locked_rate": seg["rate"],
 			"hours": frappe.utils.flt(hours, 2),
 			"hour_units": hour_units,

--- a/central/billing/tests/test_projection_repricing.py
+++ b/central/billing/tests/test_projection_repricing.py
@@ -272,3 +272,42 @@ class TestLivePricedFamilies(RepricingTestBase):
 			out["altered"]["invoice"]["total"], out["live"]["invoice"]["total"]
 		)
 		self.assertIn("priced live", out["explanation"])
+
+
+class TestEstimatedLinesKeepTheirPricingBasis(IntegrationTestCase):
+	def test_an_estimated_live_priced_line_is_still_repriced(self):
+		# Estimating the quantity says nothing about where the rate comes from. Losing
+		# that would report a price change as missing usage it actually reaches.
+		line = {
+			"amount": 933.33,
+			"derivation": {
+				"mode": "Estimated",
+				"measured_basis": {"rate_source": "current catalog rate"},
+				"rate_source": "current catalog rate",
+			},
+		}
+		self.assertEqual(repricing.classify(line), repricing.REPRICED)
+
+	def test_an_estimated_grandfathered_line_stays_grandfathered(self):
+		line = {
+			"amount": 100,
+			"derivation": {
+				"mode": "Estimated",
+				"measured_basis": {"rate_source": "locked at ingest"},
+				"rate_source": "locked at ingest",
+			},
+		}
+		self.assertEqual(repricing.classify(line), repricing.GRANDFATHERED)
+
+
+class TestTheSplitDoesNotOverclaim(RepricingTestBase):
+	def test_the_structural_split_and_the_change_are_reported_separately(self):
+		# Live-priced revenue is repriceable whether or not *this* override touches it.
+		# What the change did is the delta, and the two must not be read as one number.
+		out = scenario.compare(self._scenario(percent=20), today=TODAY)
+		r = out["repricing"]
+
+		self.assertIn("grandfathered", r)
+		self.assertIn("delta", r)
+		self.assertEqual(r["delta"], r["altered_total"] - r["live_total"])
+		self.assertEqual(r["delta"], 0.0)

--- a/central/billing/tests/test_projection_repricing.py
+++ b/central/billing/tests/test_projection_repricing.py
@@ -1,0 +1,274 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""What a price change actually reaches.
+
+The misconception this whole tool exists to correct: raising a catalog rate does not
+reprice a running subscription. The rate was snapshotted when the resource was
+provisioned, and billing reads that snapshot until the customer resizes.
+"""
+
+import frappe
+from central.billing.catalog import pricing
+from central.billing.projection import repricing, scenario
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+from central.billing.tests.utils import (
+	add_segment,
+	ensure_team,
+	make_billing_subscription,
+	make_metered_plan,
+	make_plan,
+)
+
+TEAM = "team-repricing"
+CLUSTER = "ap-south-1"
+PLAN = "bundle-repricing"
+TODAY = "2026-08-06"
+
+
+class TestTheRateSeam(IntegrationTestCase):
+	def setUp(self):
+		make_plan(PLAN, rates=[{"cluster": "", "currency": "INR", "rate": 1000}])
+		frappe.db.commit()
+
+	def test_without_an_override_the_published_rate_is_read(self):
+		rows = pricing.get_catalog_rates("Plan", PLAN)
+		self.assertEqual(resolve(rows), 1000.0)
+
+	def test_a_percentage_override_is_read_instead(self):
+		with pricing.overridden_rates([
+			{"priced_doctype": "Plan", "priced_for": PLAN, "percent": 20}
+		]):
+			self.assertEqual(resolve(pricing.get_catalog_rates("Plan", PLAN)), 1200.0)
+
+	def test_a_flat_override_replaces_the_rate(self):
+		with pricing.overridden_rates([
+			{"priced_doctype": "Plan", "priced_for": PLAN, "rate": 250}
+		]):
+			self.assertEqual(resolve(pricing.get_catalog_rates("Plan", PLAN)), 250.0)
+
+	def test_an_override_for_another_plan_is_ignored(self):
+		with pricing.overridden_rates([
+			{"priced_doctype": "Plan", "priced_for": "some-other-plan", "percent": 50}
+		]):
+			self.assertEqual(resolve(pricing.get_catalog_rates("Plan", PLAN)), 1000.0)
+
+	def test_a_currency_narrowed_override_leaves_other_currencies_alone(self):
+		with pricing.overridden_rates([
+			{"priced_doctype": "Plan", "priced_for": PLAN, "currency": "USD", "percent": 99}
+		]):
+			self.assertEqual(resolve(pricing.get_catalog_rates("Plan", PLAN)), 1000.0)
+
+	def test_the_published_rate_is_never_written(self):
+		# Asking what a price rise would do must not publish one.
+		with pricing.overridden_rates([
+			{"priced_doctype": "Plan", "priced_for": PLAN, "percent": 20}
+		]):
+			pricing.get_catalog_rates("Plan", PLAN)
+		stored = frappe.db.get_value(
+			"Catalog Rate", {"priced_doctype": "Plan", "priced_for": PLAN}, "rate"
+		)
+		self.assertEqual(frappe.utils.flt(stored), 1000.0)
+
+	def test_the_override_lifts_when_the_block_ends(self):
+		with pricing.overridden_rates([
+			{"priced_doctype": "Plan", "priced_for": PLAN, "percent": 20}
+		]):
+			pass
+		self.assertEqual(resolve(pricing.get_catalog_rates("Plan", PLAN)), 1000.0)
+
+
+def resolve(rows):
+	return pricing.resolve_rate(rows, "INR", None)
+
+
+class TestClassification(IntegrationTestCase):
+	def test_a_rate_locked_before_the_change_is_grandfathered(self):
+		line = {"amount": 100, "derivation": {"locked_rate": 1000, "rate_locked_at": "2026-01-01 00:00:00"}}
+		self.assertEqual(repricing.classify(line, "2026-09-01"), repricing.GRANDFATHERED)
+
+	def test_a_rate_locked_after_the_change_is_repriced(self):
+		line = {"amount": 100, "derivation": {"locked_rate": 1200, "rate_locked_at": "2026-09-15 00:00:00"}}
+		self.assertEqual(repricing.classify(line, "2026-09-01"), repricing.REPRICED)
+
+	def test_the_clamped_billing_window_is_never_mistaken_for_the_locking_date(self):
+		# segment_from is clamped to the period, so a resource provisioned in March reads
+		# as opening on 1 September when September is projected. Classifying on it would
+		# call every long-running subscription newly priced — the exact opposite of true.
+		line = {
+			"amount": 100,
+			"derivation": {
+				"segment_from": "2026-09-01 00:00:00",
+				"rate_locked_at": "2026-03-01 00:00:00",
+				"locked_rate": 1000,
+			},
+		}
+		self.assertEqual(repricing.classify(line, "2026-09-01"), repricing.GRANDFATHERED)
+
+	def test_a_live_priced_family_is_always_repriced(self):
+		# Depreciating storage is the deliberate exception to grandfathering: it reads
+		# today's catalog every period, so a change reaches it at once.
+		line = {"amount": 50, "derivation": {"rate_source": "current catalog rate"}}
+		self.assertEqual(repricing.classify(line), repricing.REPRICED)
+
+	def test_terms_locked_at_ingest_are_grandfathered(self):
+		line = {"amount": 50, "derivation": {"rate_source": "locked at ingest"}}
+		self.assertEqual(repricing.classify(line), repricing.GRANDFATHERED)
+
+	def test_the_split_counts_money_and_resources_on_each_side(self):
+		lines = [
+			{"amount": 1000, "subscription_resource": "a",
+			 "derivation": {"locked_rate": 1000, "rate_locked_at": "2026-01-01 00:00:00"}},
+			{"amount": 500, "subscription_resource": "b",
+			 "derivation": {"locked_rate": 500, "rate_locked_at": "2026-01-01 00:00:00"}},
+			{"amount": 40, "subscription_resource": "c",
+			 "derivation": {"rate_source": "current catalog rate"}},
+		]
+		out = repricing.split(lines, "INR", "2026-09-01")
+		self.assertEqual(out["grandfathered"], 1500.0)
+		self.assertEqual(out["repriced"], 40.0)
+		self.assertEqual(out["grandfathered_resources"], 2)
+		self.assertEqual(out["repriced_resources"], 1)
+
+
+class RepricingTestBase(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		make_plan(PLAN, rates=[{"cluster": "", "currency": "INR", "rate": 12000}])
+		self._purge()
+		self.sub = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
+		# Provisioned in March at 12,000 — the rate that follows it forever.
+		add_segment(self.sub, "Created", 12000, "2026-03-01 00:00:00")
+		frappe.db.commit()
+
+	def tearDown(self):
+		self._purge()
+
+	def _purge(self):
+		for name in frappe.get_all("Billing Scenario", pluck="name"):
+			frappe.delete_doc("Billing Scenario", name, force=True, ignore_permissions=True)
+		frappe.db.delete("Invoice", {"team": TEAM})
+		frappe.db.delete("Usage Rollup", {"team": TEAM})
+		for sub in frappe.get_all("Subscription", {"team": TEAM}, pluck="name"):
+			frappe.db.delete("Subscription Change", {"subscription": sub})
+			frappe.db.delete("Subscription", {"name": sub})
+		frappe.db.delete("Asset", {"team": TEAM})
+		frappe.db.commit()
+
+	def _scenario(self, percent=20, effective_from="2026-09-01"):
+		doc = frappe.get_doc(
+			{
+				"doctype": "Billing Scenario",
+				"scenario_name": f"Raise VM prices {percent}%",
+				"team": TEAM,
+				"period_start": "2026-09-01",
+				"months": 1,
+				"outcome_mode": "Derived",
+				"rate_overrides": [
+					{
+						"priced_doctype": "Plan",
+						"priced_for": PLAN,
+						"currency": "INR",
+						"percent": percent,
+						"effective_from": effective_from,
+					}
+				],
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+		return doc
+
+
+class TestTheHeadlineAnswer(RepricingTestBase):
+	def test_a_twenty_percent_rise_changes_nothing_for_a_running_subscription(self):
+		# The whole point. A naive model would report +20%; the real answer is zero,
+		# because the rate was locked in March and billing reads that snapshot.
+		out = scenario.compare(self._scenario(percent=20), today=TODAY)
+
+		self.assertEqual(
+			out["live"]["invoice"]["total"], out["altered"]["invoice"]["total"]
+		)
+
+	def test_the_output_says_why_rather_than_leaving_a_zero_to_be_doubted(self):
+		out = scenario.compare(self._scenario(percent=20), today=TODAY)
+		self.assertIn("No change this period", out["explanation"])
+		self.assertIn("locked", out["explanation"])
+
+	def test_the_revenue_is_reported_as_grandfathered(self):
+		out = scenario.compare(self._scenario(percent=20), today=TODAY)
+		split = out["repricing"]
+		self.assertEqual(split["grandfathered"], 12000.0)
+		self.assertEqual(split["repriced"], 0.0)
+		self.assertEqual(split["grandfathered_resources"], 1)
+
+	def test_the_delta_is_far_smaller_than_multiplying_the_book(self):
+		out = scenario.compare(self._scenario(percent=20), today=TODAY)
+		naive = out["live"]["invoice"]["total"] * 0.20
+		actual = out["altered"]["invoice"]["total"] - out["live"]["invoice"]["total"]
+		self.assertGreater(naive, 0)
+		self.assertLess(actual, naive)
+
+
+class TestLivePricedFamilies(RepricingTestBase):
+	def setUp(self):
+		super().setUp()
+		make_plan(
+			PLAN,
+			rates=[{"cluster": "", "currency": "INR", "rate": 12000}],
+			includes=[{"resource_type": "Transfer", "quantity": 100, "unit": "GB"}],
+		)
+		make_metered_plan(
+			"meter-transfer-repricing",
+			resource_type="Transfer",
+			rates=[{"cluster": "", "currency": "INR", "rate": 1.0}],
+			pricing_mode="Live",
+		)
+		frappe.get_doc(
+			{
+				"doctype": "Usage Rollup",
+				"resource_id": frappe.db.get_value("Subscription", self.sub, "asset_id"),
+				"team": TEAM,
+				"cluster": CLUSTER,
+				"resource_type": "Transfer",
+				"meter_type": "Counter",
+				"period_start": "2026-08-01 00:00:00",
+				"period_end": "2026-08-28 23:59:59",
+				"quantity": 300,
+				"unit": "GB",
+				"currency": "INR",
+				"locked_allowance": 100,
+				"locked_rate": 1.0,
+				"idempotency_key": "reprice:2026-08",
+				"sequence": 0,
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	def test_a_live_priced_add_on_does_move_with_the_catalog(self):
+		# The deliberate exception to grandfathering, and the reason the split has two
+		# sides rather than a blanket "nothing changes".
+		doc = frappe.get_doc(
+			{
+				"doctype": "Billing Scenario",
+				"scenario_name": "Raise transfer 50%",
+				"team": TEAM,
+				"period_start": "2026-09-01",
+				"months": 1,
+				"outcome_mode": "Derived",
+				"rate_overrides": [
+					{
+						"priced_doctype": "Plan",
+						"priced_for": "meter-transfer-repricing",
+						"currency": "INR",
+						"percent": 50,
+						"effective_from": "2026-09-01",
+					}
+				],
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+		out = scenario.compare(doc, today=TODAY)
+		self.assertGreater(
+			out["altered"]["invoice"]["total"], out["live"]["invoice"]["total"]
+		)
+		self.assertIn("priced live", out["explanation"])


### PR DESCRIPTION
Ask anyone outside the team what raising VM prices 20% does to next month's revenue and they will multiply the book by 1.2. They will be wrong by roughly everything.

A bundle's rate is snapshotted as `locked_rate` on the Subscription Change row that opened its segment (ADR 0010). Billing reads that snapshot forever. Changing a Catalog Rate reaches new provisions and resizes — nothing else.

<img width="1440" height="1000" alt="9-price-change" src="https://github.com/user-attachments/assets/9ba13471-9dd0-46fb-abc2-6e79689ccc54" />

## Two questions, kept apart

```mermaid
flowchart TD
    L["Projected line"] --> Q{"Where did its rate come from?"}
    Q -->|locked when provisioned| G["Grandfathered<br/>moves when resized or replaced"]
    Q -->|today's catalog<br/>live-priced family| R["Repriced<br/>moves immediately"]
    Q -->|locked on/after the change| R

    G & R --> S["Structural split — how this bill is priced"]
    D["live vs altered projection"] --> DELTA["Delta — what THIS change did"]

    style G fill:#e4f5e9,stroke:#30a66d
    style R fill:#fff1e7,stroke:#bd3e0c
```

The split says how much of a bill *could* move. The delta says what a *particular* change did. Reporting one as the other over-claims whenever an override touches one family and the bill contains another that merely happens to be live-priced.

## Rates are overridden the way settings are

Read instead of published, never written — a test asserts the Catalog Rate row is untouched after an override lifts. Every rate resolution in the module goes through one function, so overriding there reaches plan rates, the component rate card and live-priced metered plans alike, without any of them learning a simulator exists.