### PR TITLE
Notification engine + backend boundaries

### DIFF
--- a/central/api/auth.py
+++ b/central/api/auth.py
@@ -5,8 +5,6 @@ import secrets
 import frappe
 from frappe import _
 from frappe.utils import cint, escape_html, random_string
-from frappe.utils.oauth import get_oauth2_authorize_url, get_oauth_keys
-from frappe.utils.password import get_decrypted_password
 
 from central.iam import get_user_team_names
 from central.users import CENTRAL_USER_ROLE
@@ -160,56 +158,6 @@ def _signup_roles() -> list[str]:
 	if default_role and default_role not in roles:
 		roles.append(default_role)
 	return roles
-
-
-def build_auth_context() -> dict:
-	return {
-		"user": frappe.session.user or "Guest",
-		"provider_logins": _provider_logins(),
-		"onboarding_complete": _onboarding_complete(),
-	}
-
-
-def _onboarding_complete() -> bool:
-	"""True once the user's team owns a live site — the signal the SPA uses to keep a
-	brand-new user inside the onboarding funnel (and let a returning one skip it).
-	A first-run user (no team or no site yet) is still onboarding."""
-	user = frappe.session.user
-	if not user or user == "Guest":
-		return False
-	teams = get_user_team_names(user)
-	if not teams:
-		return False
-	return bool(frappe.db.exists("Site", {"team": ["in", teams], "status": ["!=", "Terminated"]}))
-
-
-def _provider_logins() -> list[dict[str, str]]:
-	providers = frappe.get_all(
-		"Social Login Key",
-		filters={"enable_social_login": 1},
-		fields=["name", "client_id", "base_url", "provider_name", "icon"],
-		order_by="name",
-	)
-	return [
-		{
-			"name": provider.name,
-			"label": provider.provider_name,
-			"icon": provider.icon or "",
-			"auth_url": get_oauth2_authorize_url(provider.name, "/dashboard/servers"),
-		}
-		for provider in providers
-		if _provider_is_configured(provider)
-	]
-
-
-def _provider_is_configured(provider) -> bool:
-	client_secret = get_decrypted_password(
-		"Social Login Key",
-		provider.name,
-		"client_secret",
-		raise_exception=False,
-	)
-	return bool(provider.client_id and client_secret and provider.base_url and get_oauth_keys(provider.name))
 
 
 def _enforce_signup_limit() -> None:

--- a/central/api/servers.py
+++ b/central/api/servers.py
@@ -261,43 +261,32 @@ def _overview_asset_row(resource_id: str, team: str):
 
 
 def _overview_plan(asset: dict, team: str) -> dict:
-	"""Tier name + billed rate — scoped to this asset, not the team's full run-rate."""
+	"""Tier name + billed rate — scoped to this asset, not the team's full run-rate.
+
+	Reads the asset's open priced segment through the billing seam
+	(`active_segment_for_resource`) rather than querying Subscription / Subscription
+	Change and re-deriving the ledger's open-segment rule here — servers does not own
+	how a segment resolves from the billing ledger."""
+	from central.billing.catalog.subscriptions import active_segment_for_resource
+
 	currency = frappe.db.get_value("Billing Profile", team, "currency") or "INR"
 	billing_cycle = "Monthly"
 	title = None
 	rate = None
 	plan_name = asset.plan
 
-	subscription = frappe.qb.DocType("Subscription")
-	change = frappe.qb.DocType("Subscription Change")
-	segment_rows = (
-		frappe.qb.from_(subscription)
-		.left_join(change)
-		.on(
-			(change.subscription == subscription.name)
-			& (change.change_type.isin(("Created", "Plan Changed", "Cancelled")))
-		)
-		.select(
-			subscription.plan,
-			change.change_type,
-			change.locked_rate,
-			change.currency,
-			change.effective_at,
-			change.creation,
-		)
-		.where(subscription.asset_id == asset.resource_id)
-		.orderby(change.effective_at, order=frappe.qb.desc)
-		.orderby(change.creation, order=frappe.qb.desc)
-		.limit(1)
-		.run(as_dict=True)
-	)
-	if segment_rows:
-		segment = segment_rows[0]
+	segment = active_segment_for_resource(asset.resource_id)
+	if segment:
 		plan_name = segment.plan or plan_name
-		if plan_name and segment.change_type and segment.change_type != "Cancelled":
-			if segment.locked_rate is not None:
-				rate = frappe.utils.flt(segment.locked_rate)
+		# Only adopt the segment's currency/rate once a plan is attached: an Asset can
+		# open a Subscription during bootstrap before a plan exists, and that segment
+		# has no meaningful price to show (keep the profile-default currency then).
+		if plan_name:
 			currency = segment.currency or currency
+			# A priced open segment carries a locked_rate; an unpriced one (0/None)
+			# falls through to the catalog rate below.
+			if segment.locked_rate:
+				rate = frappe.utils.flt(segment.locked_rate)
 
 	if plan_name:
 		plan = frappe.db.get_value("Plan", plan_name, ["title", "billing_cycle"], as_dict=True)

