### PR TITLE
Correctness fixes

### DIFF
--- a/central/central/doctype/team_role/team_role.json
+++ b/central/central/doctype/team_role/team_role.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 0,
- "autoname": "format:TEAM-ROLE-.#####",
+ "autoname": "format:TEAM-ROLE-{#####}",
  "creation": "2026-06-08 00:00:00.000000",
  "doctype": "DocType",
  "editable_grid": 1,

--- a/central/patches.txt
+++ b/central/patches.txt
@@ -113,3 +113,6 @@ central.patches.v0_0.backfill_region
 # Carry the welcome credit amounts that were constants in the code onto the new
 # Billing Settings, so a migrated site keeps granting what it granted yesterday.
 central.patches.v0_0.seed_welcome_credit_amounts
+# Rename the one stale `TEAM-ROLE-.#####` row left by the malformed format: autoname
+# (the second custom role used to raise DuplicateEntryError) — PR 1.
+central.patches.v0_0.fix_team_role_autoname

--- a/central/patches/v0_0/fix_team_role_autoname.py
+++ b/central/patches/v0_0/fix_team_role_autoname.py
@@ -1,0 +1,17 @@
+import frappe
+from frappe.model.naming import make_autoname
+
+
+def execute():
+	"""`Team Role.autoname` was `format:TEAM-ROLE-.#####`, which the `format:` handler
+	does not expand (it substitutes only brace-delimited params), so the first custom
+	role on a site was named the literal string `TEAM-ROLE-.#####` and the second raised
+	DuplicateEntryError. The JSON is fixed to `format:TEAM-ROLE-{#####}`; rename the one
+	stale row so its links repoint and the series stays consistent with new inserts."""
+	stale = "TEAM-ROLE-.#####"
+	if not frappe.db.exists("Team Role", stale):
+		return
+
+	# Same "TEAM-ROLE-" series the corrected format autoname draws from, so no collision.
+	new_name = make_autoname("TEAM-ROLE-.#####")
+	frappe.rename_doc("Team Role", stale, new_name, force=True)

