### PR TITLE
feat(admin): Put things that have not happened on the calendar

### DIFF
--- a/central/billing/doctype/billing_scenario/billing_scenario.json
+++ b/central/billing/doctype/billing_scenario/billing_scenario.json
@@ -112,6 +112,18 @@
    "label": "Promotional Credit Validity Days"
   },
   {
+   "fieldname": "section_break_events",
+   "fieldtype": "Section Break",
+   "label": "Things that have not happened",
+   "description": "Placed on the calendar and rated by the same engine that rates real ones."
+  },
+  {
+   "fieldname": "events",
+   "fieldtype": "Table",
+   "label": "Events",
+   "options": "Billing Scenario Event"
+  },
+  {
    "fieldname": "section_break_rates",
    "fieldtype": "Section Break",
    "label": "Instead of the published prices",
@@ -157,6 +169,8 @@
   "suspend_after_days",
   "terminate_after_days",
   "promotional_credit_validity_days",
+  "section_break_events",
+  "events",
   "section_break_rates",
   "rate_overrides",
   "section_break_result",

--- a/central/billing/doctype/billing_scenario/billing_scenario.py
+++ b/central/billing/doctype/billing_scenario/billing_scenario.py
@@ -41,6 +41,22 @@ class BillingScenario(Document):
 			for row in (self.rate_overrides or [])
 		]
 
+	def injected_events(self) -> list[dict]:
+		"""The invented events, as plain rows the projection can reason about."""
+		return [
+			{
+				"event_type": row.event_type,
+				"on_date": row.on_date,
+				"subscription": row.subscription,
+				"plan": row.plan,
+				"rate": row.rate,
+				"amount": row.amount,
+				"currency": row.currency,
+				"attempt": row.attempt,
+			}
+			for row in (self.events or [])
+		]
+
 	def effective_from(self):
 		"""The earliest date any pretended price takes effect."""
 		dates = [r.effective_from for r in (self.rate_overrides or []) if r.effective_from]

--- a/central/billing/doctype/billing_scenario_event/billing_scenario_event.json
+++ b/central/billing/doctype/billing_scenario_event/billing_scenario_event.json
@@ -1,0 +1,98 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "creation": "2026-08-07 00:00:00.000000",
+ "description": "Something that has not happened, placed on a projection's calendar.",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "istable": 1,
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-08-07 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Billing",
+ "name": "Billing Scenario Event",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "fields": [
+  {
+   "fieldname": "event_type",
+   "fieldtype": "Select",
+   "label": "What",
+   "options": "Resize\nProvision\nCancel\nTop up\nDecline",
+   "reqd": 1,
+   "in_list_view": 1,
+   "columns": 1
+  },
+  {
+   "fieldname": "on_date",
+   "fieldtype": "Datetime",
+   "label": "When",
+   "reqd": 1,
+   "in_list_view": 1,
+   "columns": 2
+  },
+  {
+   "fieldname": "subscription",
+   "fieldtype": "Link",
+   "label": "Subscription",
+   "options": "Subscription",
+   "in_list_view": 1,
+   "columns": 2,
+   "depends_on": "eval:['Resize','Provision','Cancel'].includes(doc.event_type)"
+  },
+  {
+   "fieldname": "plan",
+   "fieldtype": "Link",
+   "label": "Plan",
+   "options": "Plan",
+   "in_list_view": 1,
+   "columns": 2,
+   "depends_on": "eval:['Resize','Provision'].includes(doc.event_type)"
+  },
+  {
+   "fieldname": "rate",
+   "fieldtype": "Currency",
+   "label": "Rate",
+   "in_list_view": 1,
+   "columns": 1,
+   "depends_on": "eval:['Resize','Provision'].includes(doc.event_type)"
+  },
+  {
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "label": "Amount",
+   "in_list_view": 1,
+   "columns": 1,
+   "depends_on": "eval:doc.event_type=='Top up'"
+  },
+  {
+   "fieldname": "currency",
+   "fieldtype": "Link",
+   "label": "Currency",
+   "options": "Currency",
+   "depends_on": "eval:doc.event_type=='Top up'"
+  },
+  {
+   "fieldname": "attempt",
+   "fieldtype": "Int",
+   "label": "Attempt",
+   "depends_on": "eval:doc.event_type=='Decline'",
+   "description": "Which charge attempt fails."
+  }
+ ],
+ "field_order": [
+  "event_type",
+  "on_date",
+  "subscription",
+  "plan",
+  "rate",
+  "amount",
+  "currency",
+  "attempt"
+ ]
+}

--- a/central/billing/doctype/billing_scenario_event/billing_scenario_event.py
+++ b/central/billing/doctype/billing_scenario_event/billing_scenario_event.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class BillingScenarioEvent(Document):
+	pass

