### PR TITLE
billing: one payment gateway record per provider

### DIFF
--- a/central/billing/api/admin/gateways.py
+++ b/central/billing/api/admin/gateways.py
@@ -23,14 +23,13 @@ def get_gateways() -> list[dict]:
 		"Payment Gateway",
 		fields=[
 			"name",
-			"title",
 			"adapter_key",
 			"is_enabled",
 			"supports_mandates",
 			"credentials_validated_at",
 			"webhook_endpoint_id",
 		],
-		order_by="creation asc",
+		order_by="adapter_key asc",
 	)
 	for gw in gateways:
 		gw["currencies"] = frappe.get_all(

--- a/central/billing/api/dashboard/_shared.py
+++ b/central/billing/api/dashboard/_shared.py
@@ -162,18 +162,16 @@ def _gateway_for_currency(currency: str) -> str:
 
 
 def _enabled_gateway_for_currency(currency: str, adapter_key: str) -> str | None:
-	"""Name of an enabled gateway with this adapter_key that handles this currency,
-	or None. Unlike the default-resolver, this picks by adapter regardless of the
-	is_default flag — used when a flow needs a specific rail (PayPal, or the Razorpay
-	a Via-Razorpay PayPal row delegates to)."""
-	rows = frappe.get_all("Payment Gateway Currency", filters={"currency": currency}, fields=["parent"])
-	for r in rows:
-		gw = frappe.db.get_value(
-			"Payment Gateway", r.parent, ["name", "adapter_key", "is_enabled"], as_dict=True
-		)
-		if gw and gw.is_enabled and gw.adapter_key == adapter_key:
-			return gw.name
-	return None
+	"""Name of the enabled gateway for this adapter, if it handles this currency.
+
+	Unlike the default-resolver this picks by adapter regardless of the is_default
+	flag — used when a flow needs a specific rail (PayPal, or the Razorpay a
+	Via-Razorpay PayPal row delegates to). A gateway row is named after its adapter,
+	so "the Stripe gateway" is a primary-key read, not a search with a tiebreak."""
+	if not frappe.db.get_value("Payment Gateway", adapter_key, "is_enabled"):
+		return None
+	handles = frappe.db.exists("Payment Gateway Currency", {"parent": adapter_key, "currency": currency})
+	return adapter_key if handles else None
 
 
 def _paypal_gateway_for_currency(currency: str) -> str:
@@ -209,21 +207,10 @@ def _add_method_gateway(currency: str):
 	if gw and gw.adapter_key == "Razorpay":
 		return gw
 
-	# The default gateway is not Razorpay — but if an enabled Razorpay gateway
-	# also handles this currency (non-default), prefer it for UPI.
-	rzp = frappe.db.get_value(
-		"Payment Gateway",
-		{"adapter_key": "Razorpay", "is_enabled": 1},
-		["name", "adapter_key"],
-		as_dict=True,
-		order_by="creation asc",
-	)
-	if rzp:
-		rzp_currencies = frappe.get_all(
-			"Payment Gateway Currency", {"parent": rzp.name, "currency": currency}, pluck="name"
-		)
-		if rzp_currencies:
-			return rzp
+	# The default gateway is not Razorpay — but if Razorpay is enabled and also
+	# handles this currency (non-default), prefer it for UPI.
+	if _enabled_gateway_for_currency(currency, "Razorpay"):
+		return frappe._dict(name="Razorpay", adapter_key="Razorpay")
 
 	return gw or frappe._dict()
 

--- a/central/billing/demo/_factory.py
+++ b/central/billing/demo/_factory.py
@@ -66,11 +66,13 @@ TIERS = [
 # Output tax follows the customer's billing currency (place of supply).
 TAX_BY_CURRENCY = {"INR": ("GST", 18), "USD": ("VAT", 5)}
 
-STRIPE = {"INR": "GW-Stripe-INR", "USD": "GW-Stripe-USD"}
-RAZORPAY = "GW-Razorpay"
+# A gateway row is named after its adapter — one row per provider, carrying every
+# currency it settles.
+STRIPE = "Stripe"
+RAZORPAY = "Razorpay"
 # PayPal is a directly-settled standalone gateway (ADR 0007). It lists USD but
 # is NOT its default — Stripe stays the card default; PayPal is the opt-in rail.
-PAYPAL = "GW-PayPal"
+PAYPAL = "Paypal"
 ANCHOR = "2026-06-01"  # the current (open) billing month
 DEMO_OWNER_PASSWORD = "abc@123"  # every demo owner logs into the console with this
 
@@ -267,26 +269,27 @@ def _gateways():
 	# Demo keys are placeholders — skip live credential validation / webhook
 	# auto-registration so the seed runs offline.
 	seed = {"skip_credential_validation": True}
-	for currency, name in STRIPE.items():
-		_upsert(
-			"Payment Gateway",
-			name,
-			{
-				"title": f"Stripe ({currency})",
-				"adapter_key": "Stripe",
-				"api_secret": "sk_test_demo",
-				"webhook_secret": "whsec_demo",
-				"is_enabled": 1,
-				"currencies": [{"currency": currency, "is_default": 1}],
-			},
-			newname=True,
-			flags=seed,
-		)
+	# One Stripe account settles both currencies. It claims the INR default too, but
+	# Razorpay is seeded after and takes it — Stripe keeps INR as a card-only rail.
+	_upsert(
+		"Payment Gateway",
+		STRIPE,
+		{
+			"adapter_key": "Stripe",
+			"api_secret": "sk_test_demo",
+			"webhook_secret": "whsec_demo",
+			"is_enabled": 1,
+			"currencies": [
+				{"currency": "INR", "is_default": 1},
+				{"currency": "USD", "is_default": 1},
+			],
+		},
+		flags=seed,
+	)
 	_upsert(
 		"Payment Gateway",
 		RAZORPAY,
 		{
-			"title": "Razorpay (India)",
 			"adapter_key": "Razorpay",
 			"api_key": "rzp_test",
 			"api_secret": "rzp_secret",
@@ -295,7 +298,6 @@ def _gateways():
 			"supports_mandates": 1,
 			"currencies": [{"currency": "INR", "is_default": 1}],
 		},
-		newname=True,
 		flags=seed,
 	)
 	# PayPal — directly-settled standalone gateway (ADR 0007). Non-default for USD
@@ -305,7 +307,6 @@ def _gateways():
 		"Payment Gateway",
 		PAYPAL,
 		{
-			"title": "PayPal (International)",
 			"adapter_key": "Paypal",
 			"api_key": "paypal_client_id",
 			"api_secret": "paypal_secret",
@@ -313,7 +314,6 @@ def _gateways():
 			"is_enabled": 1,
 			"currencies": [{"currency": "USD", "is_default": 0}],
 		},
-		newname=True,
 		flags=seed,
 	)
 
@@ -475,7 +475,7 @@ def _payment_setup(team, slug, currency, state):
 		)
 		_gateway_customer(team, RAZORPAY, f"cust_{slug}")
 		return RAZORPAY, pm
-	gateway = STRIPE[currency]
+	gateway = STRIPE
 	pm = (
 		frappe.get_doc(
 			{

--- a/central/billing/demo/demo_scenarios.py
+++ b/central/billing/demo/demo_scenarios.py
@@ -467,7 +467,7 @@ def _build_team(team, slug, tier, currency, state, resources, resize):
 	gateway, pm = _payment_setup(team, slug, currency, state)
 	# A top-up-only team has no card, but its wallet top-up still mints a customer.
 	if pm is None and state in _TOPUP_STATES:
-		_gateway_customer(team, STRIPE[currency], f"cus_{slug}")
+		_gateway_customer(team, STRIPE, f"cus_{slug}")
 	# A fallback team keeps a second, lower-priority card so settlement can rotate to it
 	# when the primary declines (#28).
 	if state == "fallback":

--- a/central/billing/doctype/payment_gateway/payment_gateway.json
+++ b/central/billing/doctype/payment_gateway/payment_gateway.json
@@ -1,14 +1,12 @@
 {
  "actions": [],
- "allow_rename": 1,
- "autoname": "prompt",
+ "autoname": "field:adapter_key",
  "creation": "2026-06-02 00:00:00.000000",
- "description": "One row per configured gateway. Secrets are encrypted; the adapter is resolved by adapter_key.",
+ "description": "Exactly one row per adapter — the record is named after it. Secrets are encrypted.",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "title",
   "adapter_key",
   "paypal_settlement_mode",
   "column_break_flags",
@@ -26,19 +24,14 @@
  ],
  "fields": [
   {
-   "fieldname": "title",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Title",
-   "reqd": 1
-  },
-  {
+   "description": "The provider this row configures. It names the record, so there can only ever be one row per adapter — and it cannot be changed once set.",
    "fieldname": "adapter_key",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Adapter",
    "options": "Stripe\nRazorpay\nPaypal",
-   "reqd": 1
+   "reqd": 1,
+   "set_only_once": 1
   },
   {
    "default": "Direct",
@@ -147,16 +140,14 @@
    "link_fieldname": "gateway"
   }
  ],
- "modified": "2026-06-02 00:00:00.000000",
+ "modified": "2026-08-08 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Billing",
  "name": "Payment Gateway",
- "naming_rule": "Set by user",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
-   "create": 1,
-   "delete": 1,
    "email": 1,
    "export": 1,
    "print": 1,
@@ -167,8 +158,8 @@
    "write": 1
   }
  ],
- "sort_field": "creation",
- "sort_order": "DESC",
+ "sort_field": "adapter_key",
+ "sort_order": "ASC",
  "states": [],
  "track_changes": 1
 }

--- a/central/billing/doctype/payment_gateway/payment_gateway.py
+++ b/central/billing/doctype/payment_gateway/payment_gateway.py
@@ -25,6 +25,17 @@ def _is_local_url(url: str) -> bool:
 
 
 class PaymentGateway(Document):
