### PR TITLE
Index hot query columns

### DIFF
--- a/central/central/doctype/asset/asset.json
+++ b/central/central/doctype/asset/asset.json
@@ -51,7 +51,8 @@
    "in_standard_filter": 1,
    "label": "Team",
    "options": "Team",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "description": "The cluster (Atlas Instance / region) this VM lives in.",
@@ -61,7 +62,8 @@
    "in_standard_filter": 1,
    "label": "Cluster",
    "options": "Atlas Instance",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "plan",
@@ -72,7 +74,7 @@
    "options": "Plan"
   },
   {
-   "description": "Frappe version the VM was provisioned with — requested at create, resolved to a bench image and echoed back by Atlas (an unbuilt version falls back to the default).",
+   "description": "Frappe version the VM was provisioned with \u2014 requested at create, resolved to a bench image and echoed back by Atlas (an unbuilt version falls back to the default).",
    "fieldname": "frappe_version",
    "fieldtype": "Data",
    "label": "Frappe Version",

--- a/central/central/doctype/atlas_instance/atlas_instance.json
+++ b/central/central/doctype/atlas_instance/atlas_instance.json
@@ -67,7 +67,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "Atlas admin API key; Central authenticates with it for every Central→Atlas call.",
+   "description": "Atlas admin API key; Central authenticates with it for every Central\u2192Atlas call.",
    "fieldname": "api_key",
    "fieldtype": "Data",
    "label": "Admin API Key",
@@ -95,7 +95,7 @@
   },
   {
    "default": "Unregistered",
-   "description": "Unregistered → Provisioning → Active; Inactive = registered but tunnel stripped down.",
+   "description": "Unregistered \u2192 Provisioning \u2192 Active; Inactive = registered but tunnel stripped down.",
    "fieldname": "tunnel_status",
    "fieldtype": "Select",
    "in_list_view": 1,
@@ -124,7 +124,8 @@
    "fieldtype": "Link",
    "label": "Service User",
    "options": "User",
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "column_break_tunnel",

--- a/central/central/doctype/iam_permission_probe/iam_permission_probe.json
+++ b/central/central/doctype/iam_permission_probe/iam_permission_probe.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 0,
-"autoname": "format:IAM-PROBE-{#####}",
+ "autoname": "format:IAM-PROBE-{#####}",
  "creation": "2026-06-08 00:00:00.000000",
  "doctype": "DocType",
  "editable_grid": 0,
@@ -22,7 +22,8 @@
    "in_list_view": 1,
    "label": "User",
    "options": "User",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "team",
@@ -30,7 +31,8 @@
    "in_list_view": 1,
    "label": "Team",
    "options": "Team",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "capability",
@@ -38,7 +40,8 @@
    "in_list_view": 1,
    "label": "Capability",
    "options": "Capability",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "column_break_result",

--- a/central/central/doctype/pilot_credential/pilot_credential.json
+++ b/central/central/doctype/pilot_credential/pilot_credential.json
@@ -18,7 +18,7 @@
  ],
  "fields": [
   {
-   "description": "Central-minted identity of this pilot→Central credential; Atlas echoes it back on events.",
+   "description": "Central-minted identity of this pilot\u2192Central credential; Atlas echoes it back on events.",
    "fieldname": "pilot_credential_id",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -42,7 +42,8 @@
    "fieldtype": "Link",
    "in_standard_filter": 1,
    "label": "Asset",
-   "options": "Asset"
+   "options": "Asset",
+   "search_index": 1
   },
   {
    "description": "The bench's audience id (its VM resource_id), stamped into the `aud` of every token Central mints for it. Set at enrollment; independent of the Asset link so it survives mirror lag.",

--- a/central/central/doctype/site/site.json
+++ b/central/central/doctype/site/site.json
@@ -21,7 +21,7 @@
  ],
  "fields": [
   {
-   "description": "The site FQDN in Atlas (the source of truth) — the one routing identity.",
+   "description": "The site FQDN in Atlas (the source of truth) \u2014 the one routing identity.",
    "fieldname": "site_name",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -45,7 +45,8 @@
    "in_standard_filter": 1,
    "label": "Team",
    "options": "Team",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "description": "The cluster (Atlas Instance / region) this site lives in.",
@@ -82,7 +83,7 @@
    "read_only": 1
   },
   {
-   "description": "The hosting bench's pilot credential / JWT audience — set at create_site, the key for a Central-minted site login.",
+   "description": "The hosting bench's pilot credential / JWT audience \u2014 set at create_site, the key for a Central-minted site login.",
    "fieldname": "pilot_credential_id",
    "fieldtype": "Data",
    "label": "Pilot Credential ID",

--- a/central/central/doctype/team_invitation/team_invitation.json
+++ b/central/central/doctype/team_invitation/team_invitation.json
@@ -34,6 +34,7 @@
    "in_standard_filter": 1,
    "label": "Email",
    "reqd": 1,
+   "search_index": 1,
    "set_only_once": 1
   },
   {
@@ -43,6 +44,7 @@
    "label": "Team Role",
    "options": "Team Role",
    "reqd": 1,
+   "search_index": 1,
    "set_only_once": 1
   },
   {

--- a/central/central/doctype/team_member/team_member.json
+++ b/central/central/doctype/team_member/team_member.json
@@ -18,7 +18,8 @@
    "in_list_view": 1,
    "label": "User",
    "options": "User",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "role",
@@ -26,7 +27,8 @@
    "in_list_view": 1,
    "label": "Role",
    "options": "Team Role",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "default": "*",

--- a/central/central/doctype/team_role/team_role.json
+++ b/central/central/doctype/team_role/team_role.json
@@ -36,7 +36,8 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Team",
-   "options": "Team"
+   "options": "Team",
+   "search_index": 1
   },
   {
    "fieldname": "capabilities",


### PR DESCRIPTION
Add database indexes on the 13 columns that permission-gated reads filter on but that weren't indexed — the hottest being Team Member.user, hit on every permission check.

Stacked on pr-3-frontend-deadcode.