--- a/central/billing/page/billing_simulator/billing_simulator.js
+++ b/central/billing/page/billing_simulator/billing_simulator.js
@@ -367,13 +367,22 @@ class BillingSimulator {
 
 		// A total is never shown on its own when part of it was inferred — a bill that
 		// is half guesswork must not read like a bill.
+		// Every basis present gets a row. A split that does not add up to the total is
+		// worse than no split — it invites the reader to trust the total and ignore it.
 		const split = invoice.has_estimates
-			? `<div class="bs-total"><span>${__("Measured")}</span><span>${money(
-					invoice.measured
-			  )}</span></div>
-			   <div class="bs-total"><span>${__("Estimated")}</span><span>${money(
-					invoice.estimated
-			  )}</span></div>`
+			? [
+					["Measured", invoice.measured],
+					["Estimated", invoice.estimated],
+					["Assumed", invoice.assumed],
+			  ]
+					.filter(([, amount]) => amount)
+					.map(
+						([label, amount]) =>
+							`<div class="bs-total"><span>${__(label)}</span><span>${money(
+								amount
+							)}</span></div>`
+					)
+					.join("")
 			: "";
 
 		const tax = invoice.output_tax_amount

--- a/central/billing/page/billing_simulator/billing_simulator.js
+++ b/central/billing/page/billing_simulator/billing_simulator.js
@@ -235,6 +235,10 @@ class BillingSimulator {
 	render(data) {
 		this.$body.empty();
 		this.$body.append(this.invoice_card(data));
+		if (data.refused && data.refused.length) this.$body.append(this.refused_card(data.refused));
+		if (data.injected_events && data.injected_events.length) {
+			this.$body.append(this.injected_card(data.injected_events));
+		}
 		if (data.outcome) this.$body.append(this.findings_card(data.outcome));
 		this.$body.append(this.calendar_card(data.calendar, data.outcome));
 		if (data.in_flight && data.in_flight.length) {
@@ -414,6 +418,53 @@ class BillingSimulator {
 			$(this).find(".bs-caret").text(open ? "▸" : "▾");
 		});
 		return $card;
+	}
+
+	// ---- things somebody invented ------------------------------------------
+
+	injected_card(events) {
+		const rows = events
+			.map(
+				(e) => `<tr>
+					<td>${e.date}</td>
+					<td>${frappe.utils.escape_html(e.event)}</td>
+					<td class="bs-muted">${frappe.utils.escape_html(e.detail || "")}</td>
+				</tr>`
+			)
+			.join("");
+		return $(`
+			<div class="bs-card">
+				<div class="bs-card-head">
+					<span class="bs-card-title">${__("Assumed to happen")}</span>
+					<span class="bs-muted">${__("None of this is history")}</span>
+				</div>
+				<table class="bs-table">
+					<thead><tr><th>${__("When")}</th><th>${__("What")}</th><th>${__("Detail")}</th></tr></thead>
+					<tbody>${rows}</tbody>
+				</table>
+			</div>`);
+	}
+
+	refused_card(refused) {
+		// A scenario that could not happen is a finding, not a projection.
+		const items = refused
+			.map(
+				(r) => `<li class="bs-finding">
+					<span class="bs-finding-summary">${frappe.utils.escape_html(r.event)} ${
+						r.on_date
+					} — ${frappe.utils.escape_html(r.reason)}</span>
+					<span class="bs-muted">${frappe.utils.escape_html(r.detail || "")}</span>
+				</li>`
+			)
+			.join("");
+		return $(`
+			<div class="bs-card">
+				<div class="bs-card-head">
+					<span class="bs-card-title">${__("This could not happen")}</span>
+					<span class="bs-muted">${__("The platform would refuse it")}</span>
+				</div>
+				<ul class="bs-findings">${items}</ul>
+			</div>`);
 	}
 
 	// ---- what the state already decides ------------------------------------

--- a/central/billing/projection/engine.py
+++ b/central/billing/projection/engine.py
@@ -16,7 +16,7 @@ guarantee rather than a convention — see `guard`.
 import frappe
 
 from central.billing import settings
-from central.billing.projection import estimate, outcomes, state
+from central.billing.projection import estimate, events as injected, outcomes, state
 from central.billing.projection.basis import MEASURED, mark, split_totals
 from central.billing.projection.guard import read_only
 from central.billing.revenue.dunning import dunning_clock_start, dunning_policy, dunning_schedule
@@ -30,6 +30,7 @@ def project(
 	today=None,
 	mode: str = outcomes.DERIVED,
 	assume: str | None = None,
+	events: list | None = None,
 	recorder=None,
 	source=None,
 ) -> dict:
@@ -42,20 +43,29 @@ def project(
 	engine.
 	"""
 	with read_only():
-		return _project(team, period_start, period_end, today, mode, assume)
+		return _project(team, period_start, period_end, today, mode, assume, events)
 
 
 def _project(
-	team: str, period_start, period_end, today=None, mode: str = outcomes.DERIVED, assume=None
+	team: str, period_start, period_end, today=None, mode: str = outcomes.DERIVED,
+	assume=None, events: list | None = None,
 ) -> dict:
 	today = frappe.utils.getdate(today or frappe.utils.nowdate())
 	start = frappe.utils.getdate(period_start)
 	end = frappe.utils.getdate(period_end)
 
 	metered = estimate.metered_lines(team, team_clusters(team), start, end, today=today)
-	rated = rate_team_period(team, start, end, metered=metered, explain=True)
+	rated = rate_team_period(
+		team, start, end, metered=metered, explain=True,
+		changes=injected.merged_changes(events, start, end),
+	)
 
 	invoice = _invoice(rated)
+	if invoice and events:
+		# A line that only exists because somebody invented an event is not a
+		# measurement, and the totals must not let it read as one.
+		injected.mark_assumed(invoice["lines"], events, start)
+		invoice.update(split_totals(invoice["lines"]))
 	currency = frappe.db.get_value("Billing Profile", team, "currency")
 	calendar = _calendar(end, today)
 
@@ -78,6 +88,8 @@ def _project(
 		"calendar": calendar,
 		"outcome": outcomes.verdict(mode, findings, assume),
 		"in_flight": _in_flight(team, today),
+		"injected_events": injected.timeline(events),
+		"refused": injected.refusals(team, events),
 	}
 
 
@@ -198,6 +210,7 @@ def project_months(
 	today=None,
 	mode: str = outcomes.DERIVED,
 	assume: str | None = None,
+	events: list | None = None,
 ) -> dict:
 	"""Roll a team forward month by month, carrying what each month changes.
 
@@ -209,10 +222,12 @@ def project_months(
 	comfortable balance every month because it re-read today's.
 	"""
 	with read_only():
-		return _project_months(team, start, months, today, mode, assume)
+		return _project_months(team, start, months, today, mode, assume, events)
 
 
-def _project_months(team, start, months, today=None, mode=outcomes.DERIVED, assume=None) -> dict:
+def _project_months(
+	team, start, months, today=None, mode=outcomes.DERIVED, assume=None, events=None
+) -> dict:
 	today = frappe.utils.getdate(today or frappe.utils.nowdate())
 	carried = state.seed(team, today)
 	period_start = frappe.utils.get_first_day(start)
@@ -220,7 +235,9 @@ def _project_months(team, start, months, today=None, mode=outcomes.DERIVED, assu
 	periods = []
 	for _ in range(max(1, frappe.utils.cint(months))):
 		period_end = frappe.utils.get_last_day(period_start)
-		periods.append(_roll_one(team, carried, period_start, period_end, today, mode, assume))
+		periods.append(
+			_roll_one(team, carried, period_start, period_end, today, mode, assume, events)
+		)
 		period_start = frappe.utils.add_days(period_end, 1)
 
 	return {
@@ -228,6 +245,8 @@ def _project_months(team, start, months, today=None, mode=outcomes.DERIVED, assu
 		"as_of": str(today),
 		"currency": carried.currency,
 		"months": periods,
+		"injected_events": injected.timeline(events),
+		"refused": injected.refusals(team, events, state=carried),
 		"ends": {
 			"balance": carried.wallet().balance,
 			"standing": carried.standing,
@@ -238,8 +257,17 @@ def _project_months(team, start, months, today=None, mode=outcomes.DERIVED, assu
 	}
 
 
-def _roll_one(team, carried, period_start, period_end, today, mode, assume) -> dict:
+def _roll_one(team, carried, period_start, period_end, today, mode, assume, events=None) -> dict:
 	"""One month, against the state the months before it left behind."""
+	# Money an operator says arrives lands before the month is settled, so the wallet it
+	# is meant to rescue actually has it when the bill is drawn.
+	for top_up in injected.top_ups(events):
+		if period_start <= top_up["on_date"] <= period_end:
+			carried.wallet(top_up["currency"]).credit(top_up["amount"])
+			carried.events.append(
+				{"date": str(top_up["on_date"]), "event": "Topped up", "amount": top_up["amount"]}
+			)
+
 	# Promotional credit dies on its date whether or not anyone spent it. Sweep at the
 	# start of the month, not the end: a grant expiring on the 30th is the customer's to
 	# spend right up to the 30th, and destroying it before the month it covers would
@@ -260,8 +288,14 @@ def _roll_one(team, carried, period_start, period_end, today, mode, assume) -> d
 		}
 
 	metered = estimate.metered_lines(team, team_clusters(team), period_start, period_end, today=today)
-	rated = rate_team_period(team, period_start, period_end, metered=metered, explain=True)
+	rated = rate_team_period(
+		team, period_start, period_end, metered=metered, explain=True,
+		changes=injected.merged_changes(events, period_start, period_end),
+	)
 	invoice = _invoice(rated)
+	if invoice and events:
+		injected.mark_assumed(invoice["lines"], events, period_start)
+		invoice.update(split_totals(invoice["lines"]))
 	calendar = _calendar(period_end, today)
 
 	settlement_result = _settle(carried, invoice, calendar, mode, assume)

--- a/central/billing/projection/events.py
+++ b/central/billing/projection/events.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Things that have not happened, placed on the calendar and rated as if they had.
+
+Overrides change the rules; events change what happens. A resize on the 12th, a top-up
+on the 20th, a card that declines on the second attempt — these are the questions an
+operator asks when the answer to "what will this team be billed" is not the one they
+were worried about.
+
+The design constraint is the same as everywhere else here: an invented resize must be
+rated by *exactly* the code that rates a real one, or the simulator becomes a second
+model of billing and starts lying. So an injected event is not priced separately — it is
+merged into the Subscription Change stream the line engine already reads, which means it
+picks up day-weighting, the sub-24h churn window and the locked-rate segment boundaries
+for free, because it is the same code path.
+
+What an event cannot do is bypass a gate. A projected provision that would breach the
+team's effective spend cap is reported as refused, with the reason, rather than quietly
+billed — a scenario that could not happen is a finding, not a projection.
+"""
+
+import frappe
+
+from central.billing.projection.basis import ASSUMED
+
+RESIZE = "Resize"
+PROVISION = "Provision"
+CANCEL = "Cancel"
+TOP_UP = "Top up"
+DECLINE = "Decline"
+
+SEGMENT_EVENTS = (RESIZE, PROVISION, CANCEL)
+
+
+def merged_changes(events: list, period_start, period_end):
+	"""A change source for the line engine: the real rows plus the invented ones.
+
+	Returned as a callable so the engine asks for it at the moment it would have queried,
+	and only for the subscriptions it is actually billing.
+	"""
+	from central.billing.revenue.invoicing.lines import _changes_by_subscription
+
+	segment_events = [e for e in (events or []) if e.get("event_type") in SEGMENT_EVENTS]
+	if not segment_events:
+		return None
+
+	def source(subscription_names):
+		by_sub = _changes_by_subscription(subscription_names)
+		for event in segment_events:
+			subscription = event.get("subscription")
+			if subscription not in subscription_names:
+				continue
+			rows = by_sub.setdefault(subscription, [])
+			rows.append(_as_change(event))
+		for subscription, rows in by_sub.items():
+			# The segment builder depends on this order — a Cancelled sorted ahead of the
+			# Created it closes would silently drop the segment.
+			by_sub[subscription] = sorted(
+				rows, key=lambda r: (frappe.utils.get_datetime(r.effective_at), r.get("creation") or "")
+			)
+		return by_sub
+
+	return source
+
+
+def _as_change(event) -> frappe._dict:
+	"""One invented event, shaped exactly like the row the ledger would have written."""
+	kind = event["event_type"]
+	return frappe._dict(
+		subscription=event.get("subscription"),
+		change_type={RESIZE: "Plan Changed", PROVISION: "Created", CANCEL: "Cancelled"}[kind],
+		new_value=event.get("plan"),
+		# A cancellation closes the previous segment and carries no rate of its own.
+		locked_rate=None if kind == CANCEL else frappe.utils.flt(event.get("rate")),
+		effective_at=frappe.utils.get_datetime(event["on_date"]),
+		creation=frappe.utils.get_datetime(event["on_date"]),
+		injected=True,
+	)
+
+
+def mark_assumed(lines: list, events: list, period_start) -> list:
+	"""Stamp lines that only exist because somebody invented an event.
+
+	A line arising from a hypothetical is not a measurement and must not read as one, so
+	it carries the same `assumed` basis a declared quantity does.
+	"""
+	dates = sorted(
+		frappe.utils.get_datetime(e["on_date"])
+		for e in (events or [])
+		if e.get("event_type") in SEGMENT_EVENTS
+	)
+	if not dates:
+		return lines
+
+	earliest = min(dates)
+	for line in lines:
+		locked_at = (line.get("derivation") or {}).get("rate_locked_at")
+		if locked_at and frappe.utils.get_datetime(locked_at) >= earliest:
+			line["basis"] = ASSUMED
+	return lines
+
+
+def top_ups(events: list) -> list[dict]:
+	"""Wallet credits an operator has invented, oldest first."""
+	return sorted(
+		(
+			{
+				"on_date": frappe.utils.getdate(e["on_date"]),
+				"amount": frappe.utils.flt(e.get("amount")),
+				"currency": e.get("currency"),
+			}
+			for e in (events or [])
+			if e.get("event_type") == TOP_UP and frappe.utils.flt(e.get("amount"))
+		),
+		key=lambda t: t["on_date"],
+	)
+
+
+def declines(events: list) -> list[dict]:
+	"""Charge attempts an operator has decided will fail."""
+	return [
+		{"on_date": frappe.utils.getdate(e["on_date"]), "attempt": frappe.utils.cint(e.get("attempt")) or 1}
+		for e in (events or [])
+		if e.get("event_type") == DECLINE
+	]
+
+
+def refusals(team: str, events: list, state=None) -> list[dict]:
+	"""Injected provisions the real gates would not have allowed.
+
+	Checked against the same helpers provisioning checks against, so a scenario cannot
+	quietly assume a resource the platform would have refused to create.
+	"""
+	from central.billing.payments import settlement
+
+	planned = [
+		e for e in (events or []) if e.get("event_type") in (PROVISION, RESIZE) and e.get("rate")
+	]
+	if not planned:
+		return []
+
+	out = []
+	for event in planned:
+		rate = frappe.utils.flt(event["rate"])
+		if not settlement.can_accept_spend(team, rate, source=state):
+			cap = settlement.effective_spend_cap(team, source=state)
+			out.append(
+				{
+					"event": event.get("event_type"),
+					"on_date": str(frappe.utils.getdate(event["on_date"])),
+					"reason": "Over the effective spend cap",
+					"detail": (
+						f"{rate:,.2f} against a cap of {frappe.utils.flt(cap):,.2f}. "
+						"The platform would refuse to provision this."
+					),
+				}
+			)
+	return out
+
+
+def timeline(events: list) -> list[dict]:
+	"""The injected events as dated rows, marked so nobody reads them as history."""
+	return [
+		{
+			"date": str(frappe.utils.getdate(e["on_date"])),
+			"event": e.get("event_type"),
+			"detail": _describe(e),
+			"hypothetical": True,
+		}
+		for e in sorted(events or [], key=lambda e: frappe.utils.getdate(e["on_date"]))
+	]
+
+
+def _describe(event) -> str:
+	kind = event.get("event_type")
+	if kind in (RESIZE, PROVISION):
+		return f"{event.get('plan') or 'config'} at {frappe.utils.flt(event.get('rate')):,.2f}"
+	if kind == TOP_UP:
+		return f"{frappe.utils.flt(event.get('amount')):,.2f} added to the wallet"
+	if kind == DECLINE:
+		return f"attempt {frappe.utils.cint(event.get('attempt')) or 1} fails"
+	return ""

--- a/central/billing/projection/scenario.py
+++ b/central/billing/projection/scenario.py
@@ -46,16 +46,17 @@ def project(scenario, today=None) -> dict:
 	months = max(1, frappe.utils.cint(doc.months) or 1)
 
 	rates = doc.rate_overrides_applied()
+	events = doc.injected_events()
 	with settings.overridden(**overrides), pricing.overridden_rates(rates):
 		if months > 1:
 			out = engine.project_months(
 				doc.team, period_start, months=months, today=today,
-				mode=doc.outcome_mode, assume=doc.assume,
+				mode=doc.outcome_mode, assume=doc.assume, events=events,
 			)
 		else:
 			out = engine.project(
 				doc.team, period_start, frappe.utils.get_last_day(period_start), today=today,
-				mode=doc.outcome_mode, assume=doc.assume,
+				mode=doc.outcome_mode, assume=doc.assume, events=events,
 			)
 
 	# What a price change actually reaches — the part everyone gets wrong.
@@ -71,6 +72,7 @@ def project(scenario, today=None) -> dict:
 		"scenario_name": doc.scenario_name,
 		"overrides": overrides,
 		"rate_overrides": rates,
+		"events": events,
 		"outcome_mode": doc.outcome_mode,
 		"months": months,
 	}
@@ -112,15 +114,21 @@ def compare(scenario, today=None) -> dict:
 	overrides = doc.overrides()
 
 	rates = doc.rate_overrides_applied()
+	events = doc.injected_events()
+	# Events count as a difference too. Leaving them out compared a scenario against
+	# itself and reported "no change" for the one thing that had changed.
+	varies = bool(overrides or rates or events)
+
 	live = project(_bare(doc), today)
-	altered = project(doc, today) if (overrides or rates) else live
+	altered = project(doc, today) if varies else live
 
 	result = {
 		"overrides": overrides,
 		"rate_overrides": rates,
+		"events": events,
 		"live": live,
 		"altered": altered,
-		"changed": bool(overrides or rates),
+		"changed": varies,
 	}
 	if rates:
 		# Say what the number means, because the number alone is the thing that gets
@@ -150,6 +158,7 @@ def _bare(doc):
 	for field in OVERRIDE_FIELDS:
 		clone.set(field, None)
 	clone.set("rate_overrides", [])
+	clone.set("events", [])
 	return clone
 
 

--- a/central/billing/revenue/invoicing/generate.py
+++ b/central/billing/revenue/invoicing/generate.py
@@ -221,6 +221,7 @@ def rate_team_period(
 	subscription: str | None = None,
 	metered: list[dict] | None = None,
 	explain: bool = False,
+	changes=None,
 ):
 	"""What the team's whole book would bill for the period, across every cluster.
 	Reads only.
@@ -238,7 +239,7 @@ def rate_team_period(
 	# Read the team once, not once per cluster: team_line_items pulls every
 	# subscription's fixed lines in one pass, and the metered rollups for all the
 	# team's clusters come back in a single query.
-	lines = team_line_items(team, period_start, period_end, explain=explain)
+	lines = team_line_items(team, period_start, period_end, explain=explain, changes=changes)
 	if metered is None:
 		lines += metered_line_items_for_clusters(
 			team, team_clusters(team), period_start, period_end, explain=explain

--- a/central/billing/revenue/invoicing/lines.py
+++ b/central/billing/revenue/invoicing/lines.py
@@ -39,7 +39,7 @@ def _dates_touched(start_dt: datetime, end_dt: datetime) -> list:
 
 
 def compute_line_items(
-	team: str, cluster: str, period_start, period_end, explain: bool = False
+	team: str, cluster: str, period_start, period_end, explain: bool = False, changes=None
 ) -> list[dict]:
 	"""Time-weighted fixed line items for one (team, cluster) over the billing month.
 
@@ -63,7 +63,7 @@ def compute_line_items(
 
 	# All these subscriptions' changes in one query, grouped by subscription — not a
 	# query per subscription.
-	changes_by_sub = _changes_by_subscription([s.name for s in subscriptions])
+	changes_by_sub = _resolve_changes([s.name for s in subscriptions], changes)
 
 	bounds = _period_bounds(period_start, period_end)
 	lines = []
@@ -73,7 +73,7 @@ def compute_line_items(
 
 
 def team_line_items(
-	team: str, period_start, period_end, explain: bool = False
+	team: str, period_start, period_end, explain: bool = False, changes=None
 ) -> list[dict]:
 	"""Every fixed line item for a team across all the clusters it runs in, from ONE
 	read of its subscriptions, their asset clusters and their changes.
@@ -85,7 +85,7 @@ def team_line_items(
 	"""
 	subscriptions = frappe.get_all("Subscription", filters={"team": team}, fields=["name", "asset_id"])
 	clusters = _asset_clusters([s.asset_id for s in subscriptions])
-	changes_by_sub = _changes_by_subscription([s.name for s in subscriptions])
+	changes_by_sub = _resolve_changes([s.name for s in subscriptions], changes)
 
 	bounds = _period_bounds(period_start, period_end)
 	lines = []
@@ -200,6 +200,22 @@ def _subscription_lines(sub, cluster: str, changes: list, b, explain: bool = Fal
 				]
 				lines.append(_hourly_line(s, hours, b.hour_units, cd, explain, touching))
 	return lines
+
+
+def _resolve_changes(subscription_names: list[str], changes=None) -> dict:
+	"""Where the rate-snapshot segments come from.
+
+	The run reads them from Subscription Change, which is the only source there is. A
+	projection may supply its own — the real rows plus a hypothetical resize, say — so
+	that an invented change is rated by exactly the code that rates a real one, churn
+	window and all. `changes` is either a ready-made mapping or a callable taking the
+	subscription names; absent, nothing changes.
+	"""
+	if changes is None:
+		return _changes_by_subscription(subscription_names)
+	if callable(changes):
+		return changes(subscription_names)
+	return changes
 
 
 def _changes_by_subscription(subscription_names: list[str]) -> dict:

--- a/central/billing/tests/test_projection_events.py
+++ b/central/billing/tests/test_projection_events.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Things that have not happened, rated as if they had."""
+
+import frappe
+from central.billing.projection import engine, events, scenario
+from central.billing.projection.basis import ASSUMED, MEASURED
+from central.billing.revenue import credits
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+from central.billing.tests.utils import (
+	add_segment,
+	ensure_team,
+	make_billing_subscription,
+	make_plan,
+	set_team_tier,
+)
+
+TEAM = "team-events"
+CLUSTER = "ap-south-1"
+PLAN = "bundle-events"
+TODAY = "2026-08-06"
+
+
+class EventTestBase(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		make_plan(PLAN)
+		self._purge()
+		self.sub = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
+		add_segment(self.sub, "Created", 3000, "2026-01-01 00:00:00")
+		set_team_tier(TEAM, level="t1", max_spend=50000)
+		frappe.db.commit()
+
+	def tearDown(self):
+		self._purge()
+
+	def _purge(self):
+		for name in frappe.get_all("Billing Scenario", pluck="name"):
+			frappe.delete_doc("Billing Scenario", name, force=True, ignore_permissions=True)
+		for dt in ("Invoice", "Credit Ledger Entry"):
+			frappe.db.delete(dt, {"team": TEAM})
+		frappe.db.delete("Credit Wallet", {"team": TEAM})
+		for sub in frappe.get_all("Subscription", {"team": TEAM}, pluck="name"):
+			frappe.db.delete("Subscription Change", {"subscription": sub})
+			frappe.db.delete("Subscription", {"name": sub})
+		frappe.db.delete("Asset", {"team": TEAM})
+		frappe.db.commit()
+
+	def _project(self, events_list, **kw):
+		frappe.db.commit()
+		return engine.project(
+			TEAM, "2026-09-01", "2026-09-30", today=TODAY, events=events_list, **kw
+		)
+
+
+class TestTheChangeStreamIsInjectable(EventTestBase):
+	def test_without_injection_the_ledger_is_read(self):
+		out = self._project(None)
+		self.assertEqual(out["invoice"]["subtotal"], 3000.0)
+
+	def test_an_injected_resize_reprices_the_rest_of_the_month(self):
+		# Rated by the production line engine, so day-weighting comes for free.
+		out = self._project(
+			[
+				{
+					"event_type": events.RESIZE,
+					"on_date": "2026-09-16 00:00:00",
+					"subscription": self.sub,
+					"plan": PLAN,
+					"rate": 6000,
+				}
+			]
+		)
+		# 15 days at 3000 + 15 days at 6000 over a 30-day month.
+		self.assertEqual(out["invoice"]["subtotal"], 4500.0)
+
+	def test_a_resize_inside_the_churn_window_bills_that_date_hourly(self):
+		# The sub-24h rule is the line engine's, and an invented change gets it too.
+		out = self._project(
+			[
+				{"event_type": events.RESIZE, "on_date": "2026-09-15 09:00:00",
+				 "subscription": self.sub, "plan": PLAN, "rate": 6000},
+				{"event_type": events.RESIZE, "on_date": "2026-09-15 18:00:00",
+				 "subscription": self.sub, "plan": PLAN, "rate": 3000},
+			]
+		)
+		hourly = [li for li in out["invoice"]["lines"] if li["unit"] == "hour"]
+		self.assertTrue(hourly, "a config held under 24h should push its date hourly")
+
+	def test_an_injected_cancel_closes_the_segment(self):
+		out = self._project(
+			[
+				{"event_type": events.CANCEL, "on_date": "2026-09-16 00:00:00",
+				 "subscription": self.sub}
+			]
+		)
+		self.assertEqual(out["invoice"]["subtotal"], 1500.0)  # 15 of 30 days
+
+	def test_the_real_ledger_is_never_written(self):
+		before = frappe.db.count("Subscription Change", {"subscription": self.sub})
+		self._project(
+			[
+				{"event_type": events.RESIZE, "on_date": "2026-09-16 00:00:00",
+				 "subscription": self.sub, "plan": PLAN, "rate": 6000}
+			]
+		)
+		self.assertEqual(
+			frappe.db.count("Subscription Change", {"subscription": self.sub}), before
+		)
+
+
+class TestInventedLinesSaySo(EventTestBase):
+	def test_a_line_from_an_injected_event_is_assumed_not_measured(self):
+		out = self._project(
+			[
+				{"event_type": events.RESIZE, "on_date": "2026-09-16 00:00:00",
+				 "subscription": self.sub, "plan": PLAN, "rate": 6000}
+			]
+		)
+		bases = {li["basis"] for li in out["invoice"]["lines"]}
+		self.assertIn(ASSUMED, bases)
+		self.assertIn(MEASURED, bases)
+
+	def test_the_totals_carry_the_assumption_through(self):
+		out = self._project(
+			[
+				{"event_type": events.RESIZE, "on_date": "2026-09-16 00:00:00",
+				 "subscription": self.sub, "plan": PLAN, "rate": 6000}
+			]
+		)
+		self.assertGreater(out["invoice"]["assumed"], 0)
+		self.assertTrue(out["invoice"]["has_estimates"])
+
+	def test_a_projection_with_no_events_stays_measured(self):
+		out = self._project(None)
+		self.assertTrue(all(li["basis"] == MEASURED for li in out["invoice"]["lines"]))
+
+
+class TestRefusals(EventTestBase):
+	def test_a_provision_beyond_the_cap_is_reported_as_refused(self):
+		# A scenario that could not happen is a finding, not a projection.
+		set_team_tier(TEAM, level="t1", max_spend=1000)
+		out = self._project(
+			[
+				{"event_type": events.PROVISION, "on_date": "2026-09-10 00:00:00",
+				 "subscription": self.sub, "plan": PLAN, "rate": 9000}
+			]
+		)
+		self.assertTrue(out["refused"])
+		self.assertIn("cap", out["refused"][0]["reason"].lower())
+
+	def test_a_provision_within_the_cap_is_not_refused(self):
+		set_team_tier(TEAM, level="t1", max_spend=50000)
+		out = self._project(
+			[
+				{"event_type": events.PROVISION, "on_date": "2026-09-10 00:00:00",
+				 "subscription": self.sub, "plan": PLAN, "rate": 900}
+			]
+		)
+		self.assertEqual(out["refused"], [])
+
+
+class TestTheTimeline(EventTestBase):
+	def test_injected_events_are_dated_and_marked_hypothetical(self):
+		out = self._project(
+			[
+				{"event_type": events.RESIZE, "on_date": "2026-09-16 00:00:00",
+				 "subscription": self.sub, "plan": PLAN, "rate": 6000}
+			]
+		)
+		self.assertEqual(len(out["injected_events"]), 1)
+		self.assertTrue(out["injected_events"][0]["hypothetical"])
+		self.assertEqual(out["injected_events"][0]["date"], "2026-09-16")
+
+	def test_they_are_kept_apart_from_what_the_roll_forward_actually_did(self):
+		# Two different things were briefly both called "events"; they are not the same.
+		out = engine.project_months(
+			TEAM, "2026-09-01", months=2, today=TODAY,
+			events=[
+				{"event_type": events.TOP_UP, "on_date": "2026-09-10 00:00:00",
+				 "amount": 5000, "currency": "INR"}
+			],
+		)
+		self.assertIn("injected_events", out)
+		self.assertIn("events", out)
+		self.assertEqual(len(out["injected_events"]), 1)
+
+
+class TestTopUps(EventTestBase):
+	def test_an_injected_top_up_reaches_the_wallet_before_the_bill_is_drawn(self):
+		out = engine.project_months(
+			TEAM, "2026-09-01", months=2, today=TODAY,
+			events=[
+				{"event_type": events.TOP_UP, "on_date": "2026-09-10 00:00:00",
+				 "amount": 5000, "currency": "INR"}
+			],
+		)
+		first = out["months"][0]
+		self.assertEqual(first["settlement"]["from_credits"], 3000.0)
+		self.assertEqual(first["settlement"]["shortfall"], 0.0)
+
+	def test_without_the_top_up_the_month_is_short(self):
+		out = engine.project_months(TEAM, "2026-09-01", months=2, today=TODAY)
+		self.assertEqual(out["months"][0]["settlement"]["shortfall"], 3000.0)
+
+	def test_the_top_up_is_recorded_on_the_way_through(self):
+		out = engine.project_months(
+			TEAM, "2026-09-01", months=2, today=TODAY,
+			events=[
+				{"event_type": events.TOP_UP, "on_date": "2026-09-10 00:00:00",
+				 "amount": 5000, "currency": "INR"}
+			],
+		)
+		self.assertTrue(any(e["event"] == "Topped up" for e in out["events"]))
+
+	def test_no_credit_ledger_entry_is_written(self):
+		before = frappe.db.count("Credit Ledger Entry", {"team": TEAM})
+		engine.project_months(
+			TEAM, "2026-09-01", months=2, today=TODAY,
+			events=[
+				{"event_type": events.TOP_UP, "on_date": "2026-09-10 00:00:00",
+				 "amount": 5000, "currency": "INR"}
+			],
+		)
+		self.assertEqual(frappe.db.count("Credit Ledger Entry", {"team": TEAM}), before)
+
+
+class TestThroughAScenario(EventTestBase):
+	def test_a_saved_scenario_carries_its_events(self):
+		doc = frappe.get_doc(
+			{
+				"doctype": "Billing Scenario",
+				"scenario_name": "What if they double in September",
+				"team": TEAM,
+				"period_start": "2026-09-01",
+				"months": 1,
+				"outcome_mode": "Derived",
+				"events": [
+					{
+						"event_type": "Resize",
+						"on_date": "2026-09-16 00:00:00",
+						"subscription": self.sub,
+						"plan": PLAN,
+						"rate": 6000,
+					}
+				],
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+		out = scenario.project(doc, today=TODAY)
+		self.assertEqual(out["invoice"]["subtotal"], 4500.0)
+		self.assertEqual(len(out["scenario"]["events"]), 1)
+
+	def test_the_control_side_of_a_comparison_drops_the_events(self):
+		doc = frappe.get_doc(
+			{
+				"doctype": "Billing Scenario",
+				"scenario_name": "Resize mid-month",
+				"team": TEAM,
+				"period_start": "2026-09-01",
+				"months": 1,
+				"outcome_mode": "Derived",
+				"events": [
+					{
+						"event_type": "Resize",
+						"on_date": "2026-09-16 00:00:00",
+						"subscription": self.sub,
+						"plan": PLAN,
+						"rate": 6000,
+					}
+				],
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+		out = scenario.compare(doc, today=TODAY)
+		self.assertEqual(out["live"]["invoice"]["subtotal"], 3000.0)
+		self.assertEqual(out["altered"]["invoice"]["subtotal"], 4500.0)


### PR DESCRIPTION
Overrides change the rules. Events change what happens — a resize on the 16th, a top-up on the 20th, a provision the cap would refuse.

<img width="1440" height="1000" alt="10-injected-events" src="https://github.com/user-attachments/assets/023f342b-3366-4587-b519-efb43b930397" />

## Rated by the same engine, not a second model

An injected resize is merged into the Subscription Change stream the line engine already reads, rather than priced separately. It therefore picks up day-weighting, the sub-24h churn window and locked-rate segment boundaries for free — because it is the same code path. There is a test showing an *invented* change trips the hourly-billing rule exactly as a real one does.

```mermaid
flowchart LR
    R[("Subscription Change")] --> M["merged stream"]
    I["Injected resize / provision / cancel"] --> M
    M --> L["The production line engine"]
    L --> P["Lines, with basis"]

    style I fill:#fff7d3,stroke:#bb6f0c
    style L fill:#e4f5e9,stroke:#30a66d
```

Nothing is written: the real ledger is untouched, and an injected top-up credits the projected wallet without booking a Credit Ledger Entry.

## What an event cannot do is bypass a gate

A projected provision that would breach the team's effective spend cap is reported as **refused**, with the numbers, checked against the same helper provisioning checks against. A scenario that could not happen is a finding, not a projection.

## Lines that only exist because somebody invented an event say so

They carry an `assumed` basis and the totals break out accordingly — so an eighteen thousand rupee projection that is two-thirds hypothetical cannot read as a bill.