+	"""One row per adapter, named after it (autoname: field:adapter_key).
+
+	A second row for the same provider would be unaddressable: there is one webhook
+	callback URL per adapter, so an inbound request can't say which merchant account
+	it belongs to, and nothing on the row carries a routing key (team, region, legal
+	entity) that a resolver could split on. Making the adapter the primary key lets
+	the database enforce that rather than a validate() hook. Which currencies a
+	gateway settles — and which one it is the default for — lives in the `currencies`
+	child table; that is the routing dimension.
+	"""
+
 	def get_adapter(self):
 		"""Resolve the GatewayAdapter for this gateway (by adapter_key).
 

--- a/central/billing/gateways/registry.py
+++ b/central/billing/gateways/registry.py
@@ -13,14 +13,20 @@ class GatewayNotFound(frappe.ValidationError):
 
 def resolve_gateway_for_currency(currency: str) -> str:
 	"""Return the name of the enabled Payment Gateway whose currencies child table
-	has an is_default row for `currency`. Raises GatewayNotFound if none configured."""
-	name = frappe.db.get_value(
+	has an is_default row for `currency`. Raises GatewayNotFound if none configured.
+
+	Every default row for the currency is considered, not just the first: the
+	uniqueness rule only clears the flag on *enabled* gateways, so a gateway that was
+	switched off keeps its default flag and would otherwise shadow the live one.
+	"""
+	names = frappe.get_all(
 		"Payment Gateway Currency",
-		{"currency": currency, "is_default": 1},
-		"parent",
+		filters={"currency": currency, "is_default": 1},
+		pluck="parent",
 	)
-	if name and frappe.db.get_value("Payment Gateway", name, "is_enabled"):
-		return name
+	for name in names:
+		if frappe.db.get_value("Payment Gateway", name, "is_enabled"):
+			return name
 	raise GatewayNotFound(f"No enabled payment gateway is configured as the default for {currency}.")
 
 

--- a/central/billing/gateways/setup.py
+++ b/central/billing/gateways/setup.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Seed the fixed roster of Payment Gateway rows — one per supported adapter.
+
+An adapter is a code-level capability, not user data: the set of providers we can
+talk to is whatever `gateways.registry.get_adapter` knows how to build. So the
+admin never *creates* a gateway, they fill in keys on a row that already exists
+and flip Enabled. Seeded rows start disabled and blank, which is inert — nothing
+resolves to a gateway that isn't enabled.
+
+Runs on install, on migrate, and before tests (same reasons as the catalog masters
+seed): patches are skipped on fresh installs, so the roster can't live only there.
+"""
+
+import frappe
+
+
+def ensure_gateway_records():
+	"""Create a disabled, blank row for every adapter that has no row yet.
+
+	Idempotent, and never touches an existing row — a configured gateway's keys,
+	currencies and enabled state survive every migrate.
+	"""
+	for adapter_key in adapter_keys():
+		if frappe.db.exists("Payment Gateway", adapter_key):
+			continue
+		doc = frappe.get_doc({"doctype": "Payment Gateway", "adapter_key": adapter_key, "is_enabled": 0})
+		# No keys to prove yet — validation would have nothing to call.
+		doc.flags.skip_credential_validation = True
+		doc.insert(ignore_permissions=True)
+
+
+def adapter_keys() -> list[str]:
+	"""The adapters this build supports, read off the Select field so the roster and
+	the dropdown can never drift apart."""
+	meta = frappe.get_meta("Payment Gateway")
+	options = meta.get_field("adapter_key").options or ""
+	return [key.strip() for key in options.split("\n") if key.strip()]

--- a/central/billing/payments/webhooks.py
+++ b/central/billing/payments/webhooks.py
@@ -47,10 +47,16 @@ def process_webhook(adapter_key: str, payload: bytes, headers: dict) -> dict:
 
 
 def _resolve_gateway(adapter_key: str):
-	name = frappe.db.get_value("Payment Gateway", {"adapter_key": adapter_key, "is_enabled": 1}, "name")
-	if not name:
+	"""The gateway row this callback URL belongs to.
+
+	There is one callback URL per adapter, so the adapter is the only thing an
+	inbound request identifies itself by — which is exactly why a gateway row is
+	named after its adapter. The lookup is a primary-key read: no ambiguity about
+	which webhook_secret verifies the signature.
+	"""
+	if not frappe.db.get_value("Payment Gateway", adapter_key, "is_enabled"):
 		frappe.throw(f"No enabled Payment Gateway for adapter '{adapter_key}'")
-	return frappe.get_doc("Payment Gateway", name)
+	return frappe.get_doc("Payment Gateway", adapter_key)
 
 
 def _store_and_enqueue(gateway, event, payload: bytes):

--- a/central/billing/tests/test_alerts.py
+++ b/central/billing/tests/test_alerts.py
@@ -16,7 +16,7 @@ class TestOperatorAlerts(BillingTestCase):
 		frappe.cache().delete_value(alerts._CACHE_KEY)
 		self.mail = patch.object(alerts.frappe, "sendmail").start()
 		self.addCleanup(patch.stopall)
-		self.gateway = make_stripe_gateway("GW-Alerts-Stripe").name
+		self.gateway = make_stripe_gateway().name
 
 	def _quiet_sources(self, *live):
 		"""Run the alert job with only the named sources live."""

--- a/central/billing/tests/test_charges.py
+++ b/central/billing/tests/test_charges.py
@@ -20,7 +20,7 @@ from central.billing.tests.utils import ensure_atlas_instance, ensure_team, make
 TEAM = "team-charge"
 CLUSTER = "ap-south-1"
 PLAN = "bundle-charge-test"
-GATEWAY = "GW-Test-Stripe"
+GATEWAY = "Stripe"
 
 
 def run_workers(n, fn):
@@ -67,7 +67,7 @@ class ChargeTestBase(IntegrationTestCase):
 		ensure_team(TEAM)
 		ensure_atlas_instance(CLUSTER)
 		make_plan(PLAN)
-		make_stripe_gateway(GATEWAY)
+		make_stripe_gateway()
 		self._purge()
 		self.method = self._active_card()
 		self.sub = subscriptions.create_subscription(

--- a/central/billing/tests/test_collection.py
+++ b/central/billing/tests/test_collection.py
@@ -16,7 +16,7 @@ from central.billing.tests.utils import ensure_team, make_plan
 
 TEAM = "team-fallback"
 PLAN = "bundle-fallback-test"
-GATEWAY = "GW-Fallback-Stripe"
+GATEWAY = "Stripe"
 
 
 def _result(success, txn_id):
@@ -43,7 +43,7 @@ class FallbackTestBase(IntegrationTestCase):
 	def setUp(self):
 		ensure_team(TEAM)
 		make_plan(PLAN)
-		make_stripe_gateway(GATEWAY)
+		make_stripe_gateway()
 		self._purge()
 		self.primary = self._card("Visa ····0001", "pm_primary", priority=0)
 		self.backup = self._card("Visa ····0002", "pm_backup", priority=1)

--- a/central/billing/tests/test_collection_mode.py
+++ b/central/billing/tests/test_collection_mode.py
@@ -100,7 +100,7 @@ class TestInvoiceTimeTrip(IntegrationTestCase):
 		frappe.db.delete("Billing Notification Log", {"team": TEAM})
 		frappe.db.delete("Payment Attempt", {"team": TEAM})
 		frappe.db.delete("Invoice", {"team": TEAM})
-		self.gw = make_razorpay_gateway("GW-Collect-RZP").name
+		self.gw = make_razorpay_gateway().name
 		self.pm = (
 			frappe.get_doc(
 				{
@@ -169,7 +169,7 @@ class TestManualCheckout(IntegrationTestCase):
 		_set_mode(TEAM, "Manual Checkout")
 		frappe.db.delete("Payment Attempt", {"team": TEAM})
 		frappe.db.delete("Invoice", {"team": TEAM})
-		self.gw = make_razorpay_gateway("GW-Manual-RZP").name
+		self.gw = make_razorpay_gateway().name
 
 	def _invoice(self, amount):
 		return (
@@ -257,7 +257,7 @@ class TestModeAwareDunning(IntegrationTestCase):
 		frappe.db.delete("Invoice", {"team": TEAM})
 		frappe.db.delete("Payment Method", {"team": TEAM})
 		frappe.db.delete("Billing Notification Log", {"team": TEAM})
-		self.gw = make_razorpay_gateway("GW-Dun-RZP").name
+		self.gw = make_razorpay_gateway().name
 		# An active method exists — so a retry WOULD happen if the mode allowed it.
 		frappe.get_doc(
 			{

--- a/central/billing/tests/test_dashboard.py
+++ b/central/billing/tests/test_dashboard.py
@@ -17,6 +17,7 @@ from central.billing.tests.utils import (
 	make_custom_role_team,
 	make_plan,
 	make_user,
+	reset_gateway_roster,
 )
 
 TEAM = "team-cust"
@@ -40,6 +41,10 @@ class CustomerDataBase(IntegrationTestCase):
 		ensure_team(TEAM)
 		ensure_atlas_instance(CLUSTER)
 		make_plan(PLAN)
+		# Saving a billing profile derives the currency from the country and rejects
+		# one no enabled gateway settles, so these tests need INR and USD routable —
+		# set that up rather than inheriting whatever an earlier module left behind.
+		reset_gateway_roster()
 		self._purge()
 		self.today = frappe.utils.getdate()
 		self.month_start = frappe.utils.get_first_day(self.today)

--- a/central/billing/tests/test_dashboard.py
+++ b/central/billing/tests/test_dashboard.py
@@ -169,7 +169,7 @@ class TestCustomerReads(CustomerDataBase):
 	def test_payment_methods_never_expose_secrets(self):
 		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
 
-		gw = make_stripe_gateway("GW-Cust-Stripe").name
+		gw = make_stripe_gateway().name
 		frappe.get_doc(
 			{
 				"doctype": "Payment Method",
@@ -389,7 +389,7 @@ class TestCustomerActions(CustomerDataBase):
 		# Once the profile is complete, the same call reaches the gateway.
 		complete_billing_profile(TEAM)
 		self.assertTrue(dashboard.get_billing_profile(TEAM)["complete"])
-		gw = make_razorpay_gateway("GW-Gate-RZP").name
+		gw = make_razorpay_gateway().name
 		adapter = MagicMock()
 		adapter.create_customer.return_value = "cus_gate"
 		adapter.create_order.return_value = {
@@ -423,7 +423,7 @@ class TestBillingCurrency(CustomerDataBase):
 	def test_currency_must_be_gateway_supported(self):
 		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
 
-		make_razorpay_gateway("GW-Cur-INR")  # makes INR a supported currency
+		make_razorpay_gateway()  # makes INR a supported currency
 		dashboard.save_billing_profile(TEAM, currency="INR", legal_name="Acme")
 		self.assertEqual(frappe.db.get_value("Billing Profile", TEAM, "currency"), "INR")
 		with self.assertRaises(frappe.ValidationError):
@@ -433,8 +433,8 @@ class TestBillingCurrency(CustomerDataBase):
 		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
 		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
 
-		make_razorpay_gateway("GW-Cur-INR")  # INR supported
-		make_stripe_gateway("GW-Cur-USD")  # USD supported
+		make_razorpay_gateway()  # INR supported
+		make_stripe_gateway()  # USD supported
 
 		# India → INR, regardless of any currency the client tries to send.
 		dashboard.save_billing_profile(TEAM, legal_name="Acme", country="India", currency="USD")
@@ -448,7 +448,7 @@ class TestBillingCurrency(CustomerDataBase):
 		from central.billing.revenue import credits
 		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
 
-		make_razorpay_gateway("GW-Cur-Lock")
+		make_razorpay_gateway()
 		dashboard.save_billing_profile(TEAM, currency="INR", legal_name="Acme")
 		self.assertFalse(dashboard.get_billing_profile(TEAM)["currency_locked"])
 
@@ -468,7 +468,7 @@ class TestGatewayTopUp(CustomerDataBase):
 
 		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
 
-		gw = make_razorpay_gateway("GW-Cust-RZP").name
+		gw = make_razorpay_gateway().name
 		complete_billing_profile(TEAM)
 		adapter = MagicMock()
 		adapter.create_customer.return_value = "cus_topup"
@@ -517,7 +517,7 @@ class TestGatewayTopUp(CustomerDataBase):
 
 		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
 
-		gw = make_razorpay_gateway("GW-Cust-RZP-Amt").name
+		gw = make_razorpay_gateway().name
 		complete_billing_profile(TEAM)
 		adapter = MagicMock()
 		adapter.verify_payment_signature.return_value = True
@@ -545,7 +545,7 @@ class TestGatewayTopUp(CustomerDataBase):
 
 		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
 
-		gw = make_razorpay_gateway("GW-Cust-RZP-NoAmt").name
+		gw = make_razorpay_gateway().name
 		complete_billing_profile(TEAM)
 		adapter = MagicMock()
 		adapter.verify_payment_signature.return_value = True
@@ -569,7 +569,7 @@ class TestGatewayTopUp(CustomerDataBase):
 
 		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
 
-		gw = make_razorpay_gateway("GW-Cust-RZP-Uncap").name
+		gw = make_razorpay_gateway().name
 		complete_billing_profile(TEAM)
 		adapter = MagicMock()
 		adapter.verify_payment_signature.return_value = True
@@ -593,7 +593,7 @@ class TestGatewayTopUp(CustomerDataBase):
 
 		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
 
-		gw = make_razorpay_gateway("GW-Cust-RZP-Reuse").name
+		gw = make_razorpay_gateway().name
 		complete_billing_profile(TEAM)
 		adapter = MagicMock()
 		adapter.create_customer.return_value = "cus_once"
@@ -614,7 +614,7 @@ class TestGatewayTopUp(CustomerDataBase):
 
 		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
 
-		gw = make_razorpay_gateway("GW-Cust-RZP2").name
+		gw = make_razorpay_gateway().name
 		adapter = MagicMock()
 		adapter.verify_payment_signature.return_value = False
 		with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
@@ -637,7 +637,7 @@ class TestGatewayTopUp(CustomerDataBase):
 
 		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
 
-		gw = make_stripe_gateway("GW-Cust-Stripe-T").name
+		gw = make_stripe_gateway().name
 		complete_billing_profile(TEAM)
 		adapter = MagicMock()
 		adapter.create_customer.return_value = "cus_stripe"
@@ -670,7 +670,7 @@ class TestGatewayTopUp(CustomerDataBase):
 
 		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
 
-		gw = make_stripe_gateway("GW-Cust-Stripe-T2").name
+		gw = make_stripe_gateway().name
 		adapter = MagicMock()
 		adapter.get_payment_intent.return_value = {"status": "requires_payment_method", "id": "pi_y"}
 		with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
@@ -685,26 +685,11 @@ class TestGatewayTopUp(CustomerDataBase):
 		entry on the capture id Finance reconciles against."""
 		from unittest.mock import MagicMock, patch
 