--- a/central/api/site_login.py
+++ b/central/api/site_login.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, frappe and contributors
+# For license information, please see license.txt
+"""The self-serve Site one-click login-URL freshness policy.
+
+Extracted from `api/sites.py` so the endpoints there stay thin: this owns how a
+usable login URL is obtained — prefer a Central-signed assertion the site's own
+pilot exchanges (no Atlas hop), else the stored URL if still fresh, else an
+Atlas-regenerated one — and the 24h-session expiry handling that goes with it.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+from central.integrations.atlas import AtlasClient
+from central.integrations.pilot import fetch_site_login_url
+
+
+def site_login_url(doc) -> str | None:
+	"""Prefer a Central-signed assertion the site's own pilot exchanges (no Atlas hop);
+	fall back to Atlas's regenerated URL when the pilot isn't enrolled or reachable yet."""
+	return _pilot_site_login_url(doc) or _fresh_site_login_url(doc)
+
+
+def _pilot_site_login_url(doc) -> str | None:
+	"""Relay a Central-signed assertion to the site's own pilot, which returns a desk URL with a
+	fresh local session. Resolves the hosting bench's audience + gateway from the credential
+	Central bound at create_site; None (→ Atlas fallback) until the pilot enrolled and its VM is
+	Running."""
+	if not doc.pilot_credential_id:
+		return None
+	credential = frappe.qb.DocType("Pilot Credential")
+	asset = frappe.qb.DocType("Asset")
+	row = (
+		frappe.qb.from_(credential)
+		.inner_join(asset)
+		.on(credential.asset == asset.name)
+		.select(credential.audience_id, asset.gateway_url, asset.status)
+		.where((credential.name == doc.pilot_credential_id) & (credential.status == "Active"))
+	).run(as_dict=True)
+	if not row or row[0].status != "Running":
+		return None
+	gateway = (row[0].gateway_url or "").rstrip("/")
+	if not gateway:
+		return None
+	return fetch_site_login_url(gateway, row[0].audience_id, doc.name)
+
+
+def _fresh_site_login_url(doc) -> str | None:
+	"""The site's usable one-click login URL: the stored one if it hasn't expired,
+	else a freshly-regenerated one. The URL is a short-lived (24h) session, so a
+	tenant who lands on a stale mirror row would otherwise get a dead link — we
+	re-mint on read instead. Best-effort: if the regenerate call fails (Atlas
+	unreachable), fall back to the stored URL rather than blocking the handoff."""
+	if doc.login_url and not _login_url_expired(doc.login_url_expires_at):
+		return doc.login_url
+	try:
+		return _regenerate_site_login(doc.name, doc.cluster).get("login_url") or doc.login_url
+	except Exception:
+		frappe.log_error(title=f"Regenerate login failed for site {doc.name}")
+		return doc.login_url or None
+
+
+def _login_url_expired(expires_at) -> bool:
+	"""True if a stored login URL is at/past its expiry (or carries no expiry — treat
+	an unstamped URL as unusable and force a regenerate). A small skew guard trims the
+	tail so we don't hand out a URL that dies mid-click."""
+	if not expires_at:
+		return True
+	skew = frappe.utils.add_to_date(frappe.utils.now_datetime(), seconds=30)
+	return frappe.utils.get_datetime(expires_at) <= skew
+
+
+def _regenerate_site_login(name: str, cluster: str) -> dict:
+	"""Ask Atlas to re-mint the site's login URL, re-mirror the fresh handoff, and
+	return it. The Atlas Site controller re-signs the session in the guest and returns
+	the Site-mirror shape; we upsert it so the stored URL + expiry stay in lockstep."""
+	from central.central.doctype.site.site import Site
+
+	instance = frappe.get_doc("Atlas Instance", cluster)
+	fresh = AtlasClient(instance).regenerate_site_login(name)
+	Site.mirror_site(cluster, fresh, synced_at=frappe.utils.now_datetime())
+	return fresh

--- a/central/api/sites.py
+++ b/central/api/sites.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import frappe
 from frappe import _
 
+from central.api.site_login import site_login_url
 from central.iam import can, get_user_team_names, resolve_team
 from central.integrations.atlas import AtlasClient
-from central.integrations.pilot import fetch_site_login_url
 
 # Self-serve site endpoints for the SMB onboarding flow. Reads come from the Site
 # mirror (kept fresh by the site.* events Atlas pushes); writes go to Atlas as the
@@ -84,75 +84,8 @@ def get_site(name: str) -> dict:
 		"name": doc.name,
 		"status": doc.status,
 		"url": doc.url if running else None,
-		"login_url": _site_login_url(doc) if running else None,
+		"login_url": site_login_url(doc) if running else None,
 	}