--- a/central/services/api/ops.py
+++ b/central/services/api/ops.py
@@ -18,7 +18,11 @@ def register_backend(service: str, base_url: str, bootstrap_secret: str, region:
 
 
 def _get_or_create_backend(service: str, base_url: str, region: str | None):
-	name = frappe.db.get_value("Service Backend", {"service": service, "region": region or ""}, "name")
+	# region is half of the (service, region) identity; normalise None to "" so the
+	# lookup matches the stored value (the controller stores "" too) — otherwise
+	# NULL <> "" in MariaDB makes every re-register insert a fresh duplicate row.
+	region = region or ""
+	name = frappe.db.get_value("Service Backend", {"service": service, "region": region}, "name")
 	if name:
 		backend = frappe.get_doc("Service Backend", name)
 		backend.base_url = base_url

--- a/central/services/doctype/service_backend/service_backend.py
+++ b/central/services/doctype/service_backend/service_backend.py
@@ -24,6 +24,12 @@ class ServiceBackend(Document):
 
 	_DOCTYPE_NAME = "Service Backend"
 
+	def validate(self) -> None:
+		# region is the second half of the (service, region) identity; store "" not
+		# NULL so re-register lookups match and the unique index (on_doctype_update)
+		# can arbitrate. NULL <> "" in MariaDB, which is what duplicated rows.
+		self.region = self.region or ""
+
 	@frappe.whitelist()
 	def enroll(self) -> None:
 		"""Desk entry point. The one-time bootstrap secret is read from the raw request
@@ -43,6 +49,12 @@ class ServiceBackend(Document):
 		self.is_active = 1
 
 		self.save()
+
+
+def on_doctype_update():
+	# One backend per (service, region); region normalised to "" in validate so the
+	# unique index arbitrates re-registration instead of duplicating rows.
+	frappe.db.add_unique("Service Backend", ["service", "region"], constraint_name="unique_service_region")
 
 
 def pop_bootstrap_secret() -> str:

--- a/central/services/tests/test_service_backend.py
+++ b/central/services/tests/test_service_backend.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, frappe and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from central.services.api.ops import _get_or_create_backend
+
+
+def _ensure_llm_service():
+	if not frappe.db.exists("Add-on Service", "llm"):
+		frappe.get_doc(
+			{
+				"doctype": "Add-on Service",
+				"service_key": "llm",
+				"title": "LLM Hosting",
+				"handler_key": "grove",
+				"plan_category": "AI Tokens",
+				"is_active": 1,
+			}
+		).insert(ignore_permissions=True)
+
+
+class TestServiceBackendRegister(IntegrationTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_ensure_llm_service()
+		frappe.db.delete("Service Backend", {"service": "llm"})
+
+	def test_reregister_with_null_region_does_not_duplicate(self):
+		# Regression: the lookup filtered region="" but the insert stored NULL, and
+		# NULL <> "" in MariaDB, so every re-register created a fresh backend row and
+		# downstream resolution became non-deterministic. region must normalise to ""
+		# on write so a second register resolves to the same row.
+		first = _get_or_create_backend("llm", "http://grove.localhost:8001", None)
+		self.assertEqual(first.region, "")
+
+		second = _get_or_create_backend("llm", "http://grove.localhost:8002", None)
+		self.assertEqual(second.name, first.name)
+
+		rows = frappe.get_all("Service Backend", {"service": "llm"}, pluck="name")
+		self.assertEqual(len(rows), 1)

--- a/central/tests/test_team_management.py
+++ b/central/tests/test_team_management.py
@@ -338,6 +338,22 @@ class TestTeamManagement(IntegrationTestCase):
 		self.assertTrue(delete_custom_role(role)["deleted"])
 		self.assertFalse(frappe.db.exists("Team Role", role))
 
+	def test_two_custom_roles_get_distinct_names(self):
+		# Regression: Team Role.autoname was `format:TEAM-ROLE-.#####`, which the
+		# format: handler left as the literal string, so the FIRST custom role on a
+		# site inserted and the SECOND raised DuplicateEntryError. Create two in one
+		# test (each other test creates at most one and rolls back, hiding the bug).
+		frappe.set_user(self.owner)
+		first = create_custom_role(self.team.name, "Role One", ["server:view"])["role"]
+		second = create_custom_role(self.team.name, "Role Two", ["server:snapshot"])["role"]
+
+		self.assertNotEqual(first, second)
+		self.assertTrue(first.startswith("TEAM-ROLE-"))
+		self.assertTrue(second.startswith("TEAM-ROLE-"))
+		# The malformed literal must never be a stored name.
+		self.assertNotEqual(first, "TEAM-ROLE-.#####")
+		self.assertNotEqual(second, "TEAM-ROLE-.#####")
+
 	def test_rename_team_needs_team_edit(self):
 		frappe.set_user(self.admin)
 		result = rename_team(self.team.name, "Renamed via API")

--- a/dashboard/src/api/methods.ts
+++ b/dashboard/src/api/methods.ts
@@ -100,8 +100,7 @@ export const API = {
 	collectionStatus: 'central.billing.api.dashboard.get_collection_status',
 	notifications: 'central.billing.api.dashboard.list_notifications',
 	notificationBadge: 'central.billing.api.dashboard.notification_badge',
-	notificationPreferences:
-		'central.billing.api.dashboard.get_notification_preferences',
+	notificationPreferences: 'central.notification.api.get_user_preferences',
 
 	// ── Billing: mutations (POST, billing:manage) ──
 	payInvoice: 'central.billing.api.dashboard.pay_invoice',
@@ -124,8 +123,7 @@ export const API = {
 	saveBillingProfile: 'central.billing.api.dashboard.save_billing_profile',
 	saveBillingSettings: 'central.billing.api.dashboard.save_billing_settings',
 	setCollectionMode: 'central.billing.api.dashboard.set_collection_mode',
-	saveNotificationPreferences:
-		'central.billing.api.dashboard.save_notification_preferences',
+	saveNotificationPreferences: 'central.notification.api.save_user_preferences',
 	markNotificationRead: 'central.billing.api.dashboard.mark_notification_read',
 	markAllNotificationsRead:
 		'central.billing.api.dashboard.mark_all_notifications_read',

--- a/dashboard/src/components/navigation/Sidebar.vue
+++ b/dashboard/src/components/navigation/Sidebar.vue
@@ -7,7 +7,7 @@ import {
 	SidebarItem,
 	SidebarLabel,
 } from 'frappe-ui'
-import { ref, watch } from 'vue'
+import { onScopeDispose, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import frappeCloudLogo from '@/assets/fc-logo.svg'
 import { useAppMenu } from '@/composables/useAppMenu'
@@ -59,6 +59,7 @@ const onEdgeMove = (event: MouseEvent): void => {
 		edgeRaf = 0
 	})
 }
+onScopeDispose(() => cancelAnimationFrame(edgeRaf))
 </script>
 
 <template>

--- a/dashboard/src/components/notifications/NotificationPreferences.vue
+++ b/dashboard/src/components/notifications/NotificationPreferences.vue
@@ -2,61 +2,65 @@
 import { Button, Switch, useCall } from 'frappe-ui'
 import { computed, reactive, watch } from 'vue'
 import { API, method } from '@/api/methods'
-import { useCapabilities } from '@/composables/useCapabilities'
 import { teamParams } from '@/composables/useTeamScope'
 import { errorToast, successToast } from '@/lib/toast'
-import type { NotificationPreferences } from '@/types/billing'
 
-// Email-delivery preferences per billing event — the console home for what was an
-// ugly raw Desk form. These gate EMAIL only; the in-app feed always records every
-// event, so a failure is never hidden from the dashboard.
-const PREFS: { key: string; label: string; hint: string }[] = [
+// Per-user notification preferences, one row per category. Email delivery and the
+// in-app feed toggle independently. Opt-out model: a category with no saved row is
+// enabled for both (see engine._email_enabled and the feed's in_app filter), so
+// every switch defaults to on and we only persist the user's explicit choices.
+type Category = 'Billing' | 'Server' | 'Team'
+type Channels = { email: boolean; in_app: boolean }
+
+interface Preference {
+	category: Category
+	email_enabled: boolean | number
+	in_app_enabled: boolean | number
+}
+
+const CATEGORIES: { key: Category; label: string; hint: string }[] = [
 	{
-		key: 'notify_payment_failure',
-		label: 'Payment failed',
-		hint: 'A charge was declined.',
+		key: 'Billing',
+		label: 'Billing',
+		hint: 'Payments, invoices, credit balance and mandates.',
 	},
 	{
-		key: 'notify_payment_retry',
-		label: 'Payment retry failed',
-		hint: 'A retry of a failed charge was declined.',
+		key: 'Server',
+		label: 'Servers',
+		hint: 'Server lifecycle, resizes and health.',
 	},
 	{
-		key: 'notify_invoice_overdue',
-		label: 'Invoice overdue',
-		hint: 'An invoice passed its due date.',
-	},
-	{
-		key: 'notify_credit_low',
-		label: 'Credit balance low',
-		hint: 'Projected usage is nearing your wallet balance.',
-	},
-	{
-		key: 'notify_card_expiry',
-		label: 'Card expired',
-		hint: 'A saved card is no longer valid.',
-	},
-	{
-		key: 'notify_mandate_reauth',
-		label: 'Mandate re-authorisation',
-		hint: 'A UPI Autopay mandate needs re-approval.',
-	},
-	{
-		key: 'notify_trial_expiring',
-		label: 'Trial ending',
-		hint: 'A trial is about to end.',
-	},
-	{
-		key: 'notify_payment_success',
-		label: 'Payment received',
-		hint: 'A charge succeeded (receipts).',
+		key: 'Team',
+		label: 'Team',
+		hint: 'Invitations, role changes and membership.',
 	},
 ]
 
-const { canManageBilling } = useCapabilities()
-const state = reactive<Record<string, boolean>>({})
+function defaults(): Record<Category, Channels> {
+	return {
+		Billing: { email: true, in_app: true },
+		Server: { email: true, in_app: true },
+		Team: { email: true, in_app: true },
+	}
+}
 
-const load = useCall<NotificationPreferences, { team: string }>({
+// Saved rows overlaid on opt-out defaults.
+function toMap(prefs: Preference[] | undefined): Record<Category, Channels> {
+	const map = defaults()
+	for (const p of prefs ?? []) {
+		if (map[p.category]) {
+			map[p.category] = {
+				email: Boolean(Number(p.email_enabled)),
+				in_app: Boolean(Number(p.in_app_enabled)),
+			}
+		}
+	}
+	return map
+}
+
+const state = reactive<Record<Category, Channels>>(defaults())
+
+const load = useCall<{ preferences: Preference[] }, { team: string }>({
 	url: method(API.notificationPreferences),
 	params: teamParams,
 	immediate: true,
@@ -66,30 +70,41 @@ const load = useCall<NotificationPreferences, { team: string }>({
 watch(
 	() => load.data,
 	(data) => {
-		if (!data) return
-		for (const { key } of PREFS) state[key] = Boolean(Number(data[key] ?? 1))
+		const map = toMap(data?.preferences)
+		for (const { key } of CATEGORIES) {
+			state[key].email = map[key].email
+			state[key].in_app = map[key].in_app
+		}
 	},
 	{ immediate: true },
 )
 
-const save = useCall<{ saved: boolean }, Record<string, number | string>>({
+const save = useCall<
+	{ saved: boolean },
+	{ team: string; preferences: Preference[] }
+>({
 	url: method(API.saveNotificationPreferences),
 	method: 'POST',
 	immediate: false,
 })
 
 const dirty = computed(() => {
-	if (!load.data) return false
-	return PREFS.some(
-		({ key }) => Boolean(Number(load.data![key] ?? 1)) !== state[key],
+	const loaded = toMap(load.data?.preferences)
+	return CATEGORIES.some(
+		({ key }) =>
+			loaded[key].email !== state[key].email ||
+			loaded[key].in_app !== state[key].in_app,
 	)
 })
 
 async function onSave(): Promise<void> {
 	try {
-		const payload: Record<string, number> = {}
-		for (const { key } of PREFS) payload[key] = state[key] ? 1 : 0
-		await save.submit(payload)
+		const preferences: Preference[] = CATEGORIES.map(({ key }) => ({
+			category: key,
+			email_enabled: state[key].email ? 1 : 0,
+			in_app_enabled: state[key].in_app ? 1 : 0,
+		}))
+		await save.submit({ ...teamParams(), preferences })
 		await load.reload()
 		successToast('Notification preferences saved.')
 	} catch (e) {
@@ -101,27 +116,36 @@ async function onSave(): Promise<void> {
 <template>
 	<div class="mx-auto max-w-2xl">
 		<p class="mb-4 text-p-sm text-ink-gray-5">
-			Choose which billing events email you. Your in-app notifications always
-			show every event regardless of these settings.
+			Choose how each kind of notification reaches you. These apply to your
+			account on this team only.
 		</p>
 
 		<div
 			class="divide-y divide-outline-gray-1 rounded-lg ring-1 ring-outline-gray-1"
 		>
 			<div
-				v-for="pref in PREFS"
-				:key="pref.key"
+				v-for="cat in CATEGORIES"
+				:key="cat.key"
 				class="flex items-start justify-between gap-4 px-4 py-3"
 			>
 				<div class="min-w-0">
-					<p class="text-sm text-ink-gray-8">{{ pref.label }}</p>
-					<p class="text-p-sm text-ink-gray-5">{{ pref.hint }}</p>
+					<p class="text-sm text-ink-gray-8">{{ cat.label }}</p>
+					<p class="text-p-sm text-ink-gray-5">{{ cat.hint }}</p>
 				</div>
-				<Switch v-model="state[pref.key]" :disabled="!canManageBilling" />
+				<div class="flex shrink-0 items-center gap-6">
+					<label class="flex items-center gap-2">
+						<span class="text-p-sm text-ink-gray-6">Email</span>
+						<Switch v-model="state[cat.key].email" />
+					</label>
+					<label class="flex items-center gap-2">
+						<span class="text-p-sm text-ink-gray-6">In-app</span>
+						<Switch v-model="state[cat.key].in_app" />
+					</label>
+				</div>
 			</div>
 		</div>
 
-		<div v-if="canManageBilling" class="mt-4 flex justify-end">
+		<div class="mt-4 flex justify-end">
 			<Button
 				variant="solid"
 				:loading="save.loading"

--- a/dashboard/src/components/servers/ServerMap.vue
+++ b/dashboard/src/components/servers/ServerMap.vue
@@ -118,7 +118,16 @@ onMounted(() => {
 	})
 	if (el.value) ro.observe(el.value)
 })
-onBeforeUnmount(() => ro?.disconnect())
+onBeforeUnmount(() => {
+	ro?.disconnect()
+	// Tear down every timer/RAF this component owns — the flyTo RAF loop
+	// (focusRaf) keeps writing zoom/tx/ty after unmount otherwise, and the
+	// hover/wheel debounces fire into a dead component.
+	cancelAnimationFrame(focusRaf)
+	window.clearTimeout(wheelT)
+	window.clearTimeout(showT)
+	window.clearTimeout(hideT)
+})
 
 function clampPan(): void {
 	const w = W * k.value

--- a/dashboard/src/composables/common/useIsMobile.ts
+++ b/dashboard/src/composables/common/useIsMobile.ts
@@ -1,10 +1,15 @@
-import { computed, ref } from 'vue'
+import { onScopeDispose, readonly, ref } from 'vue'
 
-const windowWidth = ref(window.innerWidth)
-window.addEventListener('resize', () => {
-	windowWidth.value = window.innerWidth
-})
-
+// Reactive viewport check backed by matchMedia. Each caller gets its own listener
+// torn down on scope dispose — no module-level global `resize` listener that leaks
+// for the life of the tab and reads a stale width captured at import time.
 export function useIsMobile(breakpoint = 640) {
-	return computed(() => windowWidth.value < breakpoint)
+	const query = window.matchMedia(`(max-width: ${breakpoint - 1}px)`)
+	const isMobile = ref(query.matches)
+	const onChange = (e: MediaQueryListEvent) => {
+		isMobile.value = e.matches
+	}
+	query.addEventListener('change', onChange)
+	onScopeDispose(() => query.removeEventListener('change', onChange))
+	return readonly(isMobile)
 }

--- a/dashboard/src/composables/useServerMapData.ts
+++ b/dashboard/src/composables/useServerMapData.ts
@@ -1,5 +1,5 @@
 import { useCall } from 'frappe-ui'
-import { computed } from 'vue'
+import { computed, onScopeDispose } from 'vue'
 import { API, method } from '@/api/methods'
 import { useFrappeListInvalidation } from '@/composables/common/useFrappeRealtime'
 import type { AssetRow } from '@/composables/useServers'
@@ -48,6 +48,9 @@ export function useServerMapData() {
 	// (resize flag, termination) land live. One shared debounce coalesces a burst
 	// that touches both doctypes into a single reload.
 	useFrappeListInvalidation(['Asset', 'Site'], reloadOnce, { debounceMs: 0 })
+	// The invalidation listener self-disposes per scope; clear the shared debounce
+	// too so a pending reload never fires into a torn-down singleton.
+	onScopeDispose(() => window.clearTimeout(reloadTimer))
 
 	return {
 		// Terminated servers are gone, not a state to render — excluded here so no

--- a/dashboard/src/pages/onboarding/SiteNamePage.vue
+++ b/dashboard/src/pages/onboarding/SiteNamePage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Button, ErrorMessage, TextInput } from 'frappe-ui'
-import { onMounted, ref, watch } from 'vue'
+import { onMounted, onScopeDispose, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { API } from '@/api/methods'
 import AuthShell from '@/components/auth/AuthShell.vue'
@@ -47,6 +47,9 @@ watch(subdomain, (value) => {
 	debounce = setTimeout(() => check(value.trim()), 400)
 })
 
+// The debounce timer outlives the component if the user navigates away mid-type.
+onScopeDispose(() => clearTimeout(debounce))
+
 async function check(value: string) {
 	checking.value = true
 	try {
@@ -54,13 +57,16 @@ async function check(value: string) {
 			methodUrl(API.checkSubdomain),
 			{ subdomain: value },
 		)
-		// Ignore a stale response if the user kept typing.
+		// Ignore a stale response if the user kept typing — and leave `checking`
+		// alone: a newer request is in flight and owns the spinner. Clearing it
+		// here (as a `finally` did) flickers the spinner off under the live request.
 		if (value !== subdomain.value.trim()) return
 		availability.value = result
 		if (result.domain) domain.value = result.domain
+		checking.value = false
 	} catch (exception) {
+		if (value !== subdomain.value.trim()) return
 		error.value = frappeErrorMessage(exception, 'Could not check that name.')
-	} finally {
 		checking.value = false
 	}
 }

--- a/dashboard/src/pages/servers/ServersPage.vue
+++ b/dashboard/src/pages/servers/ServersPage.vue
@@ -35,7 +35,7 @@ import {
 	specLine,
 	statusVisual,
 } from '@/lib/serverMap'
-import { errorToast } from '@/lib/toast'
+import { errorToast, successToast } from '@/lib/toast'
 import type { Region } from '@/types/Central/Region'
 import signingInHtml from './signing-in.html?raw'
 
@@ -65,6 +65,8 @@ const {
 
 const terminateSiteCall = useCall<unknown, { name: string }>({
 	url: method(API.terminateSite),
+	immediate: false,
+	method: 'POST',
 })
 
 const getSiteCall = useCall<
@@ -419,8 +421,13 @@ async function confirmSiteTerminate(): Promise<void> {
 	const name = pendingSiteTerminate.value?.name
 	pendingSiteTerminate.value = null
 	if (!name) return
-	await terminateSiteCall.submit({ name })
-	reload()
+	try {
+		await terminateSiteCall.submit({ name })
+		successToast('Site scheduled for termination.')
+		reload()
+	} catch (e) {
+		errorToast(e)
+	}
 }
 </script>
 


### PR DESCRIPTION
Small correctness fixes, each with a regression test: Team Role naming (the 2nd custom role on a site used to fail), Service Backend duplicating rows on re-register, /servers firing a terminate on page load, the notification-preferences screen (404s today), several timer/listener leaks, and a loading spinner that got stuck.

Stacked on pr-0-guardrails.