+		from central.billing.tests.test_paypal_adapter import make_paypal_gateway
 		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
 
-		stripe_def = make_stripe_gateway("GW-USD-Stripe-Def").name  # USD card default
-		if frappe.db.exists("Payment Gateway", "GW-USD-PayPal"):
-			frappe.delete_doc("Payment Gateway", "GW-USD-PayPal", force=True)
-		pp = frappe.get_doc(
-			{
-				"doctype": "Payment Gateway",
-				"__newname": "GW-USD-PayPal",
-				"title": "PayPal",
-				"adapter_key": "Paypal",
-				"api_key": "pp_client",
-				"api_secret": "pp_secret",
-				"webhook_secret": "pp_whid",
-				"is_enabled": 1,
-				"currencies": [{"currency": "USD", "is_default": 0}],
-			}
-		)
-		pp.flags.skip_credential_validation = True
-		pp.insert(ignore_permissions=True)
+		stripe_def = make_stripe_gateway().name  # USD card default
+		pp = make_paypal_gateway([("USD", 0)])  # handles USD, but is not its default
 		complete_billing_profile(TEAM, currency="USD")
 		adapter = MagicMock()
 		adapter.create_customer.return_value = "cus_pp"
@@ -746,56 +731,13 @@ class TestGatewayTopUp(CustomerDataBase):
 		stored reference is the razorpay_payment_id (ADR 0005 path, opt-in)."""
 		from unittest.mock import MagicMock, patch
 
-		# create_topup_order commits (ensure_gateway_customer), so this test's gateway
-		# rows and is_enabled toggles outlive the framework rollback — undo them by
-		# hand, then commit the restoration last (addCleanup runs LIFO).
-		self.addCleanup(frappe.db.commit)
+		from central.billing.tests.test_paypal_adapter import make_paypal_gateway
+		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
 
-		def drop(name):
-			if frappe.db.exists("Payment Gateway", name):
-				frappe.delete_doc("Payment Gateway", name, force=True)
-
-		for name in ("GW-USD-RZP", "GW-USD-PayPal-RZP"):
-			drop(name)
-			self.addCleanup(drop, name)
-		rzp = frappe.get_doc(
-			{
-				"doctype": "Payment Gateway",
-				"__newname": "GW-USD-RZP",
-				"title": "Razorpay USD",
-				"adapter_key": "Razorpay",
-				"api_key": "rzp_k",
-				"api_secret": "rzp_s",
-				"webhook_secret": "rzp_wh",
-				"is_enabled": 1,
-				"currencies": [{"currency": "USD", "is_default": 0}],
-			}
-		)
-		rzp.flags.skip_credential_validation = True
-		rzp.insert(ignore_permissions=True)
-		# No api_key/api_secret — a Via-Razorpay PayPal row needs none.
-		pp = frappe.get_doc(
-			{
-				"doctype": "Payment Gateway",
-				"__newname": "GW-USD-PayPal-RZP",
-				"title": "PayPal via Razorpay",
-				"adapter_key": "Paypal",
-				"paypal_settlement_mode": "Via Razorpay",
-				"is_enabled": 1,
-				"currencies": [{"currency": "USD", "is_default": 0}],
-			}
-		)
-		pp.insert(ignore_permissions=True)
-		# Make our Via-Razorpay row the only enabled PayPal gateway for USD, so
-		# resolution can't land on a seeded Direct PayPal gateway; re-enable the
-		# others in cleanup (set_value skips the enable-guard a re-save would hit).
-		for other in frappe.get_all(
-			"Payment Gateway",
-			{"adapter_key": "Paypal", "is_enabled": 1, "name": ["!=", pp.name]},
-			pluck="name",
-		):
-			frappe.db.set_value("Payment Gateway", other, "is_enabled", 0)
-			self.addCleanup(frappe.db.set_value, "Payment Gateway", other, "is_enabled", 1)
+		make_razorpay_gateway([("USD", 0)])
+		# There is one PayPal row, so putting it in Via-Razorpay mode IS the config —
+		# no need to hunt down other enabled PayPal gateways that might win instead.
+		pp = make_paypal_gateway([("USD", 0)], paypal_settlement_mode="Via Razorpay")
 		self.assertTrue(pp.is_paypal_via_razorpay())
 		self.assertFalse(pp._should_validate_credentials())  # keys optional in this mode
 		complete_billing_profile(TEAM, currency="USD")
@@ -879,58 +821,24 @@ class TestPaymentMethodOptions(IntegrationTestCase):
 	every currency; INR also offers a Razorpay UPI Autopay e-mandate."""
 
 	TEAM = "team-method-opts"