-
-
-def _site_login_url(doc) -> str | None:
-	"""Prefer a Central-signed assertion the site's own pilot exchanges (no Atlas hop);
-	fall back to Atlas's regenerated URL when the pilot isn't enrolled or reachable yet."""
-	return _pilot_site_login_url(doc) or _fresh_site_login_url(doc)
-
-
-def _pilot_site_login_url(doc) -> str | None:
-	"""Relay a Central-signed assertion to the site's own pilot, which returns a desk URL with a
-	fresh local session. Resolves the hosting bench's audience + gateway from the credential
-	Central bound at create_site; None (→ Atlas fallback) until the pilot enrolled and its VM is
-	Running."""
-	if not doc.pilot_credential_id:
-		return None
-	credential = frappe.qb.DocType("Pilot Credential")
-	asset = frappe.qb.DocType("Asset")
-	row = (
-		frappe.qb.from_(credential)
-		.inner_join(asset)
-		.on(credential.asset == asset.name)
-		.select(credential.audience_id, asset.gateway_url, asset.status)
-		.where((credential.name == doc.pilot_credential_id) & (credential.status == "Active"))
-	).run(as_dict=True)
-	if not row or row[0].status != "Running":
-		return None
-	gateway = (row[0].gateway_url or "").rstrip("/")
-	if not gateway:
-		return None
-	return fetch_site_login_url(gateway, row[0].audience_id, doc.name)
-
-
-def _fresh_site_login_url(doc) -> str | None:
-	"""The site's usable one-click login URL: the stored one if it hasn't expired,
-	else a freshly-regenerated one. The URL is a short-lived (24h) session, so a
-	tenant who lands on a stale mirror row would otherwise get a dead link — we
-	re-mint on read instead. Best-effort: if the regenerate call fails (Atlas
-	unreachable), fall back to the stored URL rather than blocking the handoff."""
-	if doc.login_url and not _login_url_expired(doc.login_url_expires_at):
-		return doc.login_url
-	try:
-		return _regenerate_site_login(doc.name, doc.cluster).get("login_url") or doc.login_url
-	except Exception:
-		frappe.log_error(title=f"Regenerate login failed for site {doc.name}")
-		return doc.login_url or None
-
-
-def _login_url_expired(expires_at) -> bool:
-	"""True if a stored login URL is at/past its expiry (or carries no expiry — treat
-	an unstamped URL as unusable and force a regenerate). A small skew guard trims the
-	tail so we don't hand out a URL that dies mid-click."""
-	if not expires_at:
-		return True
-	skew = frappe.utils.add_to_date(frappe.utils.now_datetime(), seconds=30)
-	return frappe.utils.get_datetime(expires_at) <= skew
-
-
-def _regenerate_site_login(name: str, cluster: str) -> dict:
-	"""Ask Atlas to re-mint the site's login URL, re-mirror the fresh handoff, and
-	return it. The Atlas Site controller re-signs the session in the guest and returns
-	the Site-mirror shape; we upsert it so the stored URL + expiry stay in lockstep."""
-	from central.central.doctype.site.site import Site
-
-	instance = frappe.get_doc("Atlas Instance", cluster)
-	fresh = AtlasClient(instance).regenerate_site_login(name)
-	Site.mirror_site(cluster, fresh, synced_at=frappe.utils.now_datetime())
-	return fresh
 
 
 @frappe.whitelist(methods=["GET"])

--- a/central/notification/__init__.py
+++ b/central/notification/__init__.py
@@ -17,6 +17,8 @@ on ``Team Notification``.
 """
 
 import frappe
+from frappe.query_builder import Criterion, Order
+from frappe.query_builder.functions import Count
 
 CATEGORIES = ("Billing", "Server", "Team")
 SEVERITIES = ("Info", "Success", "Warning", "Error")
@@ -68,60 +70,68 @@ def create_notification(
 	return doc
 
 
-def _read_notification_names(team: str, user: str) -> set[str]:
-	"""Return the set of notification names the user has read for *team*."""
-	return set(
-		frappe.get_all(
-			"Notification Read",
-			filters={"user": user},
-			fields=["notification"],
-			pluck="notification",
-		)
+_FEED_FIELDS = (
+	"name",
+	"category",
+	"event_type",
+	"severity",
+	"required_cap",
+	"title",
+	"message",
+	"reference_doctype",
+	"reference_name",
+	"action_label",
+	"action_route",
+	"creation",
+)
+
+
+def _visible_conditions(tn, team: str, user: str, category: str | None) -> list:
+	"""WHERE criteria for the notifications a user may see in a team's feed — shared
+	by the list and the unread count so they never disagree: the team, an optional
+	category, the per-row capability gate (skipped for operators), and the user's
+	in-app category preferences. ``resolve_user_grants`` is request-cached, so the
+	cap set costs one join per request, not one per row."""
+	from central.iam import resolve_user_grants, user_has_operator_bypass
+
+	conds = [tn.team == team]
+	if category:
+		conds.append(tn.category == category)
+	if user_has_operator_bypass(user):
+		return conds
+
+	caps = sorted({cap for grant in resolve_user_grants(user).get(team, []) for cap in grant.get("caps", [])})
+	cap_gate = tn.required_cap.isnull() | (tn.required_cap == "")
+	if caps:
+		cap_gate = cap_gate | tn.required_cap.isin(caps)
+	conds.append(cap_gate)
+
+	disabled = frappe.get_all(
+		"User Notification Preference",
+		filters={"user": user, "team": team, "in_app_enabled": 0},
+		pluck="category",
 	)
-
-
-def _unread_notifications(team: str, user: str) -> list[str]:
-	"""Return notification names the user has NOT read (capability-filtered)."""
-	from central.iam import can, user_has_operator_bypass
-
-	read_names = _read_notification_names(team, user)
-	filters = {"team": team}
-
-	rows = frappe.get_all(
-		"Team Notification",
-		filters=filters,
-		fields=["name", "category", "required_cap"],
-	)
-
-	if not user_has_operator_bypass(user):
-		rows = [row for row in rows if not row.required_cap or can(user, team, row.required_cap)]
-
-	if rows:
-		categories = {row.category for row in rows}
-		disabled_categories = set(
-			frappe.db.get_all(
-				"User Notification Preference",
-				filters={
-					"user": user,
-					"team": team,
-					"in_app_enabled": 0,
-					"category": ["in", list(categories)],
-				},
-				pluck="category",
-			)
-		)
-		rows = [row for row in rows if row.category not in disabled_categories]
-
-	return [row.name for row in rows if row.name not in read_names]
+	if disabled:
+		conds.append(tn.category.notin(disabled))
+	return conds
 
 
 def unread_count(team: str, *, user: str | None = None) -> int:
 	"""Unread in-app notifications for a team, per-user — the bell badge count.
 
