### PR TITLE
feat(admin): Simulator

### DIFF
--- a/central/billing/api/admin/__init__.py
+++ b/central/billing/api/admin/__init__.py
@@ -25,9 +25,11 @@ from central.billing.api.admin.catalog import (
 from central.billing.api.admin.projection import (
 	compare_scenario,
 	project_scenario,
+	project_from_library,
 	project_team,
 	project_team_months,
 	save_scenario_result,
+	scenario_library,
 	sample_cohort,
 	size_cohort,
 	start_cohort_projection,
@@ -55,7 +57,9 @@ from central.billing.api.admin.teams import (
 __all__ = [
 	"compare_scenario",
 	"project_scenario",
+	"project_from_library",
 	"project_team",
+	"scenario_library",
 	"save_scenario_result",
 	"project_team_months",
 	"sample_cohort",

--- a/central/billing/api/admin/__init__.py
+++ b/central/billing/api/admin/__init__.py
@@ -23,6 +23,8 @@ from central.billing.api.admin.catalog import (
 	update_plan_rate,
 )
 from central.billing.api.admin.projection import (
+	check_scenario_drift,
+	compare_cohort_batches,
 	compare_scenario,
 	project_scenario,
 	project_from_library,
@@ -55,6 +57,8 @@ from central.billing.api.admin.teams import (
 )
 
 __all__ = [
+	"check_scenario_drift",
+	"compare_cohort_batches",
 	"compare_scenario",
 	"project_scenario",
 	"project_from_library",

--- a/central/billing/api/admin/projection.py
+++ b/central/billing/api/admin/projection.py
@@ -183,3 +183,29 @@ def compare_scenario(scenario: str, today: str | None = None) -> dict:
 	from central.billing.projection import scenario as scenarios
 
 	return scenarios.compare(scenario, today=today)
+
+
+@frappe.whitelist()
+def scenario_library() -> list[dict]:
+	"""The shelf of canned questions."""
+	authz.require_operator()
+
+	from central.billing.projection import library
+
+	return library.catalogue()
+
+
+@frappe.whitelist()
+def project_from_library(key: str, team: str, period_start: str | None = None, today: str | None = None) -> dict:
+	"""Apply a catalogue scenario to a real team and project it, without saving."""
+	authz.require_operator()
+
+	from central.billing.projection import library, scenario as scenarios
+
+	doc = library.build(key, team, period_start=period_start, today=today)
+	frappe.logger("billing").info(
+		f"projection: {frappe.session.user} ran library scenario {key} on {team}"
+	)
+	out = scenarios.project(doc, today=today)
+	out["library"] = {"key": key, **{k: v for k, v in library.SCENARIOS[key].items() if k in ("title", "question", "look_for")}}
+	return out

--- a/central/billing/api/admin/projection.py
+++ b/central/billing/api/admin/projection.py
@@ -209,3 +209,23 @@ def project_from_library(key: str, team: str, period_start: str | None = None, t
 	out = scenarios.project(doc, today=today)
 	out["library"] = {"key": key, **{k: v for k, v in library.SCENARIOS[key].items() if k in ("title", "question", "look_for")}}
 	return out
+
+
+@frappe.whitelist()
+def check_scenario_drift(scenario: str, today: str | None = None) -> dict:
+	"""Whether a saved scenario now answers differently than when it was saved."""
+	authz.require_operator()
+
+	from central.billing.projection import scenario as scenarios
+
+	return scenarios.check_drift(scenario, today=today)
+
+
+@frappe.whitelist()
+def compare_cohort_batches(live: str, altered: str) -> dict:
+	"""How far a change reaches, across two batches of the same teams."""
+	authz.require_operator()
+
+	from central.billing.projection import batch
+
+	return batch.compare_batches(live, altered)

--- a/central/billing/api/dashboard/invoices.py
+++ b/central/billing/api/dashboard/invoices.py
@@ -18,11 +18,9 @@ from central.billing.api.dashboard._shared import (
 	_require_manage,
 	_require_view,
 	_resolve_team,
-	_team_clusters,
 	_team_currency,
 )
-from central.billing.revenue import credits, invoicing, metering
-from central.billing.revenue.tax import resolve_tax
+from central.billing.revenue import credits
 
 
 @frappe.whitelist()
@@ -38,17 +36,29 @@ def get_forecast(team: str | None = None) -> dict:
 	month_start = frappe.utils.get_first_day(today)
 	month_end = frappe.utils.get_last_day(today)
 
-	line_items = []
-	for cluster in _team_clusters(team):
-		line_items += invoicing.compute_line_items(team, cluster, month_start, month_end)
-		line_items += metering.metered_line_items(team, cluster, month_start, month_end)
+	# The customer's forecast is a projection under one fixed scenario: this team, this
+	# month, live configuration, everything settles. Running it through the same engine
+	# an operator simulates with is what stops the two numbers drifting apart — there is
+	# no second rating path to keep in step.
+	from central.billing.projection import engine
 
-	subtotal = frappe.utils.flt(sum(li["amount"] for li in line_items), 2)
-	tax = resolve_tax(team, subtotal)
-	projected_total = frappe.utils.flt(subtotal + tax["output_tax_amount"], 2)
+	# Not strictly guarded: this is a customer page, and it must not fail because the
+	# request that reached it happened to write something first.
+	projection = engine.project(
+		team, month_start, month_end, today=today, mode="Optimistic", guarded=False
+	)
+	invoice = projection["invoice"] or {}
+	line_items = invoice.get("lines") or []
+
+	subtotal = frappe.utils.flt(invoice.get("subtotal"))
+	projected_total = frappe.utils.flt(invoice.get("total"))
 	credit_balance = frappe.utils.flt(credits.get_balance(team)["balance"])
 	shortfall = max(0.0, frappe.utils.flt(projected_total - credit_balance, 2))
-	currency = _team_currency(team)
+	currency = projection["currency"] or _team_currency(team)
+	tax = {
+		"output_tax_amount": frappe.utils.flt(invoice.get("output_tax_amount")),
+		"output_tax_type": invoice.get("output_tax_type"),
+	}
 
 	return {
 		"period_start": str(month_start),

--- a/central/billing/doctype/billing_projection_batch/billing_projection_batch.json
+++ b/central/billing/doctype/billing_projection_batch/billing_projection_batch.json
@@ -74,6 +74,13 @@
    "label": "Scope"
   },
   {
+   "fieldname": "scenario",
+   "fieldtype": "Link",
+   "label": "Scenario",
+   "options": "Billing Scenario",
+   "description": "Projected under this scenario's overrides instead of the live configuration."
+  },
+  {
    "fieldname": "filters",
    "fieldtype": "Code",
    "label": "Filters",
@@ -135,6 +142,7 @@
   "started_at",
   "completed_at",
   "section_break_scope",
+  "scenario",
   "filters",
   "column_break_counts",
   "teams_expected",

--- a/central/billing/page/billing_simulator/billing_simulator.js
+++ b/central/billing/page/billing_simulator/billing_simulator.js
@@ -67,6 +67,7 @@ class BillingSimulator {
 		});
 		this.page.set_primary_action(__("Project"), () => this.refresh());
 		this.page.add_menu_item(__("Save as scenario"), () => this.save_scenario());
+		this.page.add_inner_button(__("Try a question"), () => this.pick_from_library());
 	}
 
 	// A saved scenario drives the projection itself: its overrides are read *instead of*
@@ -182,6 +183,93 @@ class BillingSimulator {
 							: ""
 					}
 				</div>
+			</div>`);
+	}
+
+	// The shelf of canned questions. Each one says what it asks and what to look for,
+	// because a button with no explanation is one nobody presses twice.
+	pick_from_library() {
+		const team = this.team.get_value();
+		if (!team) {
+			frappe.show_alert({ message: __("Pick a team first."), indicator: "orange" });
+			return;
+		}
+
+		frappe
+			.call({ method: "central.billing.api.admin.projection.scenario_library" })
+			.then((r) => {
+				const entries = r.message || [];
+				const dialog = new frappe.ui.Dialog({
+					title: __("Try a question"),
+					fields: [
+						{
+							fieldname: "key",
+							label: __("Question"),
+							fieldtype: "Select",
+							reqd: 1,
+							options: entries.map((e) => ({ label: e.title, value: e.key })),
+							change() {
+								const chosen = entries.find((e) => e.key === this.get_value());
+								dialog.set_df_property(
+									"about",
+									"options",
+									chosen
+										? `<div class="text-muted"><p>${frappe.utils.escape_html(
+												chosen.question
+										  )}</p><p><b>${__("Look for")}:</b> ${frappe.utils.escape_html(
+												chosen.look_for
+										  )}</p></div>`
+										: ""
+								);
+							},
+						},
+						{ fieldname: "about", fieldtype: "HTML" },
+					],
+					primary_action_label: __("Project it"),
+					primary_action: ({ key }) => {
+						dialog.hide();
+						this.run_library_scenario(key, team);
+					},
+				});
+				dialog.show();
+			});
+	}
+
+	run_library_scenario(key, team) {
+		this.applying = true;
+		this.show_empty(__("Projecting…"));
+		frappe
+			.call({
+				method: "central.billing.api.admin.projection.project_from_library",
+				args: { key, team, period_start: this.period.get_value() },
+			})
+			.then((r) => {
+				if (!r.message) return;
+				const out = r.message;
+				if (out.scenario && out.scenario.months > 1) this.render_months(out);
+				else this.render(out);
+				if (out.library) this.$body.prepend(this.library_card(out.library));
+			})
+			.catch((e) => {
+				// A scenario that cannot apply to this team says why rather than
+				// projecting something misleading.
+				this.show_empty(
+					(e && e.message) || __("This question does not apply to that team.")
+				);
+			})
+			.finally(() => {
+				this.applying = false;
+			});
+	}
+
+	library_card(entry) {
+		return $(`
+			<div class="bs-card">
+				<div class="bs-card-head">
+					<span class="bs-card-title">${frappe.utils.escape_html(entry.title)}</span>
+					<span class="bs-muted">${frappe.utils.escape_html(entry.question)}</span>
+				</div>
+				<div class="bs-note">${__("Look for")}: ${frappe.utils.escape_html(entry.look_for)}</div>
 			</div>`);
 	}
 

--- a/central/billing/projection/batch.py
+++ b/central/billing/projection/batch.py
@@ -100,7 +100,10 @@ def start_sampled(
 	return batch.name
 
 
-def start(filters: dict | None = None, period_start=None, months: int = 1, today=None) -> str:
+def start(
+	filters: dict | None = None, period_start=None, months: int = 1, today=None,
+	scenario: str | None = None,
+) -> str:
 	"""Size the cohort, refuse it if it is too big, and enqueue the batch.
 
 	Raises `CohortTooLargeError` before any team is rated, and `ValidationError` while
@@ -125,6 +128,7 @@ def start(filters: dict | None = None, period_start=None, months: int = 1, today
 			"filters": json.dumps(filters or {}, indent=1, sort_keys=True),
 			"teams_expected": sizing.teams,
 			"estimated_seconds": sizing.estimated_seconds,
+			"scenario": scenario,
 		}
 	).insert(ignore_permissions=True)
 	frappe.db.commit()
@@ -215,6 +219,29 @@ def _project_page(batch_doc, teams: list) -> int:
 
 def _summarise(team: str, batch_doc) -> dict:
 	"""One team's projected position, flattened to scalars the report can read."""
+	if batch_doc.scenario:
+		return _summarise_under_scenario(team, batch_doc)
+	return _summarise_live(team, batch_doc)
+
+
+def _summarise_under_scenario(team: str, batch_doc) -> dict:
+	"""Project this team as the scenario pretends, so a batch can be a what-if.
+
+	Two batches over the same teams — one live, one under a scenario — are what the
+	blast radius compares. Without this a scenario could only ever be asked about one
+	team at a time, which is not the question anyone has before shipping a change.
+	"""
+	from central.billing import settings
+	from central.billing.catalog import pricing
+
+	doc = frappe.get_doc("Billing Scenario", batch_doc.scenario)
+	with settings.overridden(**doc.overrides()), pricing.overridden_rates(
+		doc.rate_overrides_applied()
+	):
+		return _summarise_live(team, batch_doc)
+
+
+def _summarise_live(team: str, batch_doc) -> dict:
 	months = frappe.utils.cint(batch_doc.months) or 1
 	if months > 1:
 		projection = engine.project_months(
@@ -318,3 +345,42 @@ def prune(days: int = RETENTION_DAYS) -> int:
 		frappe.delete_doc("Billing Projection Batch", name, force=True, ignore_permissions=True)
 	frappe.db.commit()
 	return len(stale)
+
+
+def compare_batches(live: str, altered: str) -> dict:
+	"""How far a change reaches, measured across two batches of the same teams.
+
+	This is what `blast` is for. Both sides have to be real projections over the same
+	cohort, or the difference between them is not attributable to the change.
+	"""
+	from central.billing.projection import blast
+
+	live_doc = frappe.get_doc("Billing Projection Batch", live)
+	altered_doc = frappe.get_doc("Billing Projection Batch", altered)
+
+	comparison = blast.compare_rows(_rows_of(live), _rows_of(altered))
+	summary = blast.summarise(
+		comparison,
+		sampled=bool(altered_doc.sampled or live_doc.sampled),
+		sample_size=frappe.utils.cint(altered_doc.sample_size),
+		population=frappe.utils.cint(altered_doc.teams_expected),
+	)
+	return {
+		"live_batch": live,
+		"altered_batch": altered,
+		"scenario": altered_doc.scenario,
+		"summary": summary,
+		"headline": blast.describe(summary),
+		"newly_suspending": comparison["newly_suspending"],
+		"newly_short": comparison["newly_short"],
+		"suspension_moved_earlier": comparison["suspension_moved_earlier"],
+	}
+
+
+def _rows_of(batch: str) -> list[dict]:
+	return frappe.get_all(
+		"Billing Projection Summary",
+		filters={"batch": batch},
+		fields=["team", "currency", "projected_total", "shortfall", "suspends_on"],
+		limit_page_length=0,
+	)

--- a/central/billing/projection/batch.py
+++ b/central/billing/projection/batch.py
@@ -25,7 +25,7 @@ import time
 
 import frappe
 
-from central.billing.projection import cohort, engine, outcomes
+from central.billing.projection import behaviour, cohort, engine, outcomes
 
 PROJECTION_QUEUE = "projection"
 PAGE_SIZE = 500
@@ -262,6 +262,7 @@ def _summarise(team: str, batch_doc) -> dict:
 		"outcome_reason": findings[0]["summary"] if findings else None,
 		"due_on": (calendar or {}).get("due_on"),
 		"suspends_on": suspends_on,
+		"paid_on_time": _paid_on_time(team, batch_doc.as_of),
 	}
 
 
@@ -285,6 +286,12 @@ def _outcome_label(outcome, findings) -> str:
 	if outcome.get("mode") != outcomes.DERIVED:
 		return outcome.get("mode")
 	return findings[0]["summary"] if findings else "No obstacle found"
+
+
+def _paid_on_time(team: str, on) -> str:
+	""""6 / 6" beside a failure points at us; "3 / 6" points at them."""
+	record = behaviour.summary(team, on=on)
+	return f"{record['on_time']} / {record['invoices']}" if record["invoices"] else "—"
 
 
 def _settles_via(team: str) -> str:

--- a/central/billing/projection/behaviour.py
+++ b/central/billing/projection/behaviour.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""How reliably a team has actually paid.
+
+Everything else here looks forward. This looks back, because a projection means almost
+nothing without it: *"suspended on the 12th"* reads completely differently next to *"and
+they have paid late in three of the last six months"* than next to *"and they have never
+missed one."* The first is a collections problem; the second is almost certainly ours —
+an expired card, a lapsed mandate, a gateway that stopped working — and the response is
+the opposite in each case.
+
+A retrospective read over rows that already exist, so it costs what the collection
+outlook costs and needs none of the bounding cohort revenue projection needs.
+
+One rule holds the whole thing honest: **lateness is measured against `due_date`, never
+`dunning_starts_on`.** The deferred clock exists to protect customers when our own
+collection fails; letting it feed a behaviour score would quietly mark customers down
+for our outages.
+"""
+
+import frappe
+
+# Trials are a computed subsidy cost, not a sale — counting them would flatter or
+# distort every rate here.
+BILLABLE = "Billable"
+
+# Statuses that mean the invoice was never collectable through no fault of the customer.
+NOT_THEIR_FAULT = ("Cancelled", "Waived")
+
+
+def summary(team: str, months: int = 6, on=None) -> dict:
+	"""One team's payment record over the trailing window."""
+	on = frappe.utils.getdate(on or frappe.utils.nowdate())
+	since = frappe.utils.add_months(on, -months)
+
+	invoices = frappe.get_all(
+		"Invoice",
+		filters={
+			"team": team,
+			"invoice_type": BILLABLE,
+			"due_date": [">=", since],
+			"status": ["not in", NOT_THEIR_FAULT],
+		},
+		fields=["name", "status", "due_date", "currency", "total", "expected_collection"],
+		order_by="due_date asc",
+	)
+
+	settled = [i for i in invoices if i.status == "Paid"]
+	outstanding = [i for i in invoices if i.status in ("Open", "Overdue")]
+	delays = [_days_late(i, on) for i in invoices]
+	delays = [d for d in delays if d is not None]
+
+	return {
+		"team": team,
+		"window_months": months,
+		"since": str(since),
+		"invoices": len(invoices),
+		"settled": len(settled),
+		"outstanding": len(outstanding),
+		# The headline: "6 / 6" is a different fact from "3 / 6" beside the same failure.
+		"on_time": sum(1 for i in invoices if _days_late(i, on) == 0),
+		"worst_delay_days": max(delays) if delays else 0,
+		"average_delay_days": round(sum(delays) / len(delays), 1) if delays else 0.0,
+		"times_dunned": _times_dunned(team, since),
+		"ever_suspended": _ever_suspended(team),
+		"billing_since": _billing_since(team),
+		"settlement_mix": _settlement_mix(team, since),
+		# Not a probability. A label an operator can read at a glance and act on.
+		"verdict": None,
+	}
+
+
+def with_verdict(team: str, months: int = 6, on=None) -> dict:
+	"""The summary plus the one-line reading of it."""
+	out = summary(team, months, on)
+	out["verdict"] = verdict(out)
+	return out
+
+
+def verdict(record: dict) -> str:
+	"""What this record says about whose problem a failure is.
+
+	Deliberately coarse. The value is in separating "they do not pay" from "they always
+	pay and something on our side broke", which is the distinction that changes what an
+	operator does next.
+	"""
+	if not record["invoices"]:
+		return "No history"
+	if record["on_time"] == record["invoices"]:
+		return "Always paid on time"
+	if record["on_time"] == 0:
+		return "Never paid on time"
+	if record["worst_delay_days"] > 30:
+		return "Chronically late"
+	return "Occasionally late"
+
+
+def _days_late(invoice, on) -> int | None:
+	"""How late this invoice was, measured from the date the customer owed it.
+
+	Never from `dunning_starts_on`: that clock is pushed forward when *we* fail to
+	collect, and scoring against it would blame the customer for our outage.
+	"""
+	if not invoice.due_date:
+		return None
+	due = frappe.utils.getdate(invoice.due_date)
+	if invoice.status == "Paid":
+		# The ledger does not keep a settled-on date, so the closest honest answer is
+		# that a paid invoice was not late unless it is still visibly overdue.
+		return 0
+	return max(0, (frappe.utils.getdate(on) - due).days)
+
+
+def _times_dunned(team: str, since) -> int:
+	return frappe.db.count(
+		"Payment Attempt", {"team": team, "status": "Failed", "creation": [">=", since]}
+	)
+
+
+def _ever_suspended(team: str) -> bool:
+	return bool(
+		frappe.get_all(
+			"Subscription",
+			filters={"team": team, "account_standing": ["in", ["Suspended", "Terminated"]]},
+			limit=1,
+		)
+	)
+
+
+def _billing_since(team: str) -> str | None:
+	earliest = frappe.get_all(
+		"Invoice", filters={"team": team}, fields=["creation"], order_by="creation asc", limit=1
+	)
+	return str(frappe.utils.getdate(earliest[0].creation)) if earliest else None
+
+
+def _settlement_mix(team: str, since) -> dict:
+	"""How this team's money has actually arrived — card, credits, or not at all."""
+	captured = frappe.db.count(
+		"Payment Attempt", {"team": team, "status": "Captured", "creation": [">=", since]}
+	)
+	drawn = frappe.db.count(
+		"Credit Ledger Entry",
+		{"team": team, "entry_type": "Debit", "creation": [">=", since]},
+	)
+	return {"card_captures": captured, "credit_draws": drawn}

--- a/central/billing/projection/blast.py
+++ b/central/billing/projection/blast.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""What a change would do to the whole book, not just to one team.
+
+Per team, a diff answers "what does this do to *them*". Across a cohort it answers the
+question an operator actually has before shipping a pricing or policy change: **how far
+does this reach?**
+
+> **The metric set below is provisional.** The issue this implements is marked HITL
+> precisely because which numbers matter is a conversation with the accounts team, not a
+> derivation — revenue delta is obvious, but "teams newly failing" versus "teams newly
+> *at risk*", or whether a suspension moving counts the same as one appearing, are
+> judgement calls. What is here is a defensible default chosen to be easy to argue with:
+> every figure is counted from the two projections rather than modelled, so swapping the
+> set is a change to this file and nothing else.
+
+Two rules hold whatever the set becomes. Money never crosses currencies. And an
+extrapolated figure says so wherever it appears, because a sampled blast radius quoted
+as a measured one is the most expensive kind of wrong here.
+"""
+
+import frappe
+
+# Counted from the pair of projections, never modelled. Each is one line to change.
+METRICS = (
+	"teams",
+	"revenue_delta",
+	"newly_short",
+	"newly_suspending",
+	"suspension_moved_earlier",
+	"suspension_moved_later",
+)
+
+
+def compare_rows(live_rows: list[dict], altered_rows: list[dict]) -> dict:
+	"""The aggregate difference between two cohort projections of the same teams.
+
+	Both sides must come from the same engine over the same teams at the same instant,
+	or the difference is not attributable to the change.
+	"""
+	live = {row["team"]: row for row in live_rows}
+	altered = {row["team"]: row for row in altered_rows}
+	shared = sorted(set(live) & set(altered))
+
+	revenue: dict = {}
+	newly_short, newly_suspending = [], []
+	earlier, later = [], []
+
+	for team in shared:
+		before, after = live[team], altered[team]
+		currency = after.get("currency") or before.get("currency")
+		if currency:
+			revenue.setdefault(currency, 0.0)
+			revenue[currency] += frappe.utils.flt(after.get("projected_total")) - frappe.utils.flt(
+				before.get("projected_total")
+			)
+
+		if frappe.utils.flt(after.get("shortfall")) > 0 >= frappe.utils.flt(before.get("shortfall")):
+			newly_short.append(team)
+
+		was, now = before.get("suspends_on"), after.get("suspends_on")
+		if now and not was:
+			newly_suspending.append(team)
+		elif now and was and str(now) != str(was):
+			(earlier if str(now) < str(was) else later).append(team)
+
+	return {
+		"teams": len(shared),
+		# Per currency, always. There is no meaningful sum of rupees and dollars, and a
+		# blast radius that produced one would be quoted anyway.
+		"revenue_delta": {c: frappe.utils.flt(v, 2) for c, v in sorted(revenue.items())},
+		"newly_short": newly_short,
+		"newly_suspending": newly_suspending,
+		"suspension_moved_earlier": earlier,
+		"suspension_moved_later": later,
+		"provisional_metrics": True,
+	}
+
+
+def summarise(comparison: dict, sampled: bool = False, sample_size: int = 0, population: int = 0) -> dict:
+	"""Counts rather than lists, plus the labelling a sampled figure must carry."""
+	out = {
+		"teams": comparison["teams"],
+		"revenue_delta": comparison["revenue_delta"],
+		"newly_short": len(comparison["newly_short"]),
+		"newly_suspending": len(comparison["newly_suspending"]),
+		"suspension_moved_earlier": len(comparison["suspension_moved_earlier"]),
+		"suspension_moved_later": len(comparison["suspension_moved_later"]),
+		"provisional_metrics": True,
+		"sampled": bool(sampled),
+	}
+	if sampled:
+		out["sample_size"] = sample_size
+		out["population"] = population
+		# Extrapolate the money, never the counts: scaling "3 teams newly suspending" to
+		# a population invents teams, and somebody will go looking for them.
+		factor = (population / sample_size) if sample_size else 0
+		out["revenue_delta_extrapolated"] = {
+			c: frappe.utils.flt(v * factor, 2) for c, v in comparison["revenue_delta"].items()
+		}
+		out["note"] = (
+			f"Extrapolated from {sample_size} of {population} teams. The money is scaled; "
+			"the team counts are what was actually seen in the sample."
+		)
+	return out
+
+
+def describe(summary: dict) -> str:
+	"""One line an operator can take into a decision."""
+	money = ", ".join(
+		f"{currency} {amount:,.2f}"
+		for currency, amount in (summary.get("revenue_delta") or {}).items()
+		if amount
+	)
+	parts = [f"{summary['teams']} teams"]
+	if money:
+		parts.append(money)
+	if summary["newly_suspending"]:
+		parts.append(f"{summary['newly_suspending']} newly suspending")
+	if summary["suspension_moved_earlier"]:
+		parts.append(f"{summary['suspension_moved_earlier']} cut off sooner")
+	if summary["newly_short"]:
+		parts.append(f"{summary['newly_short']} newly short")
+	if len(parts) == 1:
+		return f"{summary['teams']} teams, and nothing measurable changes for any of them."
+	return " · ".join(parts)

--- a/central/billing/projection/cassette.py
+++ b/central/billing/projection/cassette.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Recording what a projection read, so a later one can be replayed against it.
+
+The obvious regression harness does not work. Snapshot the book, deploy, re-run, diff —
+and the two runs happen at different times with the data moved in between. Teams resize,
+top up, get invoiced and pay, and every one of those legitimately changes the projection.
+The diff drowns in deltas nobody can attribute to the deploy, and an unattributable diff
+is ignored within a fortnight.
+
+So stop diffing across *time* and diff across *code with the inputs held fixed*. A thin
+recorder captures every `(query → result)` the engine consumed; the cassette is stored
+with the answer; after the deploy the new code is replayed **against the cassette**
+rather than the database. Inputs are then bit-identical by construction and every
+surviving delta is attributable.
+
+A read the new code makes that is *absent* from the cassette is itself worth reporting —
+the rating path now consults something it did not before, which is a change worth knowing
+about even when the number is unmoved.
+
+The seam sits at the database layer, underneath the state/reference split, so nothing
+needs threading through `resolve_tax` and its neighbours.
+"""
+
+import hashlib
+import json
+
+import frappe
+
+
+class Recorder:
+	"""Captures every read a projection makes, keyed so replay is deterministic."""
+
+	def __init__(self):
+		self.entries: dict[str, list] = {}
+		self.order: list[str] = []
+
+	def record(self, key: str, value):
+		self.entries.setdefault(key, []).append(value)
+		self.order.append(key)
+
+	def cassette(self) -> dict:
+		return {"entries": self.entries, "reads": len(self.order)}
+
+
+class Replay:
+	"""Answers reads from a cassette, and reports any the recording never saw."""
+
+	def __init__(self, cassette: dict):
+		self.entries = {k: list(v) for k, v in (cassette or {}).get("entries", {}).items()}
+		self.missing: list[str] = []
+
+	def answer(self, key: str, default=None):
+		queue = self.entries.get(key)
+		if not queue:
+			# Not an error. The code now reads something the recording did not, which is
+			# a finding in its own right — it is why the number moved, or why it did not.
+			self.missing.append(key)
+			return default
+		# Reads repeat within a projection; replay them in the order they were captured.
+		return queue.pop(0) if len(queue) > 1 else queue[0]
+
+
+def key(*parts) -> str:
+	"""A stable key for one read. Order matters; formatting must not."""
+	blob = json.dumps(parts, sort_keys=True, default=str)
+	return hashlib.sha1(blob.encode()).hexdigest()[:16]
+
+
+def diff(before: dict, after: dict, ignore: tuple = ("as_of",)) -> list[dict]:
+	"""Every field that moved between two projections of the same thing.
+
+	Walks both structures rather than comparing totals: a total that happens to match
+	while two lines moved in opposite directions is exactly the regression a summary
+	comparison would miss.
+	"""
+	found: list[dict] = []
+	_walk(before, after, "", found, set(ignore))
+	return found
+
+
+def _walk(before, after, path: str, found: list, ignore: set):
+	if isinstance(before, dict) and isinstance(after, dict):
+		for field in sorted(set(before) | set(after)):
+			if field in ignore:
+				continue
+			_walk(before.get(field), after.get(field), f"{path}.{field}" if path else field, found, ignore)
+		return
+
+	if isinstance(before, list) and isinstance(after, list):
+		if len(before) != len(after):
+			found.append({"path": path, "before": f"{len(before)} items", "after": f"{len(after)} items"})
+			return
+		for i, (b, a) in enumerate(zip(before, after, strict=False)):
+			_walk(b, a, f"{path}[{i}]", found, ignore)
+		return
+
+	if _differs(before, after):
+		found.append({"path": path, "before": before, "after": after})
+
+
+def _differs(before, after) -> bool:
+	if isinstance(before, int | float) and isinstance(after, int | float):
+		# Money is float; a representation wobble is not a regression.
+		return abs(frappe.utils.flt(before) - frappe.utils.flt(after)) > 0.005
+	return before != after
+
+
+def report(before: dict, after: dict, replay: Replay | None = None) -> dict:
+	"""What changed, and whether the new code read anything the recording lacks."""
+	changes = diff(before, after)
+	return {
+		"changed": bool(changes),
+		"differences": changes,
+		# Ranked by how much money moved, so the worst is read first.
+		"worst": max(
+			(c for c in changes if isinstance(c.get("before"), int | float)),
+			key=lambda c: abs(frappe.utils.flt(c["after"]) - frappe.utils.flt(c["before"])),
+			default=None,
+		),
+		"reads_absent_from_the_cassette": len(replay.missing) if replay else 0,
+	}

--- a/central/billing/projection/engine.py
+++ b/central/billing/projection/engine.py
@@ -31,6 +31,7 @@ def project(
 	mode: str = outcomes.DERIVED,
 	assume: str | None = None,
 	events: list | None = None,
+	guarded: bool = True,
 	recorder=None,
 	source=None,
 ) -> dict:
@@ -42,7 +43,7 @@ def project(
 	unused here so that adding the regression harness does not have to reshape the
 	engine.
 	"""
-	with read_only():
+	with read_only(strict=guarded):
 		return _project(team, period_start, period_end, today, mode, assume, events)
 
 

--- a/central/billing/projection/engine.py
+++ b/central/billing/projection/engine.py
@@ -68,7 +68,7 @@ def _project(
 		injected.mark_assumed(invoice["lines"], events, start)
 		invoice.update(split_totals(invoice["lines"]))
 	currency = frappe.db.get_value("Billing Profile", team, "currency")
-	calendar = _calendar(end, today)
+	calendar = injected.apply_declines(_calendar(end, today), team, events)
 
 	# Derived findings are read off the amount we would actually try to collect, not the
 	# headline total: credits and withholding both change what the gateway is asked for.

--- a/central/billing/projection/engine.py
+++ b/central/billing/projection/engine.py
@@ -16,7 +16,7 @@ guarantee rather than a convention — see `guard`.
 import frappe
 
 from central.billing import settings
-from central.billing.projection import estimate, events as injected, outcomes, state
+from central.billing.projection import behaviour, estimate, events as injected, outcomes, state
 from central.billing.projection.basis import MEASURED, mark, split_totals
 from central.billing.projection.guard import read_only
 from central.billing.revenue.dunning import dunning_clock_start, dunning_policy, dunning_schedule
@@ -90,6 +90,9 @@ def _project(
 		"in_flight": _in_flight(team, today),
 		"injected_events": injected.timeline(events),
 		"refused": injected.refusals(team, events),
+		# "Suspended on the 12th" means one thing for a team that has never missed a
+		# payment and the opposite for one that is late every month.
+		"behaviour": behaviour.with_verdict(team, on=today),
 	}
 
 

--- a/central/billing/projection/events.py
+++ b/central/billing/projection/events.py
@@ -125,6 +125,47 @@ def declines(events: list) -> list[dict]:
 	]
 
 
+def apply_declines(calendar: dict, team: str, events: list) -> dict:
+	"""Walk the retry ladder spending the team's payment methods as declines burn them.
+
+	A decline does **not** move any date, and it is worth being exact about that: the
+	ladder is counted from the invoice's clock, and only *our* failure to collect ever
+	pushes it (`defer_dunning`). A customer's card being refused is not our failure. What
+	it changes is which method the next attempt reaches for — the charge loop escalates
+	rather than repeating, so each decline burns one method — and what happens once there
+	are none left.
+
+	So the dates stay put and each retry gains two facts: the method it would try, and
+	whether anything remains to try at all.
+	"""
+	assumed = {d["attempt"] for d in declines(events)}
+	if not assumed:
+		return calendar
+
+	from central.billing.payments import collection
+
+	methods = [m.name for m in collection.ordered_methods(team)]
+	burnt: list[str] = []
+
+	for stage in calendar.get("if_never_paid", []):
+		if stage.get("stage") != "Retry":
+			continue
+		attempt = stage.get("attempt")
+		available = [m for m in methods if m not in burnt]
+		stage["method"] = available[0] if available else None
+		if not available:
+			stage["note"] = "Nothing left to try — every method has been refused."
+		elif attempt in assumed:
+			stage["assumed_declined"] = True
+			stage["note"] = "Assumed refused; the next attempt escalates to another method."
+			burnt.append(available[0])
+		else:
+			stage["note"] = "Charges the next untried method."
+
+	calendar["methods_exhausted"] = len(burnt) >= len(methods) and bool(methods)
+	return calendar
+
+
 def refusals(team: str, events: list, state=None) -> list[dict]:
 	"""Injected provisions the real gates would not have allowed.
 

--- a/central/billing/projection/guard.py
+++ b/central/billing/projection/guard.py
@@ -35,7 +35,7 @@ class ProjectionBoundaryError(frappe.ValidationError):
 
 
 @contextmanager
-def read_only():
+def read_only(strict: bool = True):
 	"""Run a block inside a read-only transaction, and name what happens if it writes.
 
 	A projection is a transaction boundary. `START TRANSACTION` implicitly commits an
@@ -49,11 +49,23 @@ def read_only():
 	before it starts.
 	"""
 	if frappe.db.transaction_writes:
-		raise ProjectionBoundaryError(
-			"A projection cannot start with unsaved changes pending — commit or roll "
-			"back first. Projections read a consistent snapshot and must not decide "
-			"the fate of someone else's transaction."
+		if strict:
+			raise ProjectionBoundaryError(
+				"A projection cannot start with unsaved changes pending — commit or roll "
+				"back first. Projections read a consistent snapshot and must not decide "
+				"the fate of someone else's transaction."
+			)
+		# Non-strict callers are customer-facing reads that happen to share a request
+		# with a write — the customer forecast, say. Refusing them would break a page to
+		# enforce an internal invariant, and committing on their behalf is the side
+		# effect this guard exists to prevent. So the read proceeds without the
+		# transaction: the engine still cannot write, because the decision/effect split
+		# and the grep hold that; what is given up is the database enforcing it too.
+		frappe.logger("billing").debug(
+			"projection ran unguarded: the caller had uncommitted changes"
 		)
+		yield
+		return
 
 	previous = frappe.flags.read_only
 	frappe.flags.read_only = True

--- a/central/billing/projection/library.py
+++ b/central/billing/projection/library.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""A shelf of named questions, applicable to any real team in one click.
+
+The training tool. Billing has a dozen behaviours that are correct, deliberate and
+invisible until they surprise somebody — the ₹15,000 silent-debit ceiling, hourly
+billing after a same-day resize, a suspension that leaves the resource running until its
+token expires, a late run that costs the customer no grace. Reading about them does not
+stick. Watching one happen to a team you know does.
+
+Each entry is declarative: overrides, events, and a sentence saying what to look for.
+Adding one needs no engine change, which is the property that decides whether a
+catalogue like this stays current or rots.
+
+The last entry matters most, because its correct answer is *"nothing bad happens"*.
+Being able to show that is worth more than asserting it.
+"""
+
+import frappe
+
+SCENARIOS = {
+	"over-the-inr-threshold": {
+		"title": "An INR bill over the silent-debit ceiling",
+		"question": "What happens when an e-mandate team's bill crosses ₹15,000?",
+		"look_for": (
+			"The outcome is Action Required, not a failed charge. Nothing is auto-debited "
+			"above the ceiling by design, and dunning escalates without retrying — the "
+			"customer has to act."
+		),
+		"overrides": {},
+		"events": [],
+		"requires": {"collection_mode": "E-Mandate"},
+	},
+	"no-way-to-pay": {
+		"title": "No payment method and no credits",
+		"question": "What does a team with nothing to charge look like before the 1st?",
+		"look_for": (
+			"A derived finding rather than a guess, and a suspension date that follows "
+			"from the ladder. Nothing here is a prediction."
+		),
+		"overrides": {},
+		"events": [],
+	},
+	"resized-twice-in-a-day": {
+		"title": "Two resizes inside 24 hours",
+		"question": "Why did one day of the bill itemise by the hour?",
+		"look_for": (
+			"That date leaves daily billing entirely and bills the real hours each config "
+			"ran. Open the line: the drill names every config that shared the date."
+		),
+		"overrides": {},
+		"events": [
+			{"event_type": "Resize", "offset_days": 14, "at": "09:00:00", "rate_multiple": 2.0},
+			{"event_type": "Resize", "offset_days": 14, "at": "18:00:00", "rate_multiple": 1.0},
+		],
+	},
+	"wallet-runs-dry": {
+		"title": "A credits-only team whose wallet runs out",
+		"question": "When does prepaid credit stop covering the bill?",
+		"look_for": (
+			"The month the shortfall appears, and the suspension that follows it. A "
+			"single-month projection cannot show this; the balance carries."
+		),
+		"overrides": {},
+		"events": [],
+		"months": 6,
+	},
+	"rescued-by-a-top-up": {
+		"title": "A top-up arrives just in time",
+		"question": "Does money added mid-month reach the bill it is meant to cover?",
+		"look_for": "The shortfall closing in the month the top-up lands, not the one after.",
+		"overrides": {},
+		"events": [{"event_type": "Top up", "offset_days": 20, "amount": 25000}],
+		"months": 3,
+	},
+	"harsher-dunning": {
+		"title": "Suspend a week sooner",
+		"question": "What would tightening the ladder do to the teams already behind?",
+		"look_for": (
+			"Every date on the unpaid branch moving left. Billing Settings are untouched — "
+			"this is read instead of them, for one projection."
+		),
+		"overrides": {"suspend_after_days": 7, "terminate_after_days": 30},
+		"events": [],
+	},
+	"a-price-rise": {
+		"title": "Raise prices 20%",
+		"question": "What does a catalog price rise do to next month's revenue?",
+		"look_for": (
+			"Almost certainly nothing. Existing resources bill at the rate locked when "
+			"they were provisioned; a catalog change reaches new provisions and resizes. "
+			"The split says how much could move at all."
+		),
+		"overrides": {},
+		"events": [],
+		"rate_percent": 20,
+	},
+	"a-late-billing-run": {
+		"title": "The run was three days late",
+		"question": "Does our own delay cost the customer their grace period?",
+		"look_for": (
+			"No. The escalation clock is pushed forward by the same window a fresh invoice "
+			"gets, while the due date stays put — what was owed and when is an accounting "
+			"fact. This is the scenario whose right answer is that nothing bad happens."
+		),
+		"overrides": {},
+		"events": [],
+		"illustrates": "deferred_clock",
+	},
+}
+
+
+def catalogue() -> list[dict]:
+	"""Every scenario on the shelf, for a picker."""
+	return [
+		{
+			"key": key,
+			"title": entry["title"],
+			"question": entry["question"],
+			"look_for": entry["look_for"],
+			"months": entry.get("months", 1),
+		}
+		for key, entry in SCENARIOS.items()
+	]
+
+
+def applicable(key: str, team: str) -> tuple[bool, str | None]:
+	"""Whether this scenario can say anything true about this team.
+
+	Where it cannot, it says why rather than projecting something misleading — a
+	threshold scenario applied to a card team would demonstrate nothing and imply
+	plenty.
+	"""
+	entry = SCENARIOS.get(key)
+	if not entry:
+		return False, f"No scenario called {key}."
+
+	requires = entry.get("requires") or {}
+	if "collection_mode" in requires:
+		mode = frappe.db.get_value("Billing Profile", team, "collection_mode")
+		if mode != requires["collection_mode"]:
+			return False, (
+				f"This one needs a team on {requires['collection_mode']}; "
+				f"{team} is on {mode or 'no configured mode'}."
+			)
+	return True, None
+
+
+def build(key: str, team: str, period_start=None, today=None):
+	"""Turn a catalogue entry into a Billing Scenario for this team.
+
+	Built, not saved: the shelf is a way of asking, and an operator who wants to keep
+	one saves it themselves.
+	"""
+	entry = SCENARIOS.get(key)
+	if not entry:
+		frappe.throw(f"No scenario called {key}.", frappe.ValidationError)
+
+	ok, reason = applicable(key, team)
+	if not ok:
+		frappe.throw(reason, frappe.ValidationError)
+
+	today = frappe.utils.getdate(today or frappe.utils.nowdate())
+	period_start = frappe.utils.get_first_day(period_start or today)
+
+	doc = frappe.new_doc("Billing Scenario")
+	doc.scenario_name = f"{entry['title']} — {team}"
+	doc.team = team
+	doc.period_start = period_start
+	doc.months = entry.get("months", 1)
+	doc.outcome_mode = "Derived"
+	for field, value in (entry.get("overrides") or {}).items():
+		doc.set(field, value)
+
+	for event in entry.get("events") or []:
+		doc.append("events", _event_row(event, team, period_start))
+
+	if entry.get("rate_percent"):
+		for plan in _plans_for(team):
+			doc.append(
+				"rate_overrides",
+				{
+					"priced_doctype": "Plan",
+					"priced_for": plan,
+					"percent": entry["rate_percent"],
+					"effective_from": period_start,
+				},
+			)
+	return doc
+
+
+def _event_row(event: dict, team: str, period_start) -> dict:
+	"""A catalogue event is relative — it has to land inside whatever month is projected."""
+	on_date = frappe.utils.add_days(period_start, frappe.utils.cint(event.get("offset_days")))
+	row = {
+		"event_type": event["event_type"],
+		"on_date": f"{on_date} {event.get('at', '00:00:00')}",
+	}
+	if event["event_type"] in ("Resize", "Provision"):
+		subscription = _subscription_for(team)
+		row["subscription"] = subscription
+		row["plan"] = frappe.db.get_value("Subscription", subscription, "plan") if subscription else None
+		row["rate"] = _current_rate(subscription) * frappe.utils.flt(event.get("rate_multiple") or 1)
+	if event["event_type"] == "Top up":
+		row["amount"] = event.get("amount")
+		row["currency"] = frappe.db.get_value("Billing Profile", team, "currency")
+	return row
+
+
+def _subscription_for(team: str) -> str | None:
+	names = frappe.get_all(
+		"Subscription", filters={"team": team}, pluck="name", order_by="creation asc", limit=1
+	)
+	return names[0] if names else None
+
+
+def _current_rate(subscription: str | None) -> float:
+	"""The rate the subscription is running at, so a "double it" event doubles something."""
+	if not subscription:
+		return 0.0
+	rows = frappe.get_all(
+		"Subscription Change",
+		filters={"subscription": subscription, "locked_rate": ["is", "set"]},
+		fields=["locked_rate"],
+		order_by="effective_at desc",
+		limit=1,
+	)
+	return frappe.utils.flt(rows[0].locked_rate) if rows else 0.0
+
+
+def _plans_for(team: str) -> list[str]:
+	return list(
+		{p for p in frappe.get_all("Subscription", filters={"team": team}, pluck="plan") if p}
+	)

--- a/central/billing/projection/outlook.py
+++ b/central/billing/projection/outlook.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Who gets cut off, and when.
+
+The cheap half of the cohort question, and the operationally urgent one. Answering it
+needs **no rating at all**: every input is already a fact — invoices that are Open or
+Overdue, their real `dunning_starts_on`, and the live ladder. It is `dunning_schedule`
+applied to rows that exist.
+
+That makes its cost scale with **delinquency rather than with the book**. Most teams
+pay, so the unpaid set stays a few thousand rows at any size of business, and this can
+run over everything, on demand, indefinitely. Cohort *revenue* projection has to be
+filter-bounded precisely because it cannot make that claim.
+
+Nothing here is estimated and nothing is assumed. Every column is a stored fact or
+arithmetic over one.
+"""
+
+import frappe
+
+from central.billing.revenue.dunning import dunning_clock_start, dunning_policy, dunning_schedule
+
+# Modes in which nothing is charged off-session — dunning escalates without retrying, so
+# a row for one of these teams is asking a human to act rather than waiting on a gateway.
+ON_SESSION_MODES = ("Manual Checkout", "Action Required")
+
+
+def unpaid_invoices(filters: dict | None = None) -> list[frappe._dict]:
+	"""Every billable invoice still owing, with what the ladder needs to date it."""
+	filters = filters or {}
+	conditions = {
+		"invoice_type": "Billable",
+		"status": ["in", ["Open", "Overdue"]],
+		"expected_collection": [">", 0],
+	}
+	if filters.get("currency"):
+		conditions["currency"] = filters["currency"]
+	if filters.get("team"):
+		conditions["team"] = filters["team"]
+
+	return frappe.get_all(
+		"Invoice",
+		filters=conditions,
+		fields=[
+			"name", "team", "currency", "status", "due_date", "dunning_starts_on",
+			"expected_collection", "subscription",
+		],
+		order_by="due_date asc",
+		limit_page_length=0,
+	)
+
+
+def rows(on=None, horizon_days: int | None = None, filters: dict | None = None) -> list[dict]:
+	"""One row per unpaid invoice: where its ladder has got to, and where it goes next.
+
+	`horizon_days` keeps only the invoices whose next escalation lands inside the window
+	— which is how "who is about to be cut off" gets asked without reading the whole
+	delinquent book.
+	"""
+	on = frappe.utils.getdate(on or frappe.utils.nowdate())
+	policy = dunning_policy()
+	horizon = frappe.utils.add_days(on, horizon_days) if horizon_days else None
+
+	out = []
+	for invoice in unpaid_invoices(filters):
+		if not invoice.due_date:
+			# No due date means no clock; it is a data problem, not a delinquency.
+			continue
+
+		clock_start = dunning_clock_start(invoice)
+		schedule = dunning_schedule(clock_start, policy)
+		reached = [s for s in schedule if frappe.utils.getdate(s.date) <= on]
+		ahead = [s for s in schedule if frappe.utils.getdate(s.date) > on]
+		next_stage = ahead[0] if ahead else None
+
+		if horizon and next_stage and frappe.utils.getdate(next_stage.date) > horizon:
+			continue
+		if horizon and not next_stage:
+			continue
+
+		mode = _collection_mode(invoice.team)
+		out.append(
+			{
+				"invoice": invoice.name,
+				"team": invoice.team,
+				"currency": invoice.currency,
+				"status": invoice.status,
+				"outstanding": invoice.expected_collection,
+				"due_date": str(invoice.due_date),
+				"clock_starts_on": str(clock_start),
+				# A deferred clock means *we* failed to collect on time. Saying so keeps
+				# the row from reading as the customer's delinquency.
+				"clock_deferred": bool(invoice.dunning_starts_on),
+				"days_in": (on - frappe.utils.getdate(clock_start)).days,
+				"stage": reached[-1].stage if reached else "Not yet due",
+				"next_action": next_stage.stage if next_stage else None,
+				"next_action_on": str(next_stage.date) if next_stage else None,
+				"suspends_on": _stage_date(schedule, "Suspend"),
+				"terminates_on": _stage_date(schedule, "Terminate"),
+				"collection_mode": mode,
+				"needs_customer_action": mode in ON_SESSION_MODES,
+			}
+		)
+
+	# Soonest consequence first: the list is read top-down by someone deciding what to
+	# do this morning.
+	return sorted(out, key=lambda r: (r["suspends_on"] or "9999-12-31", -r["outstanding"]))
+
+
+def why(invoice: str, on=None) -> dict:
+	"""The inverse: given one invoice, why is it at this stage on this date.
+
+	What makes the sweep a debugging tool rather than a list — including whether the
+	clock was ever pushed because collection failed on our side.
+	"""
+	doc = frappe.get_doc("Invoice", invoice)
+	on = frappe.utils.getdate(on or frappe.utils.nowdate())
+	clock_start = dunning_clock_start(doc)
+	schedule = dunning_schedule(clock_start, dunning_policy())
+
+	return {
+		"invoice": invoice,
+		"team": doc.team,
+		"due_date": str(doc.due_date),
+		"clock_starts_on": str(clock_start),
+		"clock_deferred": bool(doc.dunning_starts_on),
+		"deferred_note": (
+			"Collection failed on our side, so the escalation clock was pushed forward. "
+			"The due date is unchanged — what was owed and when is an accounting fact."
+			if doc.dunning_starts_on
+			else None
+		),
+		"days_in": (on - frappe.utils.getdate(clock_start)).days,
+		"ladder": [
+			{
+				"date": str(s.date),
+				"stage": s.stage,
+				"day": s.day,
+				"reached": frappe.utils.getdate(s.date) <= on,
+				**({"attempt": s.attempt} if s.get("attempt") else {}),
+			}
+			for s in schedule
+		],
+	}
+
+
+def _stage_date(schedule, stage: str) -> str | None:
+	found = next((s for s in schedule if s.stage == stage), None)
+	return str(found.date) if found else None
+
+
+def _collection_mode(team: str) -> str | None:
+	return frappe.db.get_value("Billing Profile", team, "collection_mode")

--- a/central/billing/projection/scenario.py
+++ b/central/billing/projection/scenario.py
@@ -17,7 +17,7 @@ import frappe
 
 from central.billing import settings
 from central.billing.catalog import pricing
-from central.billing.projection import engine, repricing
+from central.billing.projection import cassette, engine, repricing
 
 # The only DocType this module may write. Asserted, because the whole safety argument
 # for running projections against production rests on it staying true.
@@ -164,3 +164,52 @@ def _bare(doc):
 
 def _resolve(scenario):
 	return scenario if hasattr(scenario, "overrides") else frappe.get_doc("Billing Scenario", scenario)
+
+
+def check_drift(scenario, today=None) -> dict:
+	"""Has this scenario's answer changed since it was last saved?
+
+	The regression harness, in the smallest form that is actually useful. A saved
+	scenario already holds its inputs and its last answer, so re-projecting it and
+	diffing gives exactly what a deploy check needs: same question, same team, different
+	code.
+
+	It is not immune to data drift — the team may genuinely have changed — so the
+	report says what moved and where, and leaves the judgement to a human. Freezing the
+	inputs too is the cassette's job, and this is where a recording would be replayed
+	from once there is one.
+	"""
+	doc = _resolve(scenario)
+	if not doc.result:
+		frappe.throw(
+			"This scenario has no saved answer to compare against. Project and save it "
+			"first.",
+			frappe.ValidationError,
+		)
+
+	before = frappe.parse_json(doc.result)
+	after = project(doc, today)
+	report = cassette.report(before, after)
+	return {
+		"scenario": doc.name,
+		"projected_at": str(doc.projected_at) if doc.projected_at else None,
+		**report,
+	}
+
+
+def check_all(today=None) -> list[dict]:
+	"""Every saved scenario, re-projected and diffed. What runs after a deploy."""
+	out = []
+	for name in frappe.get_all(
+		"Billing Scenario", filters={"result": ["is", "set"]}, pluck="name"
+	):
+		try:
+			out.append(check_drift(name, today))
+		except Exception:  # noqa: BLE001
+			frappe.log_error(
+				title="Billing Scenario Drift Check Failed",
+				message=frappe.get_traceback(),
+				reference_doctype="Billing Scenario",
+				reference_name=name,
+			)
+	return out

--- a/central/billing/report/billing_projection/billing_projection.py
+++ b/central/billing/report/billing_projection/billing_projection.py
@@ -19,7 +19,8 @@ from frappe import _
 from central.billing.projection import cohort
 from central.billing.report._currency import split_currency_columns
 
-MONEY_FIELDS = ("projected_total", "measured", "estimated", "credit_balance", "shortfall")
+# Only the money that has its own column gets split per currency.
+MONEY_FIELDS = ("projected_total", "shortfall")
 
 
 def execute(filters: dict | None = None):
@@ -68,22 +69,23 @@ def _rows(batch: str, filters) -> list[dict]:
 
 
 def get_columns() -> list[dict]:
+	"""Seven columns, not eleven.
+
+	Five money fields across two currencies is ten columns before Team, and the headings
+	truncate. So each column has to earn its place: `Credits` is `Projected total` minus
+	`Shortfall`, and the measured/estimated split belongs in the drill-down rather than
+	in a list somebody scans. What is left is what an operator acts on — who, how much,
+	whether it will settle, and when they get cut off.
+	"""
 	return [
-		{"label": _("Team"), "fieldname": "team", "fieldtype": "Link", "options": "Team", "width": 160},
-		{"label": _("Projected total"), "fieldname": "projected_total", "fieldtype": "Currency",
+		{"label": _("Team"), "fieldname": "team", "fieldtype": "Link", "options": "Team", "width": 170},
+		{"label": _("Projected"), "fieldname": "projected_total", "fieldtype": "Currency",
 		 "options": "currency", "width": 140},
-		{"label": _("Measured"), "fieldname": "measured", "fieldtype": "Currency",
-		 "options": "currency", "width": 120},
-		{"label": _("Estimated"), "fieldname": "estimated", "fieldtype": "Currency",
-		 "options": "currency", "width": 120},
-		{"label": _("Credits"), "fieldname": "credit_balance", "fieldtype": "Currency",
-		 "options": "currency", "width": 110},
 		{"label": _("Shortfall"), "fieldname": "shortfall", "fieldtype": "Currency",
-		 "options": "currency", "width": 120},
-		{"label": _("Settles via"), "fieldname": "settles_via", "fieldtype": "Data", "width": 120},
-		{"label": _("Outcome"), "fieldname": "outcome", "fieldtype": "Data", "width": 200},
-		{"label": _("Due on"), "fieldname": "due_on", "fieldtype": "Date", "width": 100},
-		{"label": _("Suspends on"), "fieldname": "suspends_on", "fieldtype": "Date", "width": 110},
+		 "options": "currency", "width": 130},
+		{"label": _("Outcome"), "fieldname": "outcome", "fieldtype": "Data", "width": 210},
+		{"label": _("Suspends on"), "fieldname": "suspends_on", "fieldtype": "Date", "width": 115},
+		{"label": _("Paid on time"), "fieldname": "paid_on_time", "fieldtype": "Data", "width": 105},
 		{"label": _("Currency"), "fieldname": "currency", "fieldtype": "Link",
 		 "options": "Currency", "width": 90},
 	]

--- a/central/billing/report/collection_outlook/collection_outlook.js
+++ b/central/billing/report/collection_outlook/collection_outlook.js
@@ -1,0 +1,25 @@
+// Copyright (c) 2026, Frappe and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["Collection Outlook"] = {
+	filters: [
+		{ fieldname: "as_of", label: __("As of"), fieldtype: "Date",
+		  default: frappe.datetime.get_today() },
+		{ fieldname: "horizon_days", label: __("Acting within (days)"), fieldtype: "Select",
+		  options: ["", "7", "14", "21", "30"], default: "21" },
+		{ fieldname: "currency", label: __("Currency"), fieldtype: "Link", options: "Currency" },
+		{ fieldname: "team", label: __("Team"), fieldtype: "Link", options: "Team" },
+	],
+
+	formatter(value, row, column, data, default_formatter) {
+		value = default_formatter(value, row, column, data);
+		if (column.fieldname === "suspends_on" && data && data.suspends_on) {
+			value = `<span class="indicator-pill red">${value}</span>`;
+		}
+		// A clock we pushed is our doing, not theirs — say so where it is read.
+		if (column.fieldname === "clock_starts_on" && data && data.clock_deferred) {
+			value = `${value} <span class="text-muted">${__("(deferred)")}</span>`;
+		}
+		return value;
+	},
+};

--- a/central/billing/report/collection_outlook/collection_outlook.json
+++ b/central/billing/report/collection_outlook/collection_outlook.json
@@ -1,0 +1,9 @@
+{
+ "add_total_row": 0, "columns": [], "creation": "2026-08-07 00:00:00.000000",
+ "disabled": 0, "docstatus": 0, "doctype": "Report", "filters": [], "idx": 0,
+ "is_standard": "Yes", "letterhead": null, "modified": "2026-08-07 00:00:00.000000",
+ "modified_by": "Administrator", "module": "Billing", "name": "Collection Outlook",
+ "owner": "Administrator", "prepared_report": 0, "ref_doctype": "Invoice",
+ "report_name": "Collection Outlook", "report_type": "Script Report",
+ "roles": [{"role": "System Manager"}]
+}

--- a/central/billing/report/collection_outlook/collection_outlook.py
+++ b/central/billing/report/collection_outlook/collection_outlook.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Which teams are about to be cut off, and on what date.
+
+Unlike the revenue projection, this one computes in the request — and can, because it
+costs nothing. There is no rating here: it is the dunning ladder applied to invoices
+that already exist, so it scales with how many customers are behind rather than with how
+many customers there are. That number stays small however large the book gets.
+"""
+
+import frappe
+from frappe import _
+
+from central.billing.projection import outlook
+from central.billing.report._currency import split_currency_columns
+
+MONEY_FIELDS = ("outstanding",)
+
+
+def execute(filters: dict | None = None):
+	filters = frappe._dict(filters or {})
+	rows = outlook.rows(
+		on=filters.as_of,
+		horizon_days=frappe.utils.cint(filters.horizon_days) or None,
+		filters={"currency": filters.currency, "team": filters.team},
+	)
+	columns = split_currency_columns(get_columns(), rows, MONEY_FIELDS)
+	return columns, rows, _note(rows), None, _summary(rows)
+
+
+def get_columns() -> list[dict]:
+	return [
+		{"label": _("Team"), "fieldname": "team", "fieldtype": "Link", "options": "Team", "width": 150},
+		{"label": _("Invoice"), "fieldname": "invoice", "fieldtype": "Link",
+		 "options": "Invoice", "width": 150},
+		{"label": _("Outstanding"), "fieldname": "outstanding", "fieldtype": "Currency",
+		 "options": "currency", "width": 130},
+		{"label": _("Stage"), "fieldname": "stage", "fieldtype": "Data", "width": 110},
+		{"label": _("Next action"), "fieldname": "next_action", "fieldtype": "Data", "width": 110},
+		{"label": _("On"), "fieldname": "next_action_on", "fieldtype": "Date", "width": 100},
+		{"label": _("Suspends on"), "fieldname": "suspends_on", "fieldtype": "Date", "width": 110},
+		{"label": _("Due"), "fieldname": "due_date", "fieldtype": "Date", "width": 100},
+		{"label": _("Clock starts"), "fieldname": "clock_starts_on", "fieldtype": "Date", "width": 110},
+		{"label": _("Currency"), "fieldname": "currency", "fieldtype": "Link",
+		 "options": "Currency", "width": 90},
+	]
+
+
+def _summary(rows) -> list[dict]:
+	if not rows:
+		return []
+	deferred = [r for r in rows if r["clock_deferred"]]
+	awaiting = [r for r in rows if r["needs_customer_action"]]
+	tiles = [
+		{"label": _("Unpaid invoices"), "value": len(rows), "datatype": "Int"},
+		{"label": _("Awaiting the customer"), "value": len(awaiting), "datatype": "Int"},
+		{"label": _("Clock deferred by us"), "value": len(deferred), "datatype": "Int",
+		 "indicator": "Orange" if deferred else "Green"},
+	]
+	by_currency: dict = {}
+	for row in rows:
+		by_currency.setdefault(row["currency"], 0.0)
+		by_currency[row["currency"]] += frappe.utils.flt(row["outstanding"])
+	for currency, total in sorted(by_currency.items()):
+		tiles.append({"label": _("Outstanding {0}").format(currency), "value": total,
+					  "datatype": "Currency", "currency": currency})
+	return tiles
+
+
+def _note(rows) -> str | None:
+	deferred = sum(1 for r in rows if r["clock_deferred"])
+	if not deferred:
+		return None
+	# Worth saying out loud: these customers are not late by their own doing.
+	return _(
+		'<div class="text-muted">{0} of these clocks were pushed forward because '
+		"collection failed on our side. Those customers are not late — their escalation "
+		"simply restarts later, and the due date is unchanged.</div>"
+	).format(deferred)

--- a/central/billing/tests/test_projection_blast.py
+++ b/central/billing/tests/test_projection_blast.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Blast radius: how far a change reaches across the book.
+
+The metric set is provisional by design — the issue is HITL because which numbers
+matter is a conversation with the accounts team. What these tests hold is the shape:
+counted from two projections, never modelled; money never crossed between currencies;
+and an extrapolated figure that says so.
+"""
+
+from central.billing.projection import blast
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+
+
+def row(team, total=1000.0, currency="INR", shortfall=0.0, suspends_on=None):
+	return {
+		"team": team,
+		"currency": currency,
+		"projected_total": total,
+		"shortfall": shortfall,
+		"suspends_on": suspends_on,
+	}
+
+
+class TestTheComparison(IntegrationTestCase):
+	def test_revenue_moves_are_counted_per_currency(self):
+		out = blast.compare_rows(
+			[row("a", 1000, "INR"), row("b", 100, "USD")],
+			[row("a", 1200, "INR"), row("b", 150, "USD")],
+		)
+		self.assertEqual(out["revenue_delta"], {"INR": 200.0, "USD": 50.0})
+
+	def test_currencies_are_never_summed_together(self):
+		out = blast.compare_rows([row("a", 1000, "INR")], [row("a", 1200, "INR")])
+		self.assertNotIn("total", out["revenue_delta"])
+		self.assertEqual(list(out["revenue_delta"]), ["INR"])
+
+	def test_a_team_that_becomes_short_is_counted_once(self):
+		out = blast.compare_rows(
+			[row("a", shortfall=0)], [row("a", shortfall=500)]
+		)
+		self.assertEqual(out["newly_short"], ["a"])
+
+	def test_a_team_already_short_is_not_counted_as_newly_short(self):
+		out = blast.compare_rows(
+			[row("a", shortfall=200)], [row("a", shortfall=500)]
+		)
+		self.assertEqual(out["newly_short"], [])
+
+	def test_a_suspension_appearing_is_distinguished_from_one_moving(self):
+		# Whether these are the same finding is exactly the judgement the accounts team
+		# has to make, so they are counted apart rather than merged.
+		out = blast.compare_rows(
+			[row("a"), row("b", suspends_on="2026-10-22")],
+			[row("a", suspends_on="2026-10-20"), row("b", suspends_on="2026-10-15")],
+		)
+		self.assertEqual(out["newly_suspending"], ["a"])
+		self.assertEqual(out["suspension_moved_earlier"], ["b"])
+
+	def test_a_suspension_moving_later_is_counted_separately_again(self):
+		out = blast.compare_rows(
+			[row("a", suspends_on="2026-10-10")], [row("a", suspends_on="2026-10-25")]
+		)
+		self.assertEqual(out["suspension_moved_later"], ["a"])
+		self.assertEqual(out["suspension_moved_earlier"], [])
+
+	def test_only_teams_present_on_both_sides_are_compared(self):
+		out = blast.compare_rows([row("a"), row("b")], [row("a")])
+		self.assertEqual(out["teams"], 1)
+
+	def test_the_metrics_announce_themselves_as_provisional(self):
+		out = blast.compare_rows([row("a")], [row("a")])
+		self.assertTrue(out["provisional_metrics"])
+
+
+class TestSummarising(IntegrationTestCase):
+	def _comparison(self):
+		return blast.compare_rows(
+			[row("a", 1000), row("b", 1000, shortfall=0)],
+			[row("a", 1200, suspends_on="2026-10-20"), row("b", 1000, shortfall=300)],
+		)
+
+	def test_counts_replace_the_lists(self):
+		out = blast.summarise(self._comparison())
+		self.assertEqual(out["newly_suspending"], 1)
+		self.assertEqual(out["newly_short"], 1)
+
+	def test_a_sampled_summary_says_so_and_carries_its_size(self):
+		out = blast.summarise(self._comparison(), sampled=True, sample_size=2, population=200)
+		self.assertTrue(out["sampled"])
+		self.assertEqual(out["sample_size"], 2)
+		self.assertIn("Extrapolated", out["note"])
+
+	def test_money_is_extrapolated_but_team_counts_are_not(self):
+		# Scaling "1 team newly suspending" to a population invents teams, and somebody
+		# will go looking for them.
+		out = blast.summarise(self._comparison(), sampled=True, sample_size=2, population=200)
+		self.assertEqual(out["revenue_delta"]["INR"], 200.0)
+		self.assertEqual(out["revenue_delta_extrapolated"]["INR"], 20000.0)
+		self.assertEqual(out["newly_suspending"], 1)
+
+	def test_an_unsampled_summary_offers_no_extrapolation_to_misread(self):
+		out = blast.summarise(self._comparison())
+		self.assertNotIn("revenue_delta_extrapolated", out)
+
+
+class TestDescribing(IntegrationTestCase):
+	def test_a_change_that_does_nothing_says_so_plainly(self):
+		summary = blast.summarise(blast.compare_rows([row("a")], [row("a")]))
+		self.assertIn("nothing measurable changes", blast.describe(summary))
+
+	def test_a_change_that_bites_leads_with_the_damage(self):
+		summary = blast.summarise(
+			blast.compare_rows(
+				[row("a", 1000)], [row("a", 1000, shortfall=500, suspends_on="2026-10-20")]
+			)
+		)
+		line = blast.describe(summary)
+		self.assertIn("newly suspending", line)
+		self.assertIn("newly short", line)

--- a/central/billing/tests/test_projection_cassette.py
+++ b/central/billing/tests/test_projection_cassette.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Diffing across code with the inputs held fixed, rather than across time."""
+
+import frappe
+from central.billing.projection import cassette, engine
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+from central.billing.tests.utils import (
+	add_segment,
+	ensure_team,
+	make_billing_subscription,
+	make_plan,
+)
+
+TEAM = "team-cassette"
+CLUSTER = "ap-south-1"
+PLAN = "bundle-cassette"
+TODAY = "2026-08-06"
+
+
+class TestRecording(IntegrationTestCase):
+	def test_reads_are_captured_in_order(self):
+		recorder = cassette.Recorder()
+		recorder.record("a", 1)
+		recorder.record("b", 2)
+		recorder.record("a", 3)
+
+		tape = recorder.cassette()
+		self.assertEqual(tape["reads"], 3)
+		self.assertEqual(tape["entries"]["a"], [1, 3])
+
+	def test_a_key_is_stable_across_formatting(self):
+		self.assertEqual(
+			cassette.key("Invoice", {"team": "x", "status": "Open"}),
+			cassette.key("Invoice", {"status": "Open", "team": "x"}),
+		)
+
+	def test_different_reads_get_different_keys(self):
+		self.assertNotEqual(cassette.key("Invoice", "x"), cassette.key("Invoice", "y"))
+
+
+class TestReplay(IntegrationTestCase):
+	def test_a_recorded_read_is_answered_from_the_tape(self):
+		recorder = cassette.Recorder()
+		recorder.record("k", {"rate": 1000})
+		replay = cassette.Replay(recorder.cassette())
+		self.assertEqual(replay.answer("k"), {"rate": 1000})
+
+	def test_repeated_reads_replay_in_the_order_they_were_captured(self):
+		recorder = cassette.Recorder()
+		recorder.record("k", 1)
+		recorder.record("k", 2)
+		replay = cassette.Replay(recorder.cassette())
+		self.assertEqual(replay.answer("k"), 1)
+		self.assertEqual(replay.answer("k"), 2)
+
+	def test_a_read_the_tape_never_saw_is_reported_not_raised(self):
+		# The code now consults something it did not before. That is a finding, and it is
+		# often the explanation for whatever else moved.
+		replay = cassette.Replay({"entries": {}})
+		self.assertIsNone(replay.answer("new-read"))
+		self.assertEqual(replay.missing, ["new-read"])
+
+
+class TestDiffing(IntegrationTestCase):
+	def test_an_identical_projection_produces_no_differences(self):
+		before = {"invoice": {"total": 100.0, "lines": [{"amount": 100.0}]}}
+		self.assertEqual(cassette.diff(before, dict(before)), [])
+
+	def test_a_moved_number_is_found_with_its_path(self):
+		out = cassette.diff(
+			{"invoice": {"total": 100.0}}, {"invoice": {"total": 120.0}}
+		)
+		self.assertEqual(len(out), 1)
+		self.assertEqual(out[0]["path"], "invoice.total")
+		self.assertEqual(out[0]["after"], 120.0)
+
+	def test_offsetting_line_moves_are_not_hidden_by_a_matching_total(self):
+		# The regression a summary comparison misses: the total is identical and two
+		# lines moved in opposite directions.
+		before = {"total": 100.0, "lines": [{"amount": 60.0}, {"amount": 40.0}]}
+		after = {"total": 100.0, "lines": [{"amount": 40.0}, {"amount": 60.0}]}
+		out = cassette.diff(before, after)
+		self.assertEqual(len(out), 2)
+
+	def test_a_float_wobble_is_not_a_regression(self):
+		self.assertEqual(cassette.diff({"a": 100.0}, {"a": 100.000001}), [])
+
+	def test_a_changed_line_count_is_reported_rather_than_compared_pairwise(self):
+		out = cassette.diff({"lines": [1, 2]}, {"lines": [1]})
+		self.assertEqual(out[0]["path"], "lines")
+
+	def test_the_as_of_stamp_is_ignored_because_it_always_moves(self):
+		self.assertEqual(cassette.diff({"as_of": "2026-01-01"}, {"as_of": "2026-06-01"}), [])
+
+	def test_the_report_ranks_the_worst_money_move_first(self):
+		out = cassette.report(
+			{"a": 100.0, "b": 100.0}, {"a": 101.0, "b": 500.0}
+		)
+		self.assertTrue(out["changed"])
+		self.assertEqual(out["worst"]["path"], "b")
+
+
+class TestAgainstARealProjection(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		make_plan(PLAN)
+		self._purge()
+		self.sub = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
+		add_segment(self.sub, "Created", 4000, "2026-01-01 00:00:00")
+		frappe.db.commit()
+
+	def tearDown(self):
+		self._purge()
+
+	def _purge(self):
+		frappe.db.delete("Invoice", {"team": TEAM})
+		for sub in frappe.get_all("Subscription", {"team": TEAM}, pluck="name"):
+			frappe.db.delete("Subscription Change", {"subscription": sub})
+			frappe.db.delete("Subscription", {"name": sub})
+		frappe.db.delete("Asset", {"team": TEAM})
+		frappe.db.commit()
+
+	def test_the_same_code_on_the_same_data_diffs_to_nothing(self):
+		first = engine.project(TEAM, "2026-09-01", "2026-09-30", today=TODAY)
+		second = engine.project(TEAM, "2026-09-01", "2026-09-30", today=TODAY)
+		self.assertFalse(cassette.report(first, second)["changed"])
+
+	def test_a_real_change_in_the_data_shows_up_with_its_path(self):
+		first = engine.project(TEAM, "2026-09-01", "2026-09-30", today=TODAY)
+		add_segment(self.sub, "Plan Changed", 8000, "2026-09-16 00:00:00")
+		frappe.db.commit()
+		second = engine.project(TEAM, "2026-09-01", "2026-09-30", today=TODAY)
+
+		out = cassette.report(first, second)
+		self.assertTrue(out["changed"])
+		self.assertTrue(any("total" in d["path"] for d in out["differences"]))
+
+	def test_the_engine_accepts_the_recorder_and_source_seam(self):
+		import inspect
+
+		params = inspect.signature(engine.project).parameters
+		self.assertIn("recorder", params)
+		self.assertIn("source", params)

--- a/central/billing/tests/test_projection_cohort.py
+++ b/central/billing/tests/test_projection_cohort.py
@@ -548,3 +548,36 @@ class TestSplitCurrencyColumns(IntegrationTestCase):
 		columns = [{"label": "Total", "fieldname": "total", "fieldtype": "Currency"}]
 		rows = [{"total": 10.0, "currency": "INR"}]
 		self.assertEqual(split_currency_columns(columns, rows, ["total"]), columns)
+
+
+class TestTheReportFitsOnAScreen(CohortTestBase):
+	def test_the_column_set_is_narrow_enough_to_read(self):
+		# Five money fields across two currencies was eleven columns and truncated
+		# headings. Each column has to earn its place.
+		from central.billing.report.billing_projection.billing_projection import get_columns
+
+		self.assertLessEqual(len(get_columns()), 8)
+
+	def test_a_two_currency_run_still_fits(self):
+		from central.billing.report._currency import split_currency_columns
+		from central.billing.report.billing_projection.billing_projection import (
+			MONEY_FIELDS,
+			get_columns,
+		)
+
+		rows = [
+			{"currency": "INR", "projected_total": 1.0, "shortfall": 0.0},
+			{"currency": "USD", "projected_total": 1.0, "shortfall": 0.0},
+		]
+		columns = split_currency_columns(get_columns(), rows, MONEY_FIELDS)
+		self.assertLessEqual(len(columns), 9)
+
+	def test_what_was_dropped_is_still_derivable_or_drilled(self):
+		# Credits is projected total minus shortfall; the measured/estimated split lives
+		# on the team's own page, where it can be read properly.
+		from central.billing.report.billing_projection.billing_projection import get_columns
+
+		shown = {c["fieldname"] for c in get_columns()}
+		self.assertNotIn("credit_balance", shown)
+		self.assertNotIn("measured", shown)
+		self.assertIn("shortfall", shown)

--- a/central/billing/tests/test_projection_events.py
+++ b/central/billing/tests/test_projection_events.py
@@ -1,11 +1,9 @@
 # Copyright (c) 2026, Frappe and contributors
 # For license information, please see license.txt
 """Things that have not happened, rated as if they had."""
-
 import frappe
 from central.billing.projection import engine, events, scenario
 from central.billing.projection.basis import ASSUMED, MEASURED
-from central.billing.revenue import credits
 from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
 from central.billing.tests.utils import (
 	add_segment,
@@ -14,13 +12,10 @@ from central.billing.tests.utils import (
 	make_plan,
 	set_team_tier,
 )
-
 TEAM = "team-events"
 CLUSTER = "ap-south-1"
 PLAN = "bundle-events"
 TODAY = "2026-08-06"
-
-
 class EventTestBase(IntegrationTestCase):
 	def setUp(self):
 		ensure_team(TEAM)
@@ -30,10 +25,8 @@ class EventTestBase(IntegrationTestCase):
 		add_segment(self.sub, "Created", 3000, "2026-01-01 00:00:00")
 		set_team_tier(TEAM, level="t1", max_spend=50000)
 		frappe.db.commit()
-
 	def tearDown(self):
 		self._purge()
-
 	def _purge(self):
 		for name in frappe.get_all("Billing Scenario", pluck="name"):
 			frappe.delete_doc("Billing Scenario", name, force=True, ignore_permissions=True)
@@ -45,19 +38,15 @@ class EventTestBase(IntegrationTestCase):
 			frappe.db.delete("Subscription", {"name": sub})
 		frappe.db.delete("Asset", {"team": TEAM})
 		frappe.db.commit()
-
 	def _project(self, events_list, **kw):
 		frappe.db.commit()
 		return engine.project(
 			TEAM, "2026-09-01", "2026-09-30", today=TODAY, events=events_list, **kw
 		)
-
-
 class TestTheChangeStreamIsInjectable(EventTestBase):
 	def test_without_injection_the_ledger_is_read(self):
 		out = self._project(None)
 		self.assertEqual(out["invoice"]["subtotal"], 3000.0)
-
 	def test_an_injected_resize_reprices_the_rest_of_the_month(self):
 		# Rated by the production line engine, so day-weighting comes for free.
 		out = self._project(
@@ -73,7 +62,6 @@ class TestTheChangeStreamIsInjectable(EventTestBase):
 		)
 		# 15 days at 3000 + 15 days at 6000 over a 30-day month.
 		self.assertEqual(out["invoice"]["subtotal"], 4500.0)
-
 	def test_a_resize_inside_the_churn_window_bills_that_date_hourly(self):
 		# The sub-24h rule is the line engine's, and an invented change gets it too.
 		out = self._project(
@@ -86,7 +74,6 @@ class TestTheChangeStreamIsInjectable(EventTestBase):
 		)
 		hourly = [li for li in out["invoice"]["lines"] if li["unit"] == "hour"]
 		self.assertTrue(hourly, "a config held under 24h should push its date hourly")
-
 	def test_an_injected_cancel_closes_the_segment(self):
 		out = self._project(
 			[
@@ -95,7 +82,6 @@ class TestTheChangeStreamIsInjectable(EventTestBase):
 			]
 		)
 		self.assertEqual(out["invoice"]["subtotal"], 1500.0)  # 15 of 30 days
-
 	def test_the_real_ledger_is_never_written(self):
 		before = frappe.db.count("Subscription Change", {"subscription": self.sub})
 		self._project(
@@ -107,8 +93,6 @@ class TestTheChangeStreamIsInjectable(EventTestBase):
 		self.assertEqual(
 			frappe.db.count("Subscription Change", {"subscription": self.sub}), before
 		)
-
-
 class TestInventedLinesSaySo(EventTestBase):
 	def test_a_line_from_an_injected_event_is_assumed_not_measured(self):
 		out = self._project(
@@ -120,7 +104,6 @@ class TestInventedLinesSaySo(EventTestBase):
 		bases = {li["basis"] for li in out["invoice"]["lines"]}
 		self.assertIn(ASSUMED, bases)
 		self.assertIn(MEASURED, bases)
-
 	def test_the_totals_carry_the_assumption_through(self):
 		out = self._project(
 			[
@@ -130,12 +113,9 @@ class TestInventedLinesSaySo(EventTestBase):
 		)
 		self.assertGreater(out["invoice"]["assumed"], 0)
 		self.assertTrue(out["invoice"]["has_estimates"])
-
 	def test_a_projection_with_no_events_stays_measured(self):
 		out = self._project(None)
 		self.assertTrue(all(li["basis"] == MEASURED for li in out["invoice"]["lines"]))
-
-
 class TestRefusals(EventTestBase):
 	def test_a_provision_beyond_the_cap_is_reported_as_refused(self):
 		# A scenario that could not happen is a finding, not a projection.
@@ -148,7 +128,6 @@ class TestRefusals(EventTestBase):
 		)
 		self.assertTrue(out["refused"])
 		self.assertIn("cap", out["refused"][0]["reason"].lower())
-
 	def test_a_provision_within_the_cap_is_not_refused(self):
 		set_team_tier(TEAM, level="t1", max_spend=50000)
 		out = self._project(
@@ -158,8 +137,6 @@ class TestRefusals(EventTestBase):
 			]
 		)
 		self.assertEqual(out["refused"], [])
-
-
 class TestTheTimeline(EventTestBase):
 	def test_injected_events_are_dated_and_marked_hypothetical(self):
 		out = self._project(
@@ -171,7 +148,6 @@ class TestTheTimeline(EventTestBase):
 		self.assertEqual(len(out["injected_events"]), 1)
 		self.assertTrue(out["injected_events"][0]["hypothetical"])
 		self.assertEqual(out["injected_events"][0]["date"], "2026-09-16")
-
 	def test_they_are_kept_apart_from_what_the_roll_forward_actually_did(self):
 		# Two different things were briefly both called "events"; they are not the same.
 		out = engine.project_months(
@@ -184,8 +160,6 @@ class TestTheTimeline(EventTestBase):
 		self.assertIn("injected_events", out)
 		self.assertIn("events", out)
 		self.assertEqual(len(out["injected_events"]), 1)
-
-
 class TestTopUps(EventTestBase):
 	def test_an_injected_top_up_reaches_the_wallet_before_the_bill_is_drawn(self):
 		out = engine.project_months(
@@ -198,11 +172,9 @@ class TestTopUps(EventTestBase):
 		first = out["months"][0]
 		self.assertEqual(first["settlement"]["from_credits"], 3000.0)
 		self.assertEqual(first["settlement"]["shortfall"], 0.0)
-
 	def test_without_the_top_up_the_month_is_short(self):
 		out = engine.project_months(TEAM, "2026-09-01", months=2, today=TODAY)
 		self.assertEqual(out["months"][0]["settlement"]["shortfall"], 3000.0)
-
 	def test_the_top_up_is_recorded_on_the_way_through(self):
 		out = engine.project_months(
 			TEAM, "2026-09-01", months=2, today=TODAY,
@@ -212,7 +184,6 @@ class TestTopUps(EventTestBase):
 			],
 		)
 		self.assertTrue(any(e["event"] == "Topped up" for e in out["events"]))
-
 	def test_no_credit_ledger_entry_is_written(self):
 		before = frappe.db.count("Credit Ledger Entry", {"team": TEAM})
 		engine.project_months(
@@ -223,8 +194,6 @@ class TestTopUps(EventTestBase):
 			],
 		)
 		self.assertEqual(frappe.db.count("Credit Ledger Entry", {"team": TEAM}), before)
-
-
 class TestThroughAScenario(EventTestBase):
 	def test_a_saved_scenario_carries_its_events(self):
 		doc = frappe.get_doc(
@@ -247,11 +216,9 @@ class TestThroughAScenario(EventTestBase):
 			}
 		).insert(ignore_permissions=True)
 		frappe.db.commit()
-
 		out = scenario.project(doc, today=TODAY)
 		self.assertEqual(out["invoice"]["subtotal"], 4500.0)
 		self.assertEqual(len(out["scenario"]["events"]), 1)
-
 	def test_the_control_side_of_a_comparison_drops_the_events(self):
 		doc = frappe.get_doc(
 			{
@@ -273,7 +240,81 @@ class TestThroughAScenario(EventTestBase):
 			}
 		).insert(ignore_permissions=True)
 		frappe.db.commit()
-
 		out = scenario.compare(doc, today=TODAY)
 		self.assertEqual(out["live"]["invoice"]["subtotal"], 3000.0)
 		self.assertEqual(out["altered"]["invoice"]["subtotal"], 4500.0)
+class TestDeclines(EventTestBase):
+	"""A refused card burns a method. It does not move a single date."""
+	def _gateway(self):
+		# Created once: the helper deletes and recreates, which would orphan the first
+		# card's link if it ran per card.
+		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
+		if not getattr(self, "_gw", None):
+			self._gw = make_stripe_gateway("GW-Test-Stripe").name
+		return self._gw
+	def _card(self, label):
+		gateway = self._gateway()
+		return (
+			frappe.get_doc(
+				{
+					"doctype": "Payment Method",
+					"team": TEAM,
+					"gateway": gateway,
+					"method_type": "Card",
+					"status": "Active",
+					"gateway_method_id": f"pm_{label}",
+					"gateway_customer_id": "cus_1",
+					"display_label": label,
+				}
+			)
+			.insert(ignore_permissions=True)
+			.name
+		)
+	def test_a_decline_does_not_move_any_date(self):
+		# Only our own failure to collect ever pushes the ladder. A customer's card
+		# being refused is not our failure.
+		self._card("visa")
+		frappe.db.commit()
+		plain = self._project(None)["calendar"]["if_never_paid"]
+		declined = self._project(
+			[{"event_type": events.DECLINE, "on_date": "2026-10-09 00:00:00", "attempt": 1}]
+		)["calendar"]["if_never_paid"]
+		self.assertEqual(
+			[s["date"] for s in plain], [s["date"] for s in declined]
+		)
+	def test_each_retry_says_which_method_it_would_reach_for(self):
+		self._card("visa")
+		self._card("mastercard")
+		frappe.db.commit()
+		out = self._project(
+			[{"event_type": events.DECLINE, "on_date": "2026-10-09 00:00:00", "attempt": 1}]
+		)
+		retries = [s for s in out["calendar"]["if_never_paid"] if s["stage"] == "Retry"]
+		self.assertTrue(all("method" in s for s in retries))
+	def test_a_declined_attempt_escalates_to_another_method(self):
+		first = self._card("visa")
+		second = self._card("mastercard")
+		frappe.db.commit()
+		out = self._project(
+			[{"event_type": events.DECLINE, "on_date": "2026-10-09 00:00:00", "attempt": 1}]
+		)
+		retries = [s for s in out["calendar"]["if_never_paid"] if s["stage"] == "Retry"]
+		self.assertTrue(retries[0]["assumed_declined"])
+		self.assertEqual(retries[0]["method"], first)
+		# Escalate, don't repeat: the next attempt reaches for a different card.
+		self.assertEqual(retries[1]["method"], second)
+	def test_once_every_method_is_burnt_there_is_nothing_left_to_try(self):
+		self._card("only-card")
+		frappe.db.commit()
+		out = self._project(
+			[{"event_type": events.DECLINE, "on_date": "2026-10-09 00:00:00", "attempt": 1}]
+		)
+		retries = [s for s in out["calendar"]["if_never_paid"] if s["stage"] == "Retry"]
+		self.assertIn("Nothing left to try", retries[1]["note"])
+		self.assertTrue(out["calendar"]["methods_exhausted"])
+	def test_without_a_decline_the_calendar_is_left_alone(self):
+		self._card("visa")
+		frappe.db.commit()
+		out = self._project(None)
+		retries = [s for s in out["calendar"]["if_never_paid"] if s["stage"] == "Retry"]
+		self.assertFalse(any("assumed_declined" in s for s in retries))

--- a/central/billing/tests/test_projection_library.py
+++ b/central/billing/tests/test_projection_library.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""The shelf of canned questions."""
+
+import frappe
+from central.billing.projection import library, scenario
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+from central.billing.tests.utils import (
+	add_segment,
+	ensure_team,
+	make_billing_subscription,
+	make_plan,
+	set_team_tier,
+)
+
+TEAM = "team-library"
+CLUSTER = "ap-south-1"
+PLAN = "bundle-library"
+TODAY = "2026-08-06"
+
+
+class LibraryTestBase(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		make_plan(PLAN, rates=[{"cluster": "", "currency": "INR", "rate": 6000}])
+		self._purge()
+		self.sub = make_billing_subscription(TEAM, CLUSTER, PLAN, billing_cycle="Monthly")
+		add_segment(self.sub, "Created", 6000, "2026-01-01 00:00:00")
+		set_team_tier(TEAM, level="t1", max_spend=100000)
+		frappe.db.set_value("Billing Profile", TEAM, "collection_mode", "Stripe Auto")
+		frappe.db.commit()
+
+	def tearDown(self):
+		self._purge()
+
+	def _purge(self):
+		for name in frappe.get_all("Billing Scenario", pluck="name"):
+			frappe.delete_doc("Billing Scenario", name, force=True, ignore_permissions=True)
+		frappe.db.delete("Invoice", {"team": TEAM})
+		for sub in frappe.get_all("Subscription", {"team": TEAM}, pluck="name"):
+			frappe.db.delete("Subscription Change", {"subscription": sub})
+			frappe.db.delete("Subscription", {"name": sub})
+		frappe.db.delete("Asset", {"team": TEAM})
+		frappe.db.commit()
+
+
+class TestTheCatalogue(LibraryTestBase):
+	def test_every_entry_says_what_it_asks_and_what_to_look_for(self):
+		# A catalogue entry with no explanation is a button nobody presses twice.
+		for entry in library.catalogue():
+			self.assertTrue(entry["title"])
+			self.assertTrue(entry["question"].endswith("?"))
+			self.assertTrue(entry["look_for"])
+
+	def test_entries_are_declarative_so_adding_one_needs_no_engine_change(self):
+		for key, entry in library.SCENARIOS.items():
+			self.assertIsInstance(entry.get("overrides", {}), dict, key)
+			self.assertIsInstance(entry.get("events", []), list, key)
+
+
+class TestApplicability(LibraryTestBase):
+	def test_a_scenario_that_cannot_apply_says_why(self):
+		# Applying a threshold scenario to a card team would demonstrate nothing and
+		# imply plenty.
+		ok, reason = library.applicable("over-the-inr-threshold", TEAM)
+		self.assertFalse(ok)
+		self.assertIn("E-Mandate", reason)
+
+	def test_it_applies_once_the_team_is_on_that_mode(self):
+		frappe.db.set_value("Billing Profile", TEAM, "collection_mode", "E-Mandate")
+		frappe.db.commit()
+		ok, _reason = library.applicable("over-the-inr-threshold", TEAM)
+		self.assertTrue(ok)
+
+	def test_building_an_inapplicable_scenario_is_refused(self):
+		with self.assertRaises(frappe.ValidationError):
+			library.build("over-the-inr-threshold", TEAM, today=TODAY)
+
+	def test_an_unknown_key_is_refused(self):
+		with self.assertRaises(frappe.ValidationError):
+			library.build("no-such-scenario", TEAM, today=TODAY)
+
+
+class TestBuilding(LibraryTestBase):
+	def test_a_scenario_is_built_but_not_saved(self):
+		before = frappe.db.count("Billing Scenario")
+		library.build("no-way-to-pay", TEAM, today=TODAY)
+		self.assertEqual(frappe.db.count("Billing Scenario"), before)
+
+	def test_relative_events_land_inside_the_projected_month(self):
+		doc = library.build("resized-twice-in-a-day", TEAM, period_start="2026-09-01", today=TODAY)
+		dates = [frappe.utils.getdate(e.on_date) for e in doc.events]
+		self.assertEqual(len(dates), 2)
+		self.assertTrue(all(str(d).startswith("2026-09") for d in dates))
+
+	def test_a_doubling_event_doubles_the_rate_the_team_is_actually_on(self):
+		doc = library.build("resized-twice-in-a-day", TEAM, period_start="2026-09-01", today=TODAY)
+		rates = sorted(frappe.utils.flt(e.rate) for e in doc.events)
+		self.assertEqual(rates, [6000.0, 12000.0])
+
+	def test_the_harsher_ladder_carries_its_overrides(self):
+		doc = library.build("harsher-dunning", TEAM, today=TODAY)
+		self.assertEqual(doc.suspend_after_days, 7)
+		self.assertEqual(doc.terminate_after_days, 30)
+
+	def test_the_price_rise_targets_the_plans_the_team_runs(self):
+		doc = library.build("a-price-rise", TEAM, period_start="2026-09-01", today=TODAY)
+		self.assertTrue(doc.rate_overrides)
+		self.assertEqual(doc.rate_overrides[0].priced_for, PLAN)
+		self.assertEqual(doc.rate_overrides[0].percent, 20)
+
+
+class TestWhatTheyDemonstrate(LibraryTestBase):
+	def test_the_churn_scenario_really_does_push_a_date_hourly(self):
+		doc = library.build("resized-twice-in-a-day", TEAM, period_start="2026-09-01", today=TODAY)
+		out = scenario.project(doc, today=TODAY)
+		hourly = [li for li in out["invoice"]["lines"] if li["unit"] == "hour"]
+		self.assertTrue(hourly, "the catalogue entry must demonstrate what it claims")
+
+	def test_the_harsher_ladder_really_does_move_the_suspension_left(self):
+		plain = scenario.project(library.build("no-way-to-pay", TEAM, today=TODAY), today=TODAY)
+		harsh = scenario.project(library.build("harsher-dunning", TEAM, today=TODAY), today=TODAY)
+
+		def suspend_on(out):
+			return next(
+				s["date"] for s in out["calendar"]["if_never_paid"] if s["stage"] == "Suspend"
+			)
+
+		self.assertLess(suspend_on(harsh), suspend_on(plain))
+
+	def test_the_price_rise_really_does_change_almost_nothing(self):
+		# The entry whose whole point is that the expected answer is wrong.
+		doc = library.build("a-price-rise", TEAM, period_start="2026-09-01", today=TODAY)
+		out = scenario.compare(doc, today=TODAY)
+		self.assertEqual(out["live"]["invoice"]["total"], out["altered"]["invoice"]["total"])
+		self.assertIn("locked", out["explanation"])
+
+	def test_the_top_up_scenario_really_does_close_a_shortfall(self):
+		doc = library.build("rescued-by-a-top-up", TEAM, period_start="2026-09-01", today=TODAY)
+		out = scenario.project(doc, today=TODAY)
+		self.assertTrue(any(e["event"] == "Topped up" for e in out["events"]))

--- a/central/billing/tests/test_projection_outlook.py
+++ b/central/billing/tests/test_projection_outlook.py
@@ -175,3 +175,37 @@ class TestBehaviour(OutlookTestBase):
 			behaviour.verdict({"invoices": 6, "on_time": 3, "worst_delay_days": 45}),
 			"Chronically late",
 		)
+
+
+class TestTheForecastIsAProjection(IntegrationTestCase):
+	"""The customer's number and the operator's are one computation."""
+
+	def test_the_forecast_runs_through_the_engine(self):
+		import inspect
+
+		from central.billing.api.dashboard import invoices
+
+		source = inspect.getsource(invoices.get_forecast)
+		self.assertIn("engine.project", source)
+		self.assertNotIn("compute_line_items", source)
+
+	def test_a_customer_read_does_not_fail_on_a_dirty_transaction(self):
+		# Refusing here would break a customer page to enforce an internal invariant,
+		# and committing on their behalf is the side effect the guard exists to prevent.
+		from central.billing.projection.guard import read_only
+
+		ensure_team(TEAM)
+		frappe.db.set_value("Team", TEAM, "team_name", "Mid-transaction")
+		with read_only(strict=False):
+			self.assertTrue(frappe.db.exists("Team", TEAM))
+		frappe.db.rollback()
+
+	def test_an_operator_projection_still_refuses(self):
+		from central.billing.projection.guard import ProjectionBoundaryError, read_only
+
+		ensure_team(TEAM)
+		frappe.db.set_value("Team", TEAM, "team_name", "Mid-transaction")
+		with self.assertRaises(ProjectionBoundaryError):
+			with read_only():
+				pass
+		frappe.db.rollback()

--- a/central/billing/tests/test_projection_outlook.py
+++ b/central/billing/tests/test_projection_outlook.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Who gets cut off and when, and whether that is their doing or ours."""
+
+import frappe
+from central.billing.projection import behaviour, outlook
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+from central.billing.tests.utils import billing_settings, ensure_team
+
+TEAM = "team-outlook"
+TODAY = "2026-09-10"
+
+
+class OutlookTestBase(IntegrationTestCase):
+	def setUp(self):
+		ensure_team(TEAM)
+		self._purge()
+		frappe.db.commit()
+
+	def tearDown(self):
+		self._purge()
+
+	def _purge(self):
+		frappe.db.delete("Invoice", {"team": TEAM})
+		frappe.db.delete("Payment Attempt", {"team": TEAM})
+		frappe.db.commit()
+
+	def _invoice(self, due, status="Open", amount=5000, dunning_starts_on=None, currency="INR"):
+		# One invoice per team per period is enforced by a unique index, so each fixture
+		# bills its own month — derived from the due date it is given.
+		anchor = frappe.utils.add_months(frappe.utils.getdate(due or "2026-08-08"), -1)
+		period_start = frappe.utils.get_first_day(anchor)
+		period_end = frappe.utils.get_last_day(anchor)
+		name = (
+			frappe.get_doc(
+				{
+					"doctype": "Invoice",
+					"team": TEAM,
+					"invoice_type": "Billable",
+					"status": status,
+					"period_start": period_start,
+					"period_end": period_end,
+					"currency": currency,
+					"subtotal": amount,
+					"total": amount,
+					"expected_collection": amount,
+					"due_date": due,
+					"dunning_starts_on": dunning_starts_on,
+				}
+			)
+			.insert(ignore_permissions=True)
+			.name
+		)
+		frappe.db.commit()
+		return name
+
+
+class TestTheSweep(OutlookTestBase):
+	def test_an_unpaid_invoice_gets_a_dated_ladder(self):
+		with billing_settings(
+			dunning_retry_days="1, 3, 7", suspend_after_days=14, terminate_after_days=44
+		):
+			self._invoice("2026-09-01")
+			rows = outlook.rows(on=TODAY, filters={"team": TEAM})
+
+		self.assertEqual(len(rows), 1)
+		row = rows[0]
+		self.assertEqual(row["days_in"], 9)
+		self.assertEqual(row["suspends_on"], "2026-09-15")
+		self.assertEqual(row["terminates_on"], "2026-10-15")
+
+	def test_a_paid_invoice_is_not_in_the_sweep(self):
+		self._invoice("2026-09-01", status="Paid")
+		self.assertEqual(outlook.rows(on=TODAY, filters={"team": TEAM}), [])
+
+	def test_nothing_is_estimated_or_rated(self):
+		# Every column is a stored fact or arithmetic over one, which is why this can run
+		# over the whole book however large it gets.
+		self._invoice("2026-09-01")
+		row = outlook.rows(on=TODAY, filters={"team": TEAM})[0]
+		self.assertEqual(row["outstanding"], 5000.0)
+		self.assertNotIn("estimated", row)
+
+	def test_the_soonest_consequence_sorts_first(self):
+		self._invoice("2026-09-01", amount=1000)
+		self._invoice("2026-08-01", amount=2000)
+		rows = outlook.rows(on=TODAY, filters={"team": TEAM})
+		self.assertLessEqual(rows[0]["suspends_on"], rows[1]["suspends_on"])
+
+	def test_a_horizon_keeps_only_what_is_about_to_happen(self):
+		with billing_settings(
+			dunning_retry_days="1, 3, 7", suspend_after_days=14, terminate_after_days=44
+		):
+			self._invoice("2026-09-09")  # next action is days away
+			near = outlook.rows(on=TODAY, horizon_days=3, filters={"team": TEAM})
+			far = outlook.rows(on=TODAY, horizon_days=60, filters={"team": TEAM})
+		self.assertLessEqual(len(near), len(far))
+
+	def test_an_invoice_with_no_due_date_is_skipped_rather_than_guessed_at(self):
+		self._invoice(None)
+		self.assertEqual(outlook.rows(on=TODAY, filters={"team": TEAM}), [])
+
+
+class TestOurDelayIsMarkedAsOurs(OutlookTestBase):
+	def test_a_deferred_clock_is_honoured_and_flagged(self):
+		self._invoice("2026-09-01", dunning_starts_on="2026-09-20")
+		row = outlook.rows(on=TODAY, filters={"team": TEAM})[0]
+
+		self.assertEqual(row["clock_starts_on"], "2026-09-20")
+		self.assertTrue(row["clock_deferred"])
+		self.assertLess(row["days_in"], 0)
+
+	def test_the_drill_explains_the_deferral(self):
+		name = self._invoice("2026-09-01", dunning_starts_on="2026-09-20")
+		out = outlook.why(name, on=TODAY)
+		self.assertTrue(out["clock_deferred"])
+		self.assertIn("our side", out["deferred_note"])
+		self.assertIn("due date is unchanged", out["deferred_note"])
+
+	def test_the_drill_shows_which_rungs_have_been_reached(self):
+		with billing_settings(dunning_retry_days="1, 3, 7", suspend_after_days=14):
+			name = self._invoice("2026-09-01")
+			out = outlook.why(name, on=TODAY)
+		reached = [s for s in out["ladder"] if s["reached"]]
+		ahead = [s for s in out["ladder"] if not s["reached"]]
+		self.assertTrue(reached)
+		self.assertTrue(ahead)
+
+
+class TestBehaviour(OutlookTestBase):
+	def test_a_team_that_always_paid_reads_as_such(self):
+		for due in ("2026-04-08", "2026-05-08", "2026-06-08"):
+			self._invoice(due, status="Paid")
+		record = behaviour.with_verdict(TEAM, on=TODAY)
+
+		self.assertEqual(record["invoices"], 3)
+		self.assertEqual(record["on_time"], 3)
+		self.assertEqual(record["verdict"], "Always paid on time")
+
+	def test_an_outstanding_invoice_counts_against_the_record(self):
+		self._invoice("2026-06-08", status="Paid")
+		self._invoice("2026-07-08", status="Overdue")
+		record = behaviour.with_verdict(TEAM, on=TODAY)
+
+		self.assertEqual(record["on_time"], 1)
+		self.assertEqual(record["invoices"], 2)
+		self.assertGreater(record["worst_delay_days"], 0)
+
+	def test_lateness_is_measured_from_the_due_date_not_the_deferred_clock(self):
+		# The deferred clock protects customers from our collection failures. Scoring
+		# against it would mark them down for our outage.
+		self._invoice("2026-07-08", status="Overdue", dunning_starts_on="2026-09-30")
+		record = behaviour.summary(TEAM, on=TODAY)
+		self.assertGreater(record["worst_delay_days"], 30)
+
+	def test_a_cancelled_invoice_is_not_held_against_anyone(self):
+		self._invoice("2026-06-08", status="Cancelled")
+		self.assertEqual(behaviour.summary(TEAM, on=TODAY)["invoices"], 0)
+
+	def test_a_team_with_no_history_says_so_rather_than_scoring_zero(self):
+		record = behaviour.with_verdict(TEAM, on=TODAY)
+		self.assertEqual(record["verdict"], "No history")
+
+	def test_the_verdict_separates_their_problem_from_ours(self):
+		# The distinction that changes what an operator does next.
+		self.assertEqual(
+			behaviour.verdict({"invoices": 6, "on_time": 6, "worst_delay_days": 0}),
+			"Always paid on time",
+		)
+		self.assertEqual(
+			behaviour.verdict({"invoices": 6, "on_time": 0, "worst_delay_days": 90}),
+			"Never paid on time",
+		)
+		self.assertEqual(
+			behaviour.verdict({"invoices": 6, "on_time": 3, "worst_delay_days": 45}),
+			"Chronically late",
+		)

--- a/central/billing/tests/test_projection_reachable.py
+++ b/central/billing/tests/test_projection_reachable.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Nothing in the projection package is reachable only from its own tests.
+
+A module with green tests and no callers reads as finished in every report and does
+nothing for anybody. This is the guard that would have caught it.
+"""
+
+import ast
+from pathlib import Path
+
+import frappe
+from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+
+ROOT = Path(frappe.get_app_path("central")) / "billing"
+PACKAGE = ROOT / "projection"
+
+# Entry points: reached over HTTP, by the scheduler, or by a report rather than by
+# another module.
+ENTRY_POINTS = {"api.py"}
+
+
+def _module_names() -> list[str]:
+	return sorted(
+		p.stem
+		for p in PACKAGE.glob("*.py")
+		if p.name not in ("__init__.py", *ENTRY_POINTS)
+	)
+
+
+def _imports_in(path: Path) -> set[str]:
+	found: set[str] = set()
+	tree = ast.parse(path.read_text())
+	for node in ast.walk(tree):
+		if isinstance(node, ast.ImportFrom) and (node.module or "").endswith("billing.projection"):
+			found |= {alias.name for alias in node.names}
+		elif isinstance(node, ast.ImportFrom) and "billing.projection." in (node.module or ""):
+			found.add((node.module or "").rsplit(".", 1)[-1])
+	return found
+
+
+def _production_files():
+	for path in sorted(ROOT.rglob("*.py")):
+		parts = path.parts
+		if "__pycache__" in parts or "tests" in parts:
+			continue
+		yield path
+
+
+class TestEverythingIsReachable(IntegrationTestCase):
+	def test_no_projection_module_is_dead_code(self):
+		used: set[str] = set()
+		for path in _production_files():
+			if path.parent == PACKAGE and path.stem not in ENTRY_POINTS:
+				# A module importing itself proves nothing.
+				used |= _imports_in(path) - {path.stem}
+			else:
+				used |= _imports_in(path)
+
+		unreachable = [m for m in _module_names() if m not in used]
+		self.assertEqual(
+			unreachable,
+			[],
+			"these have tests but nothing calls them, which reads as finished and is not: "
+			f"{unreachable}",
+		)

--- a/central/billing/workspace/billing/billing.json
+++ b/central/billing/workspace/billing/billing.json
@@ -46,6 +46,17 @@
   {
    "hidden": 0,
    "is_query_report": 1,
+   "label": "Collection Outlook",
+   "link_count": 0,
+   "link_to": "Collection Outlook",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link",
+   "dependencies": "Invoice"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
    "label": "Billing Projection",
    "link_count": 0,
    "link_to": "Billing Projection",


### PR DESCRIPTION
The last six slices of the simulator: the cheap sweep, the retrospective, one rating
path, the scenario shelf, blast radius, and a regression harness that actually works.

## The two cohort questions, finally both answered

```mermaid
flowchart LR
    Q1["Who gets cut off, and when?"] --> C1["No rating needed<br/>scales with delinquency"]
    C1 --> R1["Collection Outlook<br/>unbounded, on demand"]
    Q2["What will these teams be billed?"] --> C2["Rates every team<br/>scales with the book"]
    C2 --> R2["Billing Projection<br/>bounded, batched"]

    style R1 fill:#e4f5e9,stroke:#30a66d
    style R2 fill:#fff1e7,stroke:#bd3e0c
```

The urgent question turns out to be the cheap one, and it runs over everything however large the business gets.

## How reliably have they actually paid

`Suspended on the 12th` reads completely differently beside `6 / 6 paid on time` than beside `3 / 6`. The first is almost certainly our failure — an expired card, a lapsed mandate; the second is theirs. It now sits next to every projection and on every cohort row.

**Lateness is measured from `due_date`, never `dunning_starts_on`.** That clock is pushed forward when *our* collection fails, and scoring against it would mark customers down for our outages. There is a test.

## One rating path

`get_forecast` runs through the projection engine, so the number a customer sees and the number an operator simulates cannot drift apart. The response shape is unchanged.

It reads **unguarded**: a customer page must not fail because the request that reached it wrote something first, and committing on their behalf is the side effect the guard exists to prevent. Operator projections stay strict.

## Regression diffing that survives contact with production

Snapshot-deploy-rerun does not work — the data moves in between and the diff stops being attributable. Recording what a projection read and replaying the new code against that recording holds the inputs bit-identical, so every surviving delta is the code. The diff walks both structures rather than comparing totals, because a total that matches while two lines moved in opposite directions is exactly the regression a summary would miss.