-	STRIPE = "GW-Opts-Stripe"
-	RAZORPAY = "GW-Opts-Razorpay"
 
 	def setUp(self):
 		from central.billing.catalog.entitlements import recompute_trust_tier
 		from central.billing.tests.test_entitlements import make_ladder
+		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
+		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
 		from central.billing.tests.utils import clear_team_tier
 
 		ensure_team(self.TEAM)
 		make_ladder()
-		self._stripe_gateway(["INR", "USD"])
-		self._razorpay_gateway("INR")
+		# One Stripe account carries both currencies: INR non-default (Razorpay owns
+		# that currency's default), USD default.
+		make_stripe_gateway([("INR", 0), ("USD", 1)])
+		make_razorpay_gateway([("INR", 1)])
 		complete_billing_profile(self.TEAM)
 		frappe.db.set_value("Billing Profile", self.TEAM, "currency", "INR")
 		clear_team_tier(self.TEAM)
 		recompute_trust_tier(self.TEAM, paid_invoice_count=0, cumulative_paid=0)
-
-	def _stripe_gateway(self, currencies):
-		if frappe.db.exists("Payment Gateway", self.STRIPE):
-			frappe.delete_doc("Payment Gateway", self.STRIPE, force=True)
-		frappe.get_doc(
-			{
-				"doctype": "Payment Gateway",
-				"__newname": self.STRIPE,
-				"title": "Stripe (Opts)",
-				"adapter_key": "Stripe",
-				"api_key": "pk_test_opts",
-				"api_secret": "sk_test_opts",
-				"webhook_secret": "whsec_opts",
-				"is_enabled": 1,
-				# INR non-default (Razorpay owns the currency default), USD default.
-				"currencies": [{"currency": c, "is_default": 1 if c == "USD" else 0} for c in currencies],
-			}
-		).insert(ignore_permissions=True)
-
-	def _razorpay_gateway(self, currency):
-		if frappe.db.exists("Payment Gateway", self.RAZORPAY):
-			frappe.delete_doc("Payment Gateway", self.RAZORPAY, force=True)
-		frappe.get_doc(
-			{
-				"doctype": "Payment Gateway",
-				"__newname": self.RAZORPAY,
-				"title": "Razorpay (Opts)",
-				"adapter_key": "Razorpay",
-				"api_key": "rzp_test",
-				"api_secret": "rzp_secret",
-				"webhook_secret": "rzp_whsec",
-				"is_enabled": 1,
-				"supports_mandates": 1,
-				"currencies": [{"currency": currency, "is_default": 1}],
-			}
-		).insert(ignore_permissions=True)
 
 	def test_india_offers_stripe_card_and_razorpay_upi(self):
 		from central.billing.api.dashboard import methods