-	Read state is per-user via ``Notification Read``.
-	"""
+	One indexed COUNT: the visible-notification filter, LEFT JOINed to the per-user
+	``Notification Read`` and kept to rows the user hasn't read."""
 	user = user or frappe.session.user
-	return len(_unread_notifications(team, user))
+	tn = frappe.qb.DocType("Team Notification")
+	nr = frappe.qb.DocType("Notification Read")
+	return (
+		frappe.qb.from_(tn)
+		.left_join(nr)
+		.on((nr.notification == tn.name) & (nr.user == user))
+		.select(Count("*"))
+		.where(Criterion.all(_visible_conditions(tn, team, user, None)))
+		.where(nr.name.isnull())
+	).run()[0][0]
 
 
 def list_notifications(
@@ -132,70 +142,32 @@ def list_notifications(
 	category: str | None = None,
 	unread_only: bool = False,
 ) -> dict:
-	"""The team's notification feed, filtered per-user.
+	"""The team's notification feed, filtered per-user, newest first.
 
-	Only notifications whose ``required_cap`` the user possesses (or which
-	have no ``required_cap``) are returned.  Operators see everything.
-
-	Read state is per-user (``Notification Read``), not the team-global
-	``is_read`` flag.
-	"""
-	from central.iam import can, user_has_operator_bypass
-
+	One indexed query: the visible-notification filter (team, per-row capability,
+	in-app category preference) is pushed into SQL — so ``limit`` is exact, never an
+	over-fetch that could silently under-return — LEFT JOINed to the per-user
+	``Notification Read`` for read state. Read state is per-user, not the shared
+	``is_read`` flag. Operators see everything."""
 	user = user or frappe.session.user
-	filters = {"team": team}
-	if category:
-		filters["category"] = category
+	limit = frappe.utils.cint(limit)
+	tn = frappe.qb.DocType("Team Notification")
+	nr = frappe.qb.DocType("Notification Read")
 
-	items = frappe.get_all(
-		"Team Notification",
-		filters=filters,
-		fields=[
-			"name",
-			"category",
-			"event_type",
-			"severity",
-			"required_cap",
-			"title",
-			"message",
-			"reference_doctype",
-			"reference_name",
-			"action_label",
-			"action_route",
-			"creation",
-		],
-		order_by="creation desc",
-		limit=frappe.utils.cint(limit) * 3,
+	query = (
+		frappe.qb.from_(tn)
+		.left_join(nr)
+		.on((nr.notification == tn.name) & (nr.user == user))
+		.select(*(getattr(tn, f) for f in _FEED_FIELDS), nr.name.as_("_read_marker"))
+		.where(Criterion.all(_visible_conditions(tn, team, user, category)))
+		.orderby(tn.creation, order=Order.desc)
+		.limit(limit)
 	)
-
-	is_operator = user_has_operator_bypass(user)
-	if not is_operator:
-		items = [row for row in items if not row.required_cap or can(user, team, row.required_cap)]
-
-		categories = {row.category for row in items}
-		if categories:
-			disabled_categories = set(
-				frappe.db.get_all(
-					"User Notification Preference",
-					filters={
-						"user": user,
-						"team": team,
-						"in_app_enabled": 0,
-						"category": ["in", list(categories)],
-					},
-					pluck="category",
-				)
-			)
-			items = [row for row in items if row.category not in disabled_categories]
-
-	read_names = _read_notification_names(team, user)
-	for row in items:
-		row["is_read"] = 1 if row.name in read_names else 0
-
 	if frappe.utils.cint(unread_only):
-		items = [row for row in items if row.name not in read_names]
+		query = query.where(nr.name.isnull())
 
-	return {
-		"items": items[: frappe.utils.cint(limit)],
-		"unread": unread_count(team, user=user),
-	}
+	items = query.run(as_dict=True)
+	for row in items:
+		row["is_read"] = 1 if row.pop("_read_marker", None) else 0
+
+	return {"items": items, "unread": unread_count(team, user=user)}

--- a/central/notification/api.py
+++ b/central/notification/api.py
@@ -107,8 +107,15 @@ def report_pilot_event(
 
 	Delegates to the notification engine. The team is resolved from the
 	authenticated pilot credential — never from the request body.
+
+	A pilot may only raise Server-domain events (the infra events a bench observes).
+	Billing/Team event types are Central-originated, so refusing them here stops a
+	compromised or buggy bench from fanning out, e.g., a payment_failure email to the
+	whole team. An unknown event type has no category and is refused too.
 	"""
 	team = frappe.local.pilot_credential.team
+	if frappe.db.get_value("Notification Event Type", event_type, "category") != "Server":
+		frappe.throw(_("This event type cannot be reported by a pilot."), frappe.PermissionError)
 	from central.notification.engine import dispatch
 
 	return dispatch(

--- a/central/notification/engine.py
+++ b/central/notification/engine.py
@@ -57,25 +57,25 @@ def dispatch(
 
 	doc = None
 	if event.create_in_app:
-		doc = frappe.get_doc(
-			{
-				"doctype": "Team Notification",
-				"team": team,
-				"category": event.category,
-				"event_type": event_type,
-				"severity": event.severity,
-				"required_cap": event.required_cap,
-				"title": title,
-				"message": body,
-				"reference_doctype": reference_doctype,
-				"reference_name": reference_name,
-				"action_label": event.action_label,
-				"action_route": _render_template(event.action_route, ctx) if event.action_route else None,
-				"is_read": 0,
-			}
-		).insert(ignore_permissions=True)
+		# One writer: dispatch resolves the event type from the registry, then hands
+		# the row to create_notification (the single Team Notification insert) rather
+		# than building its own — so there is one insert path, not two.
+		from central.notification import create_notification
 
-		publish_team_nudge(team)
+		doc = create_notification(
+			team,
+			title,
+			category=event.category,
+			event_type=event_type,
+			severity=event.severity,
+			required_cap=event.required_cap,
+			message=body,
+			reference_doctype=reference_doctype,
+			reference_name=reference_name,
+			action_label=event.action_label,
+			action_route=_render_template(event.action_route, ctx) if event.action_route else None,
+			publish=True,
+		)
 
 	email_result = _fan_out_emails(
 		team,

--- a/central/notification/engine.py
+++ b/central/notification/engine.py
@@ -363,6 +363,9 @@ def _send_member_email(
 			subject = rendered["subject"]
 			body = rendered["message"]
 		except Exception:
+			# A broken Email Template shouldn't silently downgrade to the in-app copy
+			# with no trace — log why, then fall back.
+			frappe.log_error(title=f"Notification email template render failed: {event.event_type}")
 			subject = _render_template(event.in_app_title, ctx) or event.event_type
 			body = message or _render_template(event.in_app_body, ctx) or ctx.get("message", "")
 	else:
@@ -377,4 +380,7 @@ def _send_member_email(
 		)
 		return True
 	except Exception:
+		# Best-effort delivery, but never fail silently — a missing outgoing account
+		# or a send error must leave a trace to diagnose (retry/backoff is a later phase).
+		frappe.log_error(title=f"Notification email send failed: {event.event_type} -> {user}")
 		return False

--- a/central/notification/tests/test_engine.py
+++ b/central/notification/tests/test_engine.py
@@ -582,6 +582,30 @@ class TestReportPilotEvent(EngineTestBase):
 		self.assertEqual(rows[0].reference_name, "my-site")
 		self.assertEqual(rows[0].required_cap, "server:view")
 
+	def test_pilot_event_refuses_non_server_category(self):
+		"""A pilot may only raise Server-domain events; a Billing event type is refused
+		so a bench can't fan out billing emails to the team."""
+		self._ensure_event_type(
+			"payment_failure",
+			category="Billing",
+			severity="Error",
+			required_cap="billing:view",
+			in_app_title="Payment failed",
+			in_app_body="{{ message }}",
+		)
+
+		class FakeCredential:
+			team = TEAM
+
+		with (
+			patch("central.api.pilot.PilotCredential.verify", return_value=FakeCredential()),
+			patch("frappe.get_request_header", return_value="fake-token"),
+		):
+			from central.notification.api import report_pilot_event
+
+			with self.assertRaises(frappe.PermissionError):
+				report_pilot_event(event_type="payment_failure", message="x")
+
 
 class TestTemplateContext(EngineTestBase):
 	def test_reference_doctype_in_template_context(self):

--- a/central/sso.py
+++ b/central/sso.py
@@ -15,7 +15,7 @@ from central.central.doctype.central_sso_settings.central_sso_settings import AL
 
 BENCH_LOGIN_TTL = 5 * 60  # a short-lived, single-use admin SID
 BOOTSTRAP_TTL = 30 * 60  # the first-boot enrollment window
-METRICS_TTL = 365 * 24 * 60 * 60  # long-lived: there is no revocation list, only key rotation
+METRICS_TTL = 7 * 24 * 60 * 60  # short: no revocation list, and the pilot re-fetches on 401 / near expiry
 ENROLL_SCOPE = "enroll"
 METRICS_SCOPE = "datum"
 
@@ -38,13 +38,13 @@ def bench_gateway() -> str:
 def mint_bench_login(audience: str) -> str:
 	"""A short-lived admin SID that opens a bench. The bench verifies it against the JWKS
 	and checks `aud` equals its own audience id."""
-	return _mint(audience, {"sub": "admin", "scope": "bench"}, BENCH_LOGIN_TTL)
+	return _mint(audience, "bench", BENCH_LOGIN_TTL, {"sub": "admin"})
 
 
 def mint_site_login(audience: str, site: str) -> str:
 	"""A one-time assertion the site's pilot exchanges for an Administrator session, scoped to
 	one site. `aud` is the hosting bench's audience id; the pilot verifies it against the JWKS."""
-	return _mint(audience, {"sub": "admin", "scope": "site", "site": site}, BENCH_LOGIN_TTL)
+	return _mint(audience, "site", BENCH_LOGIN_TTL, {"sub": "admin", "site": site})
 
 
 def mint_bootstrap_token(team: str, pilot_credential_id: str) -> str:
@@ -54,7 +54,7 @@ def mint_bootstrap_token(team: str, pilot_credential_id: str) -> str:
 	`aud` is the `pilot_credential_id` — the per-deployment audience id. Central controls it
 	up front (the VM's resource_id isn't known until Atlas provisions), so it doubles as the
 	audience every downward token to this bench will carry."""
-	return _mint(pilot_credential_id, {"scope": ENROLL_SCOPE, "team": team}, BOOTSTRAP_TTL)
+	return _mint(pilot_credential_id, ENROLL_SCOPE, BOOTSTRAP_TTL, {"team": team})
 
 
 def verify_bootstrap_token(token: str) -> dict:
@@ -71,7 +71,7 @@ def verify_bootstrap_token(token: str) -> dict:
 			token,
 			load_pem_public_key(settings.public_key.encode()),
 			algorithms=[ALGORITHM],
-			options={"verify_aud": False, "require": ["exp", "aud", "jti"]},
+			options={"verify_aud": False, "require": ["exp", "aud", "jti", "scope"]},
 		)
 	except jwt.InvalidTokenError as exc:
 		frappe.throw(f"Invalid enrollment token: {exc}", frappe.AuthenticationError)
@@ -94,15 +94,17 @@ def mint_metrics_token(audience: str, resource_id: str) -> str:
 		)
 	return _mint(
 		audience,
-		{
-			"scope": METRICS_SCOPE,
-			"vm_access": {"metrics_extra_labels": [f"resource_id={resource_id}"]},
-		},
+		METRICS_SCOPE,
 		METRICS_TTL,
+		{"vm_access": {"metrics_extra_labels": [f"resource_id={resource_id}"]}},
 	)
 
 
-def _mint(audience: str, claims: dict, ttl: int) -> str:
+def _mint(audience: str, scope: str, ttl: int, extra: dict | None = None) -> str:
+	"""Mint a signed assertion. `scope` is a required, first-class claim (not buried
+	in `extra`) so every token declares its purpose and verifiers can assert it —
+	bench-login, enroll, and metrics tokens all share this key, and the scope is what
+	keeps one from being accepted as another."""
 	private_pem, kid = CentralSSOSettings.instance().signing_key()
 	now = int(time.time())
 	payload = {
@@ -111,6 +113,7 @@ def _mint(audience: str, claims: dict, ttl: int) -> str:
 		"iat": now,
 		"exp": now + ttl,
 		"jti": frappe.generate_hash(length=16),
-		**claims,
+		"scope": scope,
+		**(extra or {}),
 	}
 	return jwt.encode(payload, private_pem, algorithm=ALGORITHM, headers={"kid": kid})

--- a/central/tests/test_auth.py
+++ b/central/tests/test_auth.py
@@ -3,7 +3,8 @@ from unittest.mock import patch
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from central.api.auth import _otp_key, build_auth_context, sign_up, verify_signup
+from central.api.auth import _otp_key, sign_up, verify_signup
+from central.www.dashboard import build_auth_context
 
 
 class TestAuth(IntegrationTestCase):

--- a/central/tests/test_sso.py
+++ b/central/tests/test_sso.py
@@ -63,6 +63,24 @@ class TestCentralSSO(IntegrationTestCase):
 		self.assertEqual(claims["scope"], "bench")
 		self.assertEqual(claims["aud"], DEV_AUDIENCE)
 
+	def test_bootstrap_verifier_rejects_other_scopes(self):
+		# scope is an asserted claim, not a convention: bench-login and metrics tokens
+		# are signed with the same key, so only the scope check stops one from being
+		# accepted as an enrollment token.
+		from central.sso import (
+			mint_bench_login,
+			mint_bootstrap_token,
+			mint_metrics_token,
+			verify_bootstrap_token,
+		)
+
+		enroll = mint_bootstrap_token("team-x", "pcred-x")
+		self.assertEqual(verify_bootstrap_token(enroll)["team"], "team-x")
+
+		for other in (mint_bench_login("pcred-x"), mint_metrics_token("pcred-x", "vm-1")):
+			with self.assertRaises(frappe.AuthenticationError):
+				verify_bootstrap_token(other)
+
 	def test_server_open_gates_the_handoff(self):
 		# server:open is the console gate, distinct from server:view (which only lists).
 		# A Developer carries it and can open; a Viewer sees servers but cannot open one.

--- a/central/www/dashboard.py
+++ b/central/www/dashboard.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import frappe
 from frappe.sessions import get_csrf_token
+from frappe.utils.oauth import get_oauth2_authorize_url, get_oauth_keys
+from frappe.utils.password import get_decrypted_password
 
-from central.api.auth import build_auth_context
+from central.iam import get_user_team_names
 
 no_cache = 1
 
@@ -32,3 +34,57 @@ def get_context(context):
 	boot["site_name"] = frappe.local.site
 	context.boot = boot
 	return context
+
+
+# Page-boot auth context — these are dashboard page-load concerns (not an HTTP API),
+# so they live here beside get_context rather than in central.api.auth.
+
+
+def build_auth_context() -> dict:
+	return {
+		"user": frappe.session.user or "Guest",
+		"provider_logins": _provider_logins(),
+		"onboarding_complete": _onboarding_complete(),
+	}
+
+
+def _onboarding_complete() -> bool:
+	"""True once the user's team owns a live site — the signal the SPA uses to keep a
+	brand-new user inside the onboarding funnel (and let a returning one skip it).
+	A first-run user (no team or no site yet) is still onboarding."""
+	user = frappe.session.user
+	if not user or user == "Guest":
+		return False
+	teams = get_user_team_names(user)
+	if not teams:
+		return False
+	return bool(frappe.db.exists("Site", {"team": ["in", teams], "status": ["!=", "Terminated"]}))
+
+
+def _provider_logins() -> list[dict[str, str]]:
+	providers = frappe.get_all(
+		"Social Login Key",
+		filters={"enable_social_login": 1},
+		fields=["name", "client_id", "base_url", "provider_name", "icon"],
+		order_by="name",
+	)
+	return [
+		{
+			"name": provider.name,
+			"label": provider.provider_name,
+			"icon": provider.icon or "",
+			"auth_url": get_oauth2_authorize_url(provider.name, "/dashboard/servers"),
+		}
+		for provider in providers
+		if _provider_is_configured(provider)
+	]
+
+
+def _provider_is_configured(provider) -> bool:
+	client_secret = get_decrypted_password(
+		"Social Login Key",
+		provider.name,
+		"client_secret",
+		raise_exception=False,
+	)
+	return bool(provider.client_id and client_secret and provider.base_url and get_oauth_keys(provider.name))

--- a/spec/ATLAS_COORDINATION.md
+++ b/spec/ATLAS_COORDINATION.md
@@ -1,0 +1,46 @@
+# Atlas / bench coordination
+
+Central-side changes in the pre-1.0 refactor that touch a contract shared with
+Atlas or a deployed bench (pilot). The goal is to keep the Atlas-side footprint
+**small** — most token/permission work below is Central-only and needs no Atlas
+change. Only the first item requires a coordinated bench-side change.
+
+## Requires a coordinated Atlas / bench change
+
+### 1. Scoped grants in the `fc_teams` OIDC claim (+ `CAPABILITY_VERSION` bump)
+- **Central change (deferred, not yet landed):** wire `Team Member.resource_type` /
+  `resource_name` through `resolve_user_grants` / `can`, and emit the real per-grant
+  `scope` in the `fc_teams` claim instead of the hardcoded `"*"`. Bump
+  `CAPABILITY_VERSION` (`central/iam.py`).
+- **Why Atlas is affected:** the bench mirrors the `fc_teams` claim from the OIDC
+  userinfo response (`central/oauth.py`) into its own `BENCH_CAPS`. Today every grant
+  carries `scope: "*"`; after the change a grant may be scoped to a single server
+  (`{resource_type: "Server", resource_name: <id>}`). A bench that assumes `"*"` would
+  either ignore scope (over-permit) or misread the claim.
+- **Bench-side work required:** read `scope` per grant and enforce it (fall back to
+  `"*"` when absent, so the change is backward-compatible during rollout). Honor the
+  bumped `cap_version` for drift detection per `CAPABILITIES.md`.
+- **Rollout:** bump `CAPABILITY_VERSION` and ship the bench reader together; keep the
+  claim additive (scope defaults to `"*"`) so an un-updated bench keeps working.
+
+## Central-only — token-adjacent, but **no** Atlas/bench change needed
+
+- **Shorten the Datum `METRICS_TTL`** (1 year → days/week): the pilot already
+  re-fetches the metrics token on 401 and near expiry (`central/api/pilot.py`), so a
+  shorter TTL is transparent to the bench.
+- **`jti` / credential binding for metrics-token revocation:** Central mints and
+  Central's `Pilot Credential` revocation invalidates; the bench only presents the
+  token and re-fetches on 401. No bench change.
+- **Assert `scope` as a required claim in `_mint`/verify** (`central/sso.py`): the
+  tokens already carry `scope`; the verifiers are Central-side. Internal hardening.
+- **Restrict `report_pilot_event` to a Server-category allow-list:** a well-behaved
+  pilot only dispatches Server events already; Central just refuses out-of-scope ones.
+  No change unless a bench was sending billing events (it should not).
+
+## Deliberately unchanged (so Atlas stays untouched)
+
+- The inbound Atlas HTTP endpoints `central/api/atlas.py` `register`/`sizes`/`images`/
+  `ping` — kept as-is (annotated).
+- The Atlas **event payload shape** consumed by the mirror (`mirror_vm`/`mirror_site`
+  via `central/mirror.py`) — the PR-6 mirror dedup did not change the wire contract.
+- `Asset` / `Site` mirrored field set — no fields the bench reports were removed.

--- a/spec/SSO.md
+++ b/spec/SSO.md
@@ -53,3 +53,21 @@ the real site session id lives in the Frappe site's own session store.
   per-user session must ride a NEW scope (e.g. `site_user`) so older benches reject it here — the
   identity is threaded through `SiteLogin.create_session(login_as=...)`, which defaults to
   Administrator. Adding it is additive: a new claim + a new scope handler, no contract change.
+
+## Token scopes (one signing key, three purposes)
+
+Central mints three token types with the same RS256 key, separated **only** by the
+`scope` claim, which `_mint` now sets as a required first-class claim on every token:
+
+| scope | minter | `aud` | TTL | consumed by |
+| --- | --- | --- | --- | --- |
+| `bench` / `site` | `mint_bench_login` / `mint_site_login` | bench's `pilot_credential_id` | 5 min | the bench (login SID) |
+| `enroll` | `mint_bootstrap_token` | `pilot_credential_id` | 30 min | Central (`verify_bootstrap_token`, asserts `scope == enroll`) |
+| `datum` | `mint_metrics_token` | `pilot_credential_id` | **7 days** | Datum's vmauth metrics gateway |
+
+The `datum` token carries a vmauth-specific claim: `vm_access.metrics_extra_labels =
+["resource_id=<id>"]`. vmauth turns those into labels the metrics store applies over
+whatever the producer sent, so a pilot can only write metrics attributed to its own
+resource — it cannot spoof another. There is **no revocation list**; the short TTL plus
+the pilot's re-fetch on 401 / near expiry (`api/pilot.py`) is the bound. `verify_bootstrap_token`
+requires `scope`, so a `bench`/`datum` token can never be accepted as an enrollment token.

--- a/spec/refactor_todo.md
+++ b/spec/refactor_todo.md
@@ -1,0 +1,58 @@
+# Central pre-1.0 refactor — remaining work
+
+Companion to the delivered refactor PRs (guardrails → correctness → dead-code sweeps →
+indexes → IAM hot-path cache → backend boundaries → notification engine). Tracks what is
+left so it can be picked up cleanly. See also `spec/ATLAS_COORDINATION.md`.
+
+## Large backend refactors (each its own PR)
+
+- **Split `integrations/atlas.py`** (878 LOC) into `client` (outbound RPC) / `mirror` (event
+  ingest + reconcile) / `tunnel` (WireGuard registration). Use a package facade
+  (`integrations/atlas/__init__.py` re-exporting the public **and test-imported** names —
+  `_on_vm`, `_on_vm_deleted`, `_remote_error_message`, etc. — so the ~16 call sites don't
+  change). Collapse `AtlasClient`'s redundant construction paths (`for_region` is redundant —
+  an Atlas Instance is `autoname:field:region`, so `name == region`) and its duplicate
+  transports/auth-header copies. Correctness-sensitive (tunnel + event ingest) — test against
+  the atlas suites.
+- **Merge `Service API Key` + `Site Service Credential`** into one DocType with a
+  `subject_type` discriminator — deletes a table, a controller, a TS type, and the dual loop
+  in `services/llm.py`. **Needs a data migration.** If not worth it, record why.
+- **Naming pass:** one noun for Asset/Server/VM, cluster vs region, `Order.desc` vs
+  `frappe.qb.desc`; wrap the remaining bare `frappe.throw` strings in `_()`.
+
+## PR 7 — frontend consolidation
+
+One `RowActions` / `ConfirmDialog` / mutation-runner / empty-state / spec+memory formatter;
+dedupe `get_billing_profile` (four concurrent fetchers) and reshape `useBillingOverview`'s
+return; split `ServerMap.vue` (912 LOC) and extract `useFleetRows`; fix stale enums
+(`Asset.status` missing `Resizing`, `InvoiceStatus`); make `gateway.ts` a discriminated union
+on `adapter_key`; structure cleanup (`utils/`→`lib/`, flatten `composables/common/`, renames).
+Plus the behavioural items: lazy-load the search index, feature-flag the addons page, wire
+`/team/settings` + `/team/invitations` into the nav, drop the discarded `useServers`
+reportview list.
+
+## PR 8 — docs + tests
+
+`CAPABILITIES.md` / `spec/IAM.md` / `spec/EXECUTION_PLAN.md` are materially wrong (capability
+counts, retired `vm:*` vocabulary). Behavioural test gaps on the touched endpoints; fix
+`test_atlas_register._wipe` (deletes every Atlas Instance and commits); freeze the `2099` /
+`add_days` clocks; inject the `_verify_over_tunnel` retry delay; wire
+`scripts/lib/central/test_wireguard.py` into CI; settle the doctype-dir-vs-`tests/` convention.
+
+## PR 8b — CI hardening
+
+Flip the deferred gates on once the cleanup above lands green: `vue-tsc --noEmit` (scope to
+`src/`, exclude frappe-ui internals) and biome `preset: recommended`.
+
+## Deferred / needs a decision
+
+- **Rest of the schema pass:** composite indexes (`Asset(team, status)`, `Asset(cluster,
+  status)`, `Team Invitation(email, status)`) via `on_doctype_update`; `Site.pilot_credential_id`
+  Data→Link; regenerate drifted DocType type blocks; collapse the two `Region` TS types.
+- **Scoped grants + `CAPABILITY_VERSION` bump** — needs bench-side coordination
+  (`spec/ATLAS_COORDINATION.md`): land the bench reader together and keep `scope` defaulting to
+  `"*"` so an un-updated bench keeps working.
+- **Security PR (separate):** `create_server` size clamp, `create_site` billing gate,
+  orphan-VM-on-throw, dev-mode OTP bypass, `resend_signup_code` rate limit, the GET-reachable
+  mutations, `get_site` gating, `setup_local` role check, pilot-enroll replay — and the
+  `User Notification Preference` cross-tenant read/write leak.


### PR DESCRIPTION
Notification engine + boundaries: rewrite the feed as one indexed query, log email failures, use one notification writer, fence pilot-reported events to server-only, and shorten the metrics-token TTL + require its scope. Also: servers reads plan info through a billing seam, and auth page-boot helpers move to the page module. Adds spec/refactor_todo.md and spec/ATLAS_COORDINATION.md. The two big refactors (split atlas.py, merge the service-credential doctypes) are intentionally left for their own PRs.

Stacked on pr-6-boundaries.