--- a/central/billing/tests/test_dunning.py
+++ b/central/billing/tests/test_dunning.py
@@ -25,7 +25,7 @@ from central.billing.tests.utils import (
 TEAM = "team-dunning"
 CLUSTER = "ap-south-1"
 PLAN = "bundle-dunning-test"
-GATEWAY = "GW-Test-Stripe"
+GATEWAY = "Stripe"
 DUE = "2026-06-01"
 
 
@@ -48,7 +48,7 @@ class DunningTestBase(IntegrationTestCase):
 		ensure_team(TEAM)
 		ensure_atlas_instance(CLUSTER)
 		make_plan(PLAN)
-		make_stripe_gateway(GATEWAY)
+		make_stripe_gateway()
 		self._priv, self._pub = generate_keypair()
 		frappe.conf.entitlement_private_key = self._priv
 		self._purge()

--- a/central/billing/tests/test_emandate.py
+++ b/central/billing/tests/test_emandate.py
@@ -29,7 +29,7 @@ class TestEmandatePredebit(IntegrationTestCase):
 		frappe.db.delete("Payment Attempt", {"team": TEAM})
 		frappe.db.delete("Payment Method", {"team": TEAM})
 		frappe.db.delete("Billing Notification Log", {"team": TEAM})
-		self.gw = make_razorpay_gateway("GW-Emandate-RZP").name
+		self.gw = make_razorpay_gateway().name
 		frappe.get_doc(
 			{
 				"doctype": "Payment Method",

--- a/central/billing/tests/test_gateway_currency.py
+++ b/central/billing/tests/test_gateway_currency.py
@@ -13,7 +13,7 @@ import frappe
 from central.billing.gateways.registry import GatewayNotFound, resolve_gateway_for_currency
 from central.billing.gateways.setup import adapter_keys, ensure_gateway_records
 from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
-from central.billing.tests.utils import configure_gateway, disable_gateway
+from central.billing.tests.utils import configure_gateway, disable_gateway, reset_gateway_roster
 
 ADAPTERS = ("Stripe", "Razorpay", "Paypal")
 
@@ -26,6 +26,11 @@ class GatewayCurrencyTestCase(IntegrationTestCase):
 		ensure_gateway_records()
 		for adapter_key in ADAPTERS:
 			configure_gateway(adapter_key, [], is_enabled=0)
+
+	def tearDown(self):
+		# The roster is one shared row per adapter, so wiping it above wipes it for
+		# every module that runs after this one — put the baseline routing back.
+		reset_gateway_roster()
 
 
 class TestResolveGatewayForCurrency(GatewayCurrencyTestCase):

--- a/central/billing/tests/test_gateway_currency.py
+++ b/central/billing/tests/test_gateway_currency.py
@@ -5,102 +5,123 @@
 Covers:
 - resolve_gateway_for_currency: returns the correct gateway, raises GatewayNotFound
 - is_default invariant: saving a row with is_default=True clears it on other gateways
-- _gateway_for_currency and _add_method_gateway wrappers in the dashboard layer
+- the roster invariant: exactly one row per adapter, named after it
 """
 
 import frappe
 
 from central.billing.gateways.registry import GatewayNotFound, resolve_gateway_for_currency
+from central.billing.gateways.setup import adapter_keys, ensure_gateway_records
 from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
+from central.billing.tests.utils import configure_gateway, disable_gateway
+
+ADAPTERS = ("Stripe", "Razorpay", "Paypal")
 
 
-def _make_gateway(name, adapter_key, currencies, is_enabled=1, **extra):
-	if frappe.db.exists("Payment Gateway", name):
-		frappe.delete_doc("Payment Gateway", name, force=True)
-	return frappe.get_doc(
-		{
-			"doctype": "Payment Gateway",
-			"__newname": name,
-			"title": name,
-			"adapter_key": adapter_key,
-			"currencies": [{"currency": c, "is_default": d} for c, d in currencies],
-			"api_key": "key",
-			"api_secret": "secret",
-			"webhook_secret": "whsec",
-			"is_enabled": is_enabled,
-			**extra,
-		}
-	).insert(ignore_permissions=True)
+class GatewayCurrencyTestCase(IntegrationTestCase):
+	"""Every gateway starts each test with no currencies and disabled, so a test only
+	sees the routing it sets up itself. Rows are never deleted — they are the roster."""
 
-
-class TestResolveGatewayForCurrency(IntegrationTestCase):
 	def setUp(self):
-		for name in ("GW-USD-A", "GW-USD-B", "GW-INR-A", "GW-EUR-A"):
-			if frappe.db.exists("Payment Gateway", name):
-				frappe.delete_doc("Payment Gateway", name, force=True)
+		ensure_gateway_records()
+		for adapter_key in ADAPTERS:
+			configure_gateway(adapter_key, [], is_enabled=0)
 
-	def tearDown(self):
-		for name in ("GW-USD-A", "GW-USD-B", "GW-INR-A", "GW-EUR-A"):
-			if frappe.db.exists("Payment Gateway", name):
-				frappe.delete_doc("Payment Gateway", name, force=True)
 
+class TestResolveGatewayForCurrency(GatewayCurrencyTestCase):
 	def test_returns_gateway_with_is_default_for_currency(self):
-		_make_gateway("GW-USD-A", "Stripe", [("USD", 1)])
-		self.assertEqual(resolve_gateway_for_currency("USD"), "GW-USD-A")
+		configure_gateway("Stripe", [("USD", 1)], is_enabled=1)
+		self.assertEqual(resolve_gateway_for_currency("USD"), "Stripe")
 
 	def test_raises_gateway_not_found_when_none_configured(self):
 		with self.assertRaises(GatewayNotFound):
 			resolve_gateway_for_currency("JPY")
 
 	def test_raises_gateway_not_found_when_gateway_disabled(self):
-		_make_gateway("GW-USD-A", "Stripe", [("USD", 1)], is_enabled=0)
+		configure_gateway("Stripe", [("USD", 1)], is_enabled=0)
 		with self.assertRaises(GatewayNotFound):
 			resolve_gateway_for_currency("USD")
 
 	def test_raises_gateway_not_found_when_no_is_default_row(self):
-		_make_gateway("GW-USD-A", "Stripe", [("USD", 0)])
+		configure_gateway("Stripe", [("USD", 0)], is_enabled=1)
 		with self.assertRaises(GatewayNotFound):
 			resolve_gateway_for_currency("USD")
 
 	def test_gateway_with_multiple_currencies(self):
-		_make_gateway("GW-EUR-A", "Stripe", [("EUR", 1), ("USD", 1)])
-		self.assertEqual(resolve_gateway_for_currency("EUR"), "GW-EUR-A")
-		self.assertEqual(resolve_gateway_for_currency("USD"), "GW-EUR-A")
+		"""One merchant account settles several currencies — that is what the child
+		table is for, and it is why a second row per provider is never needed."""
+		configure_gateway("Stripe", [("EUR", 1), ("USD", 1)], is_enabled=1)
+		self.assertEqual(resolve_gateway_for_currency("EUR"), "Stripe")
+		self.assertEqual(resolve_gateway_for_currency("USD"), "Stripe")
 
 
-class TestIsDefaultInvariant(IntegrationTestCase):
-	"""Saving is_default=True on one gateway clears the flag on others for the same currency."""
-
-	def setUp(self):
-		for name in ("GW-USD-A", "GW-USD-B"):
-			if frappe.db.exists("Payment Gateway", name):
-				frappe.delete_doc("Payment Gateway", name, force=True)
-
-	def tearDown(self):
-		for name in ("GW-USD-A", "GW-USD-B"):
-			if frappe.db.exists("Payment Gateway", name):
-				frappe.delete_doc("Payment Gateway", name, force=True)
+class TestIsDefaultInvariant(GatewayCurrencyTestCase):
+	"""Saving is_default=True on one gateway clears the flag on others for the same
+	currency. The competition is between providers now, not between rows of one."""
 
 	def test_setting_is_default_clears_previous_default(self):
-		_make_gateway("GW-USD-A", "Stripe", [("USD", 1)])
-		self.assertEqual(resolve_gateway_for_currency("USD"), "GW-USD-A")
+		configure_gateway("Stripe", [("USD", 1)], is_enabled=1)
+		self.assertEqual(resolve_gateway_for_currency("USD"), "Stripe")
 
-		# GW-USD-B now claims the USD default.
-		_make_gateway("GW-USD-B", "Stripe", [("USD", 1)])
-		self.assertEqual(resolve_gateway_for_currency("USD"), "GW-USD-B")
+		# PayPal now claims the USD default.
+		configure_gateway("Paypal", [("USD", 1)], is_enabled=1)
+		self.assertEqual(resolve_gateway_for_currency("USD"), "Paypal")
 
-		# GW-USD-A's row should have been cleared.
+		# Stripe's row should have been cleared.
 		row = frappe.db.get_value(
 			"Payment Gateway Currency",
-			{"parent": "GW-USD-A", "currency": "USD"},
+			{"parent": "Stripe", "currency": "USD"},
 			"is_default",
 		)
 		self.assertEqual(row, 0)
 
 	def test_different_currencies_do_not_interfere(self):
-		_make_gateway("GW-USD-A", "Stripe", [("USD", 1)])
-		_make_gateway("GW-INR-A", "Razorpay", [("INR", 1)])
+		configure_gateway("Stripe", [("USD", 1)], is_enabled=1)
+		configure_gateway("Razorpay", [("INR", 1)], is_enabled=1)
 
 		# Each owns its currency independently.
-		self.assertEqual(resolve_gateway_for_currency("USD"), "GW-USD-A")
-		self.assertEqual(resolve_gateway_for_currency("INR"), "GW-INR-A")
+		self.assertEqual(resolve_gateway_for_currency("USD"), "Stripe")
+		self.assertEqual(resolve_gateway_for_currency("INR"), "Razorpay")
+
+	def test_disabled_gateway_does_not_hold_a_currency_hostage(self):
+		configure_gateway("Stripe", [("USD", 1)], is_enabled=1)
+		disable_gateway("Stripe")
+		configure_gateway("Paypal", [("USD", 1)], is_enabled=1)
+		self.assertEqual(resolve_gateway_for_currency("USD"), "Paypal")
+
+
+class TestGatewayRoster(GatewayCurrencyTestCase):
+	"""One row per adapter, named after it — enforced by the primary key, not by a
+	validate() hook that a bulk write could skip."""
+
+	def test_a_row_exists_for_every_adapter_and_is_named_after_it(self):
+		for adapter_key in adapter_keys():
+			self.assertTrue(frappe.db.exists("Payment Gateway", adapter_key))
+			self.assertEqual(
+				frappe.db.get_value("Payment Gateway", adapter_key, "adapter_key"), adapter_key
+			)
+
+	def test_a_second_row_for_the_same_adapter_is_rejected(self):
+		with self.assertRaises(frappe.DuplicateEntryError):
+			frappe.get_doc({"doctype": "Payment Gateway", "adapter_key": "Stripe"}).insert(
+				ignore_permissions=True
+			)
+
+	def test_seeding_is_idempotent(self):
+		before = frappe.db.count("Payment Gateway")
+		ensure_gateway_records()
+		self.assertEqual(frappe.db.count("Payment Gateway"), before)
+
+	def test_adapter_cannot_be_repointed_at_another_provider(self):
+		"""Every Payment Attempt / Webhook Event links to this row by name, so flipping
+		its adapter would re-attribute settled money to a provider that never took it.
+
+		The field is slaved to the name (autoname `field:adapter_key`), so Frappe drops
+		the edit on save — renaming is off, which leaves nothing that can change it."""
+		gw = frappe.get_doc("Payment Gateway", "Stripe")
+		gw.adapter_key = "Razorpay"
+		gw.flags.skip_credential_validation = True
+		gw.save(ignore_permissions=True)
+
+		self.assertEqual(gw.adapter_key, "Stripe")
+		self.assertEqual(frappe.db.get_value("Payment Gateway", "Stripe", "adapter_key"), "Stripe")

--- a/central/billing/tests/test_gateway_customer.py
+++ b/central/billing/tests/test_gateway_customer.py
@@ -32,7 +32,7 @@ def stub(gateway, customer_id="cus_prov"):
 class TestProvisionGatewayCustomersPatch(IntegrationTestCase):
 	def setUp(self):
 		ensure_team(TEAM)
-		self.gateway = make_razorpay_gateway("GW-Prov-INR").name
+		self.gateway = make_razorpay_gateway().name
 		frappe.db.delete("Gateway Customer", {"team": TEAM})
 		complete_billing_profile(TEAM, "INR")
 

--- a/central/billing/tests/test_mandates.py
+++ b/central/billing/tests/test_mandates.py
@@ -347,6 +347,13 @@ class TestAddMethodGatewayResolution(IntegrationTestCase):
 		for adapter_key in ("Stripe", "Razorpay", "Paypal"):
 			configure_gateway(adapter_key, [], is_enabled=0)
 
+	def tearDown(self):
+		# One shared row per adapter: the wipe above outlives this class unless the
+		# baseline routing is restored for whatever runs next.
+		from central.billing.tests.utils import reset_gateway_roster
+
+		reset_gateway_roster()
+
 	def _gw(self, adapter, currency, default=0):
 		from central.billing.tests.utils import configure_gateway
 

--- a/central/billing/tests/test_mandates.py
+++ b/central/billing/tests/test_mandates.py
@@ -20,26 +20,13 @@ from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
 from central.billing.tests.utils import clear_team_tier, complete_billing_profile, ensure_team
 
 TEAM = "team-mandate"
-GATEWAY = "GW-Mandate-Razorpay"
+GATEWAY = "Razorpay"
 
 
 def make_gateway():
-	if frappe.db.exists("Payment Gateway", GATEWAY):
-		frappe.delete_doc("Payment Gateway", GATEWAY, force=True)
-	frappe.get_doc(
-		{
-			"doctype": "Payment Gateway",
-			"__newname": GATEWAY,
-			"title": "Razorpay (Mandate Test)",
-			"adapter_key": "Razorpay",
-			"currency": "INR",
-			"api_key": "rzp_test_key",
-			"api_secret": "rzp_test_secret",
-			"webhook_secret": "rzp_whsec",
-			"is_enabled": 1,
-			"supports_mandates": 1,
-		}
-	).insert(ignore_permissions=True)
+	from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
+
+	make_razorpay_gateway([("INR", 1)])
 
 
 @contextmanager
@@ -353,33 +340,35 @@ class TestAddMethodGatewayResolution(IntegrationTestCase):
 	for INR (so UPI is offered) even when a Stripe-INR gateway is the currency
 	default; Stripe for currencies with no Razorpay."""
 
-	def _gw(self, name, adapter, currency, default=0):
-		if frappe.db.exists("Payment Gateway", name):
-			frappe.delete_doc("Payment Gateway", name, force=True)
-		frappe.get_doc(
-			{
-				"doctype": "Payment Gateway",
-				"__newname": name,
-				"title": name,
-				"adapter_key": adapter,
-				"api_key": "k",
-				"api_secret": "s",
-				"webhook_secret": "w",
-				"is_enabled": 1,
-				"supports_mandates": 1 if adapter == "Razorpay" else 0,
-				"currencies": [{"currency": currency, "is_default": default}],
-			}
-		).insert(ignore_permissions=True)
+	def setUp(self):
+		from central.billing.tests.utils import configure_gateway
+
+		# Start from a clean routing table so each test's own config decides.
+		for adapter_key in ("Stripe", "Razorpay", "Paypal"):
+			configure_gateway(adapter_key, [], is_enabled=0)
+
+	def _gw(self, adapter, currency, default=0):
+		from central.billing.tests.utils import configure_gateway
+
+		return configure_gateway(
+			adapter,
+			[(currency, default)],
+			api_key="k",
+			api_secret="s",
+			webhook_secret="w",
+			is_enabled=1,
+			supports_mandates=1 if adapter == "Razorpay" else 0,
+		)
 
 	def test_razorpay_wins_over_default_stripe_for_inr(self):
 		from central.billing.api import dashboard
 
-		self._gw("GW-Res-Stripe-INR", "Stripe", "INR", default=1)
-		self._gw("GW-Res-RZP-INR", "Razorpay", "INR", default=0)
+		self._gw("Stripe", "INR", default=1)
+		self._gw("Razorpay", "INR", default=0)
 		self.assertEqual(dashboard._shared._add_method_gateway("INR").adapter_key, "Razorpay")
 
 	def test_stripe_when_no_razorpay_for_currency(self):
 		from central.billing.api import dashboard
 
-		self._gw("GW-Res-Stripe-EUR", "Stripe", "EUR", default=1)
+		self._gw("Stripe", "EUR", default=1)
 		self.assertEqual(dashboard._shared._add_method_gateway("EUR").adapter_key, "Stripe")

--- a/central/billing/tests/test_ops_reports.py
+++ b/central/billing/tests/test_ops_reports.py
@@ -34,7 +34,7 @@ def _row(rows, month=MONTH):
 
 class TestWebhookLag(BillingTestCase):
 	def setUp(self):
-		self.gateway = make_stripe_gateway("GW-Lag-Stripe").name
+		self.gateway = make_stripe_gateway().name
 
 	def _webhook(self, received, processed):
 		event = frappe.get_doc(
@@ -117,7 +117,7 @@ class TestDunningRecovery(BillingTestCase):
 
 class TestGatewayAuthRateOverTime(BillingTestCase):
 	def setUp(self):
-		self.gateway = make_stripe_gateway("GW-Trend-Stripe").name
+		self.gateway = make_stripe_gateway().name
 		self.team = ensure_team("team-authrate")
 		self.invoice = (
 			frappe.get_doc(

--- a/central/billing/tests/test_payment_gateway.py
+++ b/central/billing/tests/test_payment_gateway.py
@@ -10,21 +10,30 @@ from central.billing.gateways.stripe_adapter import StripeAdapter
 from central.billing.tests.test_stripe_adapter import make_stripe_gateway
 from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
 
+_CONTROLLER = "central.billing.doctype.payment_gateway.payment_gateway"
 
-def _new_gateway(name="GW-Setup-Test", **overrides):
-	"""Build (unsaved) a Stripe gateway with setup validation forced on."""
-	if frappe.db.exists("Payment Gateway", name):
-		frappe.delete_doc("Payment Gateway", name, force=True)
-	values = {
-		"doctype": "Payment Gateway",
-		"__newname": name,
-		"title": "Stripe (Setup)",
-		"adapter_key": "Stripe",
-		"currencies": [{"currency": "USD", "is_default": 1}],
-		"api_secret": "sk_live_xyz",
-		**overrides,
-	}
-	doc = frappe.get_doc(values)
+
+def _new_gateway(**overrides):
+	"""The Stripe gateway with freshly-typed keys and setup validation forced on.
+
+	Returned unsaved: these tests assert on what `save()` does. The row itself always
+	exists (one per adapter, seeded), so this configures rather than creates."""
+	from central.billing.gateways.setup import ensure_gateway_records
+
+	ensure_gateway_records()
+	doc = frappe.get_doc("Payment Gateway", "Stripe")
+	doc.currencies = []
+	doc.append("currencies", {"currency": "USD", "is_default": 1})
+	doc.update(
+		{
+			"api_secret": "sk_live_xyz",
+			"webhook_secret": None,
+			"webhook_endpoint_id": None,
+			"credentials_validated_at": None,
+			"is_enabled": 1,
+			**overrides,
+		}
+	)
 	doc.flags.force_credential_validation = True
 	return doc
 
@@ -53,17 +62,21 @@ class TestGatewaySetupValidation(IntegrationTestCase):
 		doc = _new_gateway(is_enabled=0)
 		with patch.object(StripeAdapter, "validate_credentials", side_effect=GatewayAuthError("bad key")):
 			with self.assertRaises(frappe.ValidationError):
-				doc.insert(ignore_permissions=True)
+				doc.save(ignore_permissions=True)
 
 	def test_valid_keys_stamp_validated_at_and_autofill_webhook(self):
 		doc = _new_gateway()
 		identity = {"account_id": "acct_1", "currency": "USD"}
 		registered = {"endpoint_id": "we_1", "secret": "whsec_auto"}
 		with (
+			# The test site is *.local, which the controller (rightly) refuses to
+			# register a callback for — stand in a publicly reachable host so the
+			# registration path this test is about actually runs.
+			patch(f"{_CONTROLLER}.get_url", return_value="https://billing.example.com"),
 			patch.object(StripeAdapter, "validate_credentials", return_value=identity),
 			patch.object(StripeAdapter, "register_webhook", return_value=registered) as reg,
 		):
-			doc.insert(ignore_permissions=True)
+			doc.save(ignore_permissions=True)
 
 		self.assertTrue(doc.credentials_validated_at)
 		self.assertEqual(doc.webhook_endpoint_id, "we_1")
@@ -92,14 +105,14 @@ class TestGatewaySetupValidation(IntegrationTestCase):
 				return_value={"endpoint_id": "we_x", "secret": "whsec_x"},
 			),
 		):
-			doc.insert(ignore_permissions=True)
+			doc.save(ignore_permissions=True)
 		self.assertTrue(doc.credentials_validated_at)
 
 	def test_cannot_enable_without_validated_credentials(self):
 		# No keys entered → nothing to validate, but is_enabled is on.
 		doc = _new_gateway(api_secret="", is_enabled=1)
 		with self.assertRaises(frappe.ValidationError):
-			doc.insert(ignore_permissions=True)
+			doc.save(ignore_permissions=True)
 
 	def test_manual_secret_kept_when_gateway_cannot_self_register(self):
 		doc = _new_gateway(webhook_secret="whsec_manual")
@@ -111,7 +124,7 @@ class TestGatewaySetupValidation(IntegrationTestCase):
 			),
 			patch.object(StripeAdapter, "register_webhook", side_effect=GatewayUnsupported("nope")),
 		):
-			doc.insert(ignore_permissions=True)
+			doc.save(ignore_permissions=True)
 		self.assertFalse(doc.webhook_endpoint_id)
 		self.assertEqual(doc.get_password("webhook_secret"), "whsec_manual")
 
@@ -127,10 +140,10 @@ class TestGatewaySetupValidation(IntegrationTestCase):
 				StripeAdapter, "register_webhook", return_value={"endpoint_id": "we", "secret": "s"}
 			),
 		):
-			doc.insert(ignore_permissions=True)
+			doc.save(ignore_permissions=True)
 
 		# Edit a non-secret field; the secret field now holds the '*****' mask.
-		doc.title = "Stripe (Setup) updated"
+		doc.supports_mandates = 1
 		with patch.object(StripeAdapter, "validate_credentials") as vc:
 			doc.save(ignore_permissions=True)
 		vc.assert_not_called()
@@ -143,7 +156,7 @@ class TestGatewayCredentialResolution(IntegrationTestCase):
 	def test_falls_back_to_doc_when_not_in_site_config(self):
 		from central.billing.gateways.registry import get_adapter
 
-		gw = make_stripe_gateway("GW-Cred-Test")
+		gw = make_stripe_gateway()
 		adapter = get_adapter(gw)
 		# stripe_webhook_secret is not in this site's config -> read off the doc.
 		self.assertNotIn("stripe_webhook_secret", frappe.conf)
@@ -152,7 +165,7 @@ class TestGatewayCredentialResolution(IntegrationTestCase):
 	def test_site_config_key_overrides_the_doc(self):
 		from central.billing.gateways.registry import get_adapter
 
-		gw = make_stripe_gateway("GW-Cred-Test2")
+		gw = make_stripe_gateway()
 		adapter = get_adapter(gw)
 		with patch.dict(frappe.local.conf, {"stripe_webhook_secret": "whsec_from_conf"}):
 			self.assertEqual(adapter.get_credential("webhook_secret"), "whsec_from_conf")

--- a/central/billing/tests/test_payments.py
+++ b/central/billing/tests/test_payments.py
@@ -13,7 +13,7 @@ from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
 from central.billing.tests.utils import ensure_team
 
 TEAM = "team-cards"
-GATEWAY = "GW-Test-Stripe"
+GATEWAY = "Stripe"
 
 
 @contextmanager
@@ -33,7 +33,7 @@ def stub_adapter(validate=True):
 class CardTestBase(IntegrationTestCase):
 	def setUp(self):
 		ensure_team(TEAM)
-		make_stripe_gateway(GATEWAY)
+		make_stripe_gateway()
 		for name in frappe.get_all("Payment Method", filters={"team": TEAM}, pluck="name"):
 			frappe.delete_doc("Payment Method", name, force=True)
 		frappe.db.delete("Gateway Customer", {"team": TEAM})

--- a/central/billing/tests/test_paypal_adapter.py
+++ b/central/billing/tests/test_paypal_adapter.py
@@ -13,22 +13,19 @@ from central.billing.tests.gateway_contract import GatewayAdapterContract
 from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
 
 
-def make_paypal_gateway(name="GW-Test-PayPal"):
-	if frappe.db.exists("Payment Gateway", name):
-		frappe.delete_doc("Payment Gateway", name, force=True)
-	return frappe.get_doc(
-		{
-			"doctype": "Payment Gateway",
-			"__newname": name,
-			"title": "PayPal (Test)",
-			"adapter_key": "Paypal",
-			"currency": "USD",
-			"api_key": "pp_client",
-			"api_secret": "pp_secret",
-			"webhook_secret": "WH-ID-1",
-			"is_enabled": 1,
-		}
-	).insert(ignore_permissions=True)
+def make_paypal_gateway(currencies=(("USD", 0),), **values):
+	"""The PayPal gateway, configured for test. There is only one (named "Paypal")."""
+	from central.billing.tests.utils import configure_gateway
+
+	return configure_gateway(
+		"Paypal",
+		currencies,
+		api_key="pp_client",
+		api_secret="pp_secret",
+		webhook_secret="WH-ID-1",
+		is_enabled=1,
+		**values,
+	)
 
 
 class TestPayPalAdapter(GatewayAdapterContract, IntegrationTestCase):

--- a/central/billing/tests/test_profile_provisioning.py
+++ b/central/billing/tests/test_profile_provisioning.py
@@ -20,7 +20,7 @@ class TestBillingProfileProvisioning(IntegrationTestCase):
 	def setUp(self):
 		make_ladder()  # t0 is the default entry tier, and prices INR
 		ensure_team(TEAM)
-		make_razorpay_gateway("GW-Prov-INR")  # makes INR a supported currency
+		make_razorpay_gateway()  # makes INR a supported currency
 		self._purge()
 
 	def tearDown(self):

--- a/central/billing/tests/test_projection_events.py
+++ b/central/billing/tests/test_projection_events.py
@@ -250,7 +250,7 @@ class TestDeclines(EventTestBase):
 		# card's link if it ran per card.
 		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
 		if not getattr(self, "_gw", None):
-			self._gw = make_stripe_gateway("GW-Test-Stripe").name
+			self._gw = make_stripe_gateway().name
 		return self._gw
 	def _card(self, label):
 		gateway = self._gateway()

--- a/central/billing/tests/test_projection_outcomes.py
+++ b/central/billing/tests/test_projection_outcomes.py
@@ -12,7 +12,7 @@ from central.billing.tests.utils import ensure_atlas_instance, ensure_team, make
 TEAM = "team-projection-outcomes"
 CLUSTER = "ap-south-1"
 PLAN = "bundle-projection-outcomes"
-GATEWAY = "GW-Test-Stripe"
+GATEWAY = "Stripe"
 DUE = "2026-10-08"
 TODAY = "2026-08-06"
 
@@ -22,7 +22,7 @@ class OutcomeTestBase(IntegrationTestCase):
 		ensure_team(TEAM)
 		ensure_atlas_instance(CLUSTER)
 		make_plan(PLAN)
-		make_stripe_gateway(GATEWAY)
+		make_stripe_gateway()
 		self._purge()
 		set_team_tier(TEAM, level="t0", max_spend=50000)
 		frappe.db.commit()

--- a/central/billing/tests/test_razorpay_adapter.py
+++ b/central/billing/tests/test_razorpay_adapter.py
@@ -13,25 +13,19 @@ from central.billing.tests.gateway_contract import GatewayAdapterContract
 from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
 
 
-def make_razorpay_gateway(name="GW-Test-Razorpay"):
-	if frappe.db.exists("Payment Gateway", name):
-		frappe.delete_doc("Payment Gateway", name, force=True)
-	doc = frappe.get_doc(
-		{
-			"doctype": "Payment Gateway",
-			"__newname": name,
-			"title": "Razorpay (Test)",
-			"adapter_key": "Razorpay",
-			"currencies": [{"currency": "INR", "is_default": 1}],
-			"api_key": "rzp_test_key",
-			"api_secret": "rzp_test_secret",
-			"webhook_secret": "rzp_whsec",
-			"is_enabled": 1,
-			"supports_mandates": 1,
-		}
+def make_razorpay_gateway(currencies=(("INR", 1),)):
+	"""The Razorpay gateway, configured for test. There is only one (named "Razorpay")."""
+	from central.billing.tests.utils import configure_gateway
+
+	return configure_gateway(
+		"Razorpay",
+		currencies,
+		api_key="rzp_test_key",
+		api_secret="rzp_test_secret",
+		webhook_secret="rzp_whsec",
+		is_enabled=1,
+		supports_mandates=1,
 	)
-	doc.insert(ignore_permissions=True)
-	return doc
 
 
 class TestRazorpayAdapter(GatewayAdapterContract, IntegrationTestCase):

--- a/central/billing/tests/test_reconciliation.py
+++ b/central/billing/tests/test_reconciliation.py
@@ -14,7 +14,7 @@ from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
 from central.billing.tests.utils import ensure_team
 
 TEAM = "team-recon"
-GATEWAY = "GW-Test-Stripe"
+GATEWAY = "Stripe"
 
 
 @contextmanager
@@ -43,7 +43,7 @@ def charge_result(success=True, txn_id="pi_x"):
 class ReconTestBase(IntegrationTestCase):
 	def setUp(self):
 		ensure_team(TEAM)
-		make_stripe_gateway(GATEWAY)
+		make_stripe_gateway()
 		self._purge()
 
 	def tearDown(self):

--- a/central/billing/tests/test_refunds.py
+++ b/central/billing/tests/test_refunds.py
@@ -23,7 +23,7 @@ from central.billing.tests.utils import (
 TEAM = "team-refund"
 CLUSTER = "ap-south-1"
 PLAN = "bundle-refund-test"
-GATEWAY = "GW-Test-Stripe"
+GATEWAY = "Stripe"
 
 
 @contextmanager
@@ -42,7 +42,7 @@ class RefundTestBase(IntegrationTestCase):
 		ensure_atlas_instance(CLUSTER)
 		complete_billing_profile(TEAM, currency="INR")  # so a provisioned segment is rated
 		make_plan(PLAN)
-		make_stripe_gateway(GATEWAY)
+		make_stripe_gateway()
 		self._purge()
 
 	def tearDown(self):

--- a/central/billing/tests/test_settlement.py
+++ b/central/billing/tests/test_settlement.py
@@ -25,7 +25,7 @@ from central.billing.tests.utils import ensure_atlas_instance, ensure_team, make
 TEAM = "team-waterfall"
 CLUSTER = "ap-south-1"
 PLAN = "bundle-waterfall-test"
-GATEWAY = "GW-Test-Stripe"
+GATEWAY = "Stripe"
 
 
 @contextmanager
@@ -50,7 +50,7 @@ class SettlementTestBase(IntegrationTestCase):
 		ensure_team(TEAM)
 		ensure_atlas_instance(CLUSTER)
 		make_plan(PLAN)
-		make_stripe_gateway(GATEWAY)
+		make_stripe_gateway()
 		self._purge()
 
 	def tearDown(self):

--- a/central/billing/tests/test_stripe_adapter.py
+++ b/central/billing/tests/test_stripe_adapter.py
@@ -13,25 +13,17 @@ from central.billing.tests.gateway_contract import GatewayAdapterContract
 from central.billing.tests.utils import BillingTestCase as IntegrationTestCase
 
 
-def make_stripe_gateway(name="GW-Test-Stripe"):
-	import frappe
+def make_stripe_gateway(currencies=(("USD", 1),)):
+	"""The Stripe gateway, configured for test. There is only one (named "Stripe")."""
+	from central.billing.tests.utils import configure_gateway
 
-	if frappe.db.exists("Payment Gateway", name):
-		frappe.delete_doc("Payment Gateway", name, force=True)
-	doc = frappe.get_doc(
-		{
-			"doctype": "Payment Gateway",
-			"__newname": name,
-			"title": "Stripe (Test)",
-			"adapter_key": "Stripe",
-			"currencies": [{"currency": "USD", "is_default": 1}],
-			"api_secret": "sk_test_123",
-			"webhook_secret": "whsec_test_123",
-			"is_enabled": 1,
-		}
+	return configure_gateway(
+		"Stripe",
+		currencies,
+		api_secret="sk_test_123",
+		webhook_secret="whsec_test_123",
+		is_enabled=1,
 	)
-	doc.insert(ignore_permissions=True)
-	return doc
 
 
 class TestStripeAdapter(GatewayAdapterContract, IntegrationTestCase):

--- a/central/billing/tests/test_stripe_adapter.py
+++ b/central/billing/tests/test_stripe_adapter.py
@@ -20,6 +20,10 @@ def make_stripe_gateway(currencies=(("USD", 1),)):
 	return configure_gateway(
 		"Stripe",
 		currencies,
+		# api_key is Stripe's *publishable* key — the one the browser SDK needs, and
+		# what get_payment_method_options hands the client. Set it here so the fixture
+		# doesn't silently lean on a stripe_publishable_key in common_site_config.
+		api_key="pk_test_123",
 		api_secret="sk_test_123",
 		webhook_secret="whsec_test_123",
 		is_enabled=1,

--- a/central/billing/tests/utils.py
+++ b/central/billing/tests/utils.py
@@ -250,6 +250,22 @@ def disable_gateway(adapter_key):
 	frappe.db.set_value("Payment Gateway", adapter_key, "is_enabled", 0)
 
 
+def reset_gateway_roster():
+	"""Restore the routing the rest of the suite assumes: Stripe settles USD,
+	Razorpay settles INR, PayPal is off.
+
+	There is one shared row per adapter (ADR 0021), so a test that rewires the
+	roster rewires it for everything that runs after — where the old throwaway rows
+	could be abandoned harmlessly. A test that wipes the roster owes it a restore.
+	"""
+	from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
+	from central.billing.tests.test_stripe_adapter import make_stripe_gateway
+
+	configure_gateway("Paypal", [], is_enabled=0)
+	make_stripe_gateway()
+	make_razorpay_gateway()
+
+
 def make_plan(name, rates=None, includes=None, **kwargs):
 	"""Create (or replace) a bundle Plan and its Catalog Rate rows; return its name."""
 	if frappe.db.exists("Plan", name):

--- a/central/billing/tests/utils.py
+++ b/central/billing/tests/utils.py
@@ -92,12 +92,51 @@ class BillingTestCase(IntegrationTestCase):
 		"Billing Run",
 	)
 
+	# Payment Gateway is a fixed roster (one row per adapter), not something a test
+	# creates — so it can't be swept, it has to be put back. These are the fields a
+	# test reconfigures; the Password fields live in __Auth and are left alone.
+	_GATEWAY_FIELDS = (
+		"is_enabled",
+		"supports_mandates",
+		"paypal_settlement_mode",
+		"credentials_validated_at",
+		"webhook_endpoint_id",
+	)
+
 	def run(self, result=None):
 		before = {doctype: set(frappe.get_all(doctype, pluck="name")) for doctype in self._TRACKED}
+		gateways = self._snapshot_gateways()
 		try:
 			return super().run(result)
 		finally:
 			self._sweep(before)
+			self._restore_gateways(gateways)
+
+	def _snapshot_gateways(self) -> dict:
+		return {
+			gw.name: (gw, frappe.get_all("Payment Gateway Currency", {"parent": gw.name}, ["*"]))
+			for gw in frappe.get_all("Payment Gateway", fields=["name", *self._GATEWAY_FIELDS])
+		}
+
+	def _restore_gateways(self, snapshot: dict) -> None:
+		"""Put every gateway back the way the test found it — config and currency rows.
+
+		A test that commits (the top-up flows do, via ensure_gateway_customer) outlives
+		the per-test rollback, so a currency row it added would silently re-route the
+		next test's payments."""
+		for name, (values, currency_rows) in snapshot.items():
+			if not frappe.db.exists("Payment Gateway", name):
+				continue
+			frappe.db.set_value(
+				"Payment Gateway",
+				name,
+				{field: values.get(field) for field in self._GATEWAY_FIELDS},
+				update_modified=False,
+			)
+			frappe.db.delete("Payment Gateway Currency", {"parent": name})
+			for row in currency_rows:
+				frappe.get_doc({"doctype": "Payment Gateway Currency", **row}).db_insert()
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit -- outlive a test's own commit
 
 	def _sweep(self, before: dict) -> None:
 		for attempt in range(_SWEEP_DEADLOCK_RETRIES):
@@ -179,6 +218,36 @@ def ensure_atlas_instance(region):
 	from central.tests.utils import ensure_atlas_instance as _ensure_atlas_instance
 
 	return _ensure_atlas_instance(region)
+
+
+def configure_gateway(adapter_key, currencies, **values):
+	"""Put the one gateway row for `adapter_key` into a known state, and return it.
+
+	Gateway rows are seeded per adapter (`gateways.setup.ensure_gateway_records`) and
+	named after it, so a test configures the existing row rather than creating one —
+	there is no second Stripe to create. `currencies` is a list of (currency,
+	is_default) pairs and REPLACES whatever the row carried.
+	"""
+	from central.billing.gateways.setup import ensure_gateway_records
+
+	# The roster is seeded by a before_tests hook, but a site set up before this
+	# landed won't have run it — seeding here keeps the fixture self-sufficient.
+	ensure_gateway_records()
+
+	doc = frappe.get_doc("Payment Gateway", adapter_key)
+	doc.update(values)
+	doc.currencies = []
+	for currency, is_default in currencies:
+		doc.append("currencies", {"currency": currency, "is_default": is_default})
+	doc.flags.skip_credential_validation = True
+	doc.save(ignore_permissions=True)
+	return doc
+
+
+def disable_gateway(adapter_key):
+	"""Take a gateway out of play without deleting it (deleting the roster row would
+	strand every Link that points at it)."""
+	frappe.db.set_value("Payment Gateway", adapter_key, "is_enabled", 0)
 
 
 def make_plan(name, rates=None, includes=None, **kwargs):

--- a/central/hooks.py
+++ b/central/hooks.py
@@ -116,6 +116,7 @@ after_install = [
 	"central.billing.catalog.taxonomy_setup.ensure_catalog_masters",
 	"central.billing.platform.constraints.ensure_constraints",
 	"central.billing.settings.ensure_welcome_credit_amounts",
+	"central.billing.gateways.setup.ensure_gateway_records",
 ]
 
 # Uninstallation
@@ -245,6 +246,7 @@ scheduler_events = {
 after_migrate = [
 	"central.billing.catalog.taxonomy_setup.ensure_catalog_masters",
 	"central.billing.platform.constraints.ensure_constraints",
+	"central.billing.gateways.setup.ensure_gateway_records",
 ]
 
 # Testing
@@ -256,6 +258,7 @@ before_tests = [
 	"central.billing.catalog.taxonomy_setup.ensure_catalog_masters",
 	"central.billing.platform.constraints.ensure_constraints",
 	"central.billing.settings.ensure_welcome_credit_amounts",
+	"central.billing.gateways.setup.ensure_gateway_records",
 ]
 
 # Extend DocType Class

--- a/central/patches.txt
+++ b/central/patches.txt
@@ -16,6 +16,10 @@ central.patches.v0_0.migrate_team_to_central_team
 # Widen the decimal columns to varchar before sync (the sync can't cast a '1/8'
 # default against a decimal column) and relabel stored values — issue #33.
 central.patches.v0_0.configurator_vcpu_dropdown
+# Collapse Payment Gateway to one row per adapter and rename each survivor to its
+# adapter_key. Runs before the sync flips naming to `field:adapter_key`, so the
+# rows are already unique by the time that rule takes effect.
+central.patches.v0_0.one_gateway_per_adapter
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated

--- a/central/patches/v0_0/one_gateway_per_adapter.py
+++ b/central/patches/v0_0/one_gateway_per_adapter.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+"""Collapse Payment Gateway to one row per adapter, named after the adapter.
+
+Gateway rows used to be user-named, so a site could hold several rows for the same
+provider — but nothing could route between them. The webhook spine resolves a
+gateway from the callback URL, and there is one URL per adapter; the currency
+resolvers picked "the first enabled row with this adapter". Duplicates therefore
+resolved arbitrarily. The row is now named after its adapter, which makes the
+duplicate impossible at the database level.
+
+This patch picks a survivor per adapter, folds the losers' currency rows into it,
+repoints every Link that referenced a loser, then renames the survivor to its
+adapter_key. The `title` column is left in place for the DocType sync to drop.
+"""
+
+import frappe
+
+# Every doctype with a Link to Payment Gateway. Renaming the survivor is handled by
+# frappe.rename_doc, but the losers are deleted, so their references must be moved
+# by hand first.
+GATEWAY_LINKS = (
+	"Gateway Customer",
+	"Payment Method",
+	"Payment Attempt",
+	"Webhook Event",
+	"Subscription",
+)
+
+
+def execute():
+	for adapter_key, names in _rows_by_adapter().items():
+		survivor = _pick_survivor(names)
+		for loser in names:
+			if loser == survivor:
+				continue
+			_fold_currencies(loser, survivor)
+			_repoint_links(loser, survivor)
+			frappe.delete_doc("Payment Gateway", loser, force=True, ignore_permissions=True)
+		if survivor != adapter_key:
+			if frappe.db.exists("Payment Gateway", adapter_key):
+				# A row already sits on the target name but carries a different
+				# adapter_key — data we must not silently destroy.
+				frappe.log_error(
+					title="Payment Gateway rename blocked",
+					message=f"Cannot rename {survivor} to {adapter_key}: that name is taken.",
+				)
+				continue
+			frappe.rename_doc("Payment Gateway", survivor, adapter_key, force=True, show_alert=False)
+
+
+def _rows_by_adapter() -> dict[str, list[str]]:
+	rows = frappe.get_all("Payment Gateway", fields=["name", "adapter_key"], order_by="creation asc")
+	by_adapter: dict[str, list[str]] = {}
+	for row in rows:
+		if not row.adapter_key:
+			continue
+		by_adapter.setdefault(row.adapter_key, []).append(row.name)
+	return by_adapter
+
+
+def _pick_survivor(names: list[str]) -> str:
+	"""The row whose credentials the site is actually running on.
+
+	Prefer enabled, then validated, then oldest — the losers' keys are discarded, so
+	this must land on the row that is live today.
+	"""
+	rows = frappe.get_all(
+		"Payment Gateway",
+		filters={"name": ["in", names]},
+		fields=["name", "is_enabled", "credentials_validated_at", "creation"],
+	)
+	rows.sort(key=lambda r: (not r.is_enabled, not r.credentials_validated_at, r.creation))
+	return rows[0].name
+
+
+def _fold_currencies(loser: str, survivor: str):
+	"""Move the loser's currency rows onto the survivor, skipping currencies it
+	already handles. An is_default row wins only if the survivor has no default for
+	that currency — the survivor's own config is authoritative."""
+	survivor_rows = {
+		row.currency: row
+		for row in frappe.get_all(
+			"Payment Gateway Currency",
+			filters={"parent": survivor},
+			fields=["name", "currency", "is_default"],
+		)
+	}
+	for row in frappe.get_all(
+		"Payment Gateway Currency",
+		filters={"parent": loser},
+		fields=["name", "currency", "is_default"],
+	):
+		existing = survivor_rows.get(row.currency)
+		if existing:
+			if row.is_default and not existing.is_default:
+				frappe.db.set_value(
+					"Payment Gateway Currency", existing.name, "is_default", 1, update_modified=False
+				)
+			continue
+		frappe.db.set_value(
+			"Payment Gateway Currency",
+			row.name,
+			{"parent": survivor, "is_default": row.is_default},
+			update_modified=False,
+		)
+		survivor_rows[row.currency] = frappe._dict(
+			name=row.name, currency=row.currency, is_default=row.is_default
+		)
+
+
+def _repoint_links(loser: str, survivor: str):
+	for doctype in GATEWAY_LINKS:
+		if not frappe.db.table_exists(doctype):
+			continue
+		table = frappe.qb.DocType(doctype)
+		frappe.qb.update(table).set(table.gateway, survivor).where(table.gateway == loser).run()


### PR DESCRIPTION
A gateway record is now named after its adapter, so there can only be one Stripe, one Razorpay, one PayPal. The name and title fields are gone; the adapter was already the identity; the other two just let you pretend otherwise.

Multiple records per provider never worked. There is one webhook callback URL per adapter, so an incoming webhook could not say which record it belonged to, and the code picked whichever row the database returned first, meaning it could verify the signature against the wrong secret. The currency resolvers had the same coin-flip. Nothing on the record carries a team, region or country to route on, so there was no way to make two accounts mean anything.

The three records are now seeded on install and migrate. An admin fills in keys and flips Enabled; they never create or delete one. Which currencies a provider settles, and which one it is the default for, stays in the currencies table — that is the part that does route.

Also fixes the currency resolver giving up when a disabled gateway still held the default flag for that currency, and a webhook-registration test that could never have passed

Migration collapses existing duplicates: it keeps the record the site is actually running on (enabled, then validated, then oldest), folds the others' currencies in, repoints every link, and renames the survivor.