### PR TITLE
docs+test: PR8 — capability docs + Atlas test safety + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,19 @@ jobs:
       - name: Every patch module is in patches.txt
         run: python3 scripts/check_patches.py
 
+  wireguard:
+    runs-on: ubuntu-latest
+    name: WireGuard config unit tests
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+      - name: WireGuard hub rule/config generation
+        # Pure stdlib, no Frappe/site/host — runs straight from scripts/lib.
+        working-directory: scripts/lib
+        run: python3 -m unittest central.test_wireguard -v
+
   tests:
     runs-on: ubuntu-latest
     strategy:

--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -38,9 +38,9 @@ The distinction matters:
   a new capability string, so a bench always understands the result. Teams can
   create as many custom roles as they like without affecting this contract.
 
-## The 13 capabilities
+## The 15 capabilities
 
-### `central` plane (5)
+### `central` plane (7)
 
 | Capability | Meaning |
 | --- | --- |
@@ -49,6 +49,8 @@ The distinction matters:
 | `team:edit` | Edit team metadata. |
 | `team:manage_members` | Invite, suspend, and change team members. |
 | `team:delete` | Delete a team. |
+| `service:view` | View the team's add-on services (LLM, storage). |
+| `service:manage` | Provision and manage add-on services and their credentials. |
 
 ### `atlas` plane (8)
 
@@ -80,6 +82,7 @@ under these implications before it is asserted or evaluated
 | `server:open` | `server:view` |
 | `server:create` | `server:view`, `cluster:view` |
 | `server:power` / `resize` / `snapshot` / `terminate` | `server:view` |
+| `service:manage` | `service:view` |
 
 The role builder can let a user tick `server:create` without remembering
 `server:view`/`cluster:view`, and a grant hand-crafted through the API cannot
@@ -105,8 +108,10 @@ all teams. Teams may also define custom roles scoped to themselves.
 | `server:snapshot` | ✓ | ✓ | ✓ | | |
 | `server:terminate` | ✓ | ✓ | ✓ | | |
 | `server:open` | ✓ | ✓ | ✓ | | |
+| `service:view` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `service:manage` | ✓ | ✓ | ✓ | | ✓ |
 
-Totals: Owner 13, Admin 12, Developer 8, Viewer 2, Billing 4.
+Totals: Owner 15, Admin 14, Developer 10, Viewer 3, Billing 6.
 
 The ladder reads top to bottom: **Viewer** (look) → **Billing** (look + pay) →
 **Developer** (operate servers) → **Admin** (Developer + run the team) → **Owner**

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -753,11 +753,18 @@ def _rotate_service_credentials(user_name: str) -> tuple[str, str]:
 	return api_key, api_secret
 
 
-def _verify_over_tunnel(client, tunnel_url: str, attempts: int = 8, delay: float = 2.0) -> None:
+# Seconds between verify-ping retries. A module constant (not a default arg, which
+# binds at import) so tests can patch it to 0 and not sleep through the retries.
+VERIFY_RETRY_DELAY = 2.0
+
+
+def _verify_over_tunnel(client, tunnel_url: str, attempts: int = 8, delay: float | None = None) -> None:
 	"""Ping the Atlas over wg0 until it answers. The hub adds the peer immediately
 	before this, so the first packet triggers the WireGuard handshake and can race it
 	(connection reset / incomplete read). Retry a handful of times so a freshly-dialled
 	tunnel gets a moment to settle before we treat it as unreachable and roll back."""
+	if delay is None:
+		delay = VERIFY_RETRY_DELAY
 	last: Exception | None = None
 	for attempt in range(attempts):
 		try:

--- a/central/tests/test_atlas_register.py
+++ b/central/tests/test_atlas_register.py
@@ -56,26 +56,33 @@ class TestAtlasRegister(IntegrationTestCase):
 	def setUp(self) -> None:
 		frappe.set_user("Administrator")
 		# register_atlas commits mid-flow (host tasks, User creation), so its rows
-		# survive IntegrationTestCase's rollback. Wipe them before each test for a
-		# deterministic allocation baseline, and again after (committed) so the suite
-		# leaves no residue on the dev site.
-		self._wipe()
-		self.addCleanup(self._wipe, commit=True)
+		# survive IntegrationTestCase's rollback. Track only what this test creates and
+		# wipe (committed) exactly those on teardown — never every Atlas Instance, so
+		# the suite can't destroy real instances on a shared dev site.
+		self._created_regions: set[str] = set()
+		self.addCleanup(self._wipe)
 		self.addCleanup(frappe.set_user, "Administrator")
+		# Don't sleep through the verify-ping retries on the rollback paths.
+		delay_patch = patch("central.integrations.atlas.VERIFY_RETRY_DELAY", 0)
+		delay_patch.start()
+		self.addCleanup(delay_patch.stop)
 		_set_hub(active=True)
 
-	def _wipe(self, commit: bool = False) -> None:
-		"""Delete every Atlas Instance + per-Atlas service user — instances first to
-		drop the service_user link, then the users."""
-		for name in frappe.get_all("Atlas Instance", pluck="name"):
-			frappe.delete_doc("Atlas Instance", name, force=True, ignore_permissions=True)
-		for name in frappe.get_all("User", filters={"name": ["like", "atlas-%@%"]}, pluck="name"):
-			frappe.delete_doc("User", name, force=True, ignore_permissions=True)
-		if commit:
-			frappe.db.commit()  # nosemgrep: frappe-manual-commit -- durably remove rows register_atlas committed mid-flow
+	def _wipe(self) -> None:
+		"""Delete the Atlas Instances this test created + their per-Atlas service users —
+		instances first to drop the service_user link, then the users."""
+		for region in self._created_regions:
+			if frappe.db.exists("Atlas Instance", region):
+				frappe.delete_doc("Atlas Instance", region, force=True, ignore_permissions=True)
+		for region in self._created_regions:
+			email = _service_user_email(region)
+			if frappe.db.exists("User", email):
+				frappe.delete_doc("User", email, force=True, ignore_permissions=True)
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit -- durably remove rows register_atlas committed mid-flow
 
 	def make_instance(self, region: str, **overrides):
 		ensure_region(region)
+		self._created_regions.add(region)
 		if frappe.db.exists("Atlas Instance", region):
 			frappe.delete_doc("Atlas Instance", region, force=True, ignore_permissions=True)
 		values = {

--- a/spec/EXECUTION_PLAN.md
+++ b/spec/EXECUTION_PLAN.md
@@ -2,7 +2,9 @@
 
 ## 1. Complete The Capability Catalog
 
-- Add `vm:snapshot`, `vm:rebuild`, and `vm:clone` capabilities.
+- Seed the server capability set (`server:view/create/open/power/resize/snapshot/terminate`,
+  `cluster:view`); rebuild and clone are folded into `server:resize` rather than
+  separate capabilities.
 - Assign them to the standard Team roles.
 - Keep Viewer read-only and Billing limited to billing plus read access.
 - Export fixtures and verify Central's resolved grants.
@@ -31,11 +33,11 @@ Verification:
 
 Verification:
 
-- A Viewer sees resources only for Teams with `vm:view`.
+- A Viewer sees resources only for Teams with `server:view`.
 - Direct document access follows the same boundary as list access.
 - `System Manager` retains full visibility.
 
-## 4. Enforce VM Actions
+## 4. Enforce Server Actions
 
 - Apply the authorization decorator to loaded-VM actions.
 - Use explicit checks for create, clone, and other cross-resource operations.

--- a/spec/IAM.md
+++ b/spec/IAM.md
@@ -146,18 +146,18 @@ Observe-only endpoints:
 
 ```mermaid
 flowchart LR
-    S[Atlas session grants] --> V{team + vm:create?}
+    S[Atlas session grants] --> V{team + server:create?}
     T[Requested Team] --> V
-    V -->|Yes| VM[Create Virtual Machine]
-    VM --> SN[Snapshot inherits VM Team]
+    V -->|Yes| VM[Create Asset]
+    VM --> SN[Snapshot inherits Asset Team]
     V -->|No| X[Deny]
 ```
 
 Attribution rules:
 
-- New VMs require an explicit Team and `vm:create` for that Team.
-- Snapshots inherit their VM's Team.
-- Clone and rebuild operations cannot cross Team boundaries.
+- New servers require an explicit Team and `server:create` for that Team.
+- Snapshots inherit their server's Team.
+- Resize operations cannot cross Team boundaries.
 - Legacy unattributed resources are operator-only.
 - Resource ownership must never be inferred from the Frappe document owner.
 
@@ -169,23 +169,20 @@ Canonical routes use the Team identifier:
 Read rules:
 
 - `System Manager` can read all resources.
-- Other users require `vm:view` for the resource Team.
+- Other users require `server:view` for the resource Team.
 - List filters use `permission_query_conditions`; document reads use
   `has_permission`.
-- Linked operational records, including Tasks, inherit visibility from their VM.
+- Linked operational records, including Tasks, inherit visibility from their server.
 - An empty or malformed grant set denies access.
 
 | Action | Required capability |
 | --- | --- |
-| Create, provision, retry provision | `vm:create` |
-| Start, resume | `vm:start` |
-| Stop, pause | `vm:stop` |
-| Restart | `vm:stop` and `vm:start` |
-| Resize | `vm:resize` |
-| Snapshot | `vm:snapshot` |
-| Rebuild | `vm:rebuild` |
-| Clone | `vm:view` and `vm:clone` |
-| Terminate | `vm:terminate` |
+| Create, provision, retry provision | `server:create` |
+| Start, stop, restart | `server:power` |
+| Resize | `server:resize` |
+| Snapshot | `server:snapshot` |
+| Terminate | `server:terminate` |
+| Open console (bench SSO) | `server:open` |
 
 Loaded-document actions should use the authorization decorator. Creation and
 cross-resource actions should perform explicit checks because no single loaded

--- a/spec/refactor_todo.md
+++ b/spec/refactor_todo.md
@@ -20,24 +20,39 @@ left so it can be picked up cleanly. See also `spec/ATLAS_COORDINATION.md`.
 - **Naming pass:** one noun for Asset/Server/VM, cluster vs region, `Order.desc` vs
   `frappe.qb.desc`; wrap the remaining bare `frappe.throw` strings in `_()`.
 
-## PR 7 — frontend consolidation
+## PR 7 — frontend consolidation ✅ delivered
 
-One `RowActions` / `ConfirmDialog` / mutation-runner / empty-state / spec+memory formatter;
-dedupe `get_billing_profile` (four concurrent fetchers) and reshape `useBillingOverview`'s
-return; split `ServerMap.vue` (912 LOC) and extract `useFleetRows`; fix stale enums
-(`Asset.status` missing `Resizing`, `InvoiceStatus`); make `gateway.ts` a discriminated union
-on `adapter_key`; structure cleanup (`utils/`→`lib/`, flatten `composables/common/`, renames).
-Plus the behavioural items: lazy-load the search index, feature-flag the addons page, wire
-`/team/settings` + `/team/invitations` into the nav, drop the discarded `useServers`
-reportview list.
+Shared `RowActionsMenu` (the seven row menus) + `ConfirmDialog` (the pending-target
+confirms); deduped the four `get_billing_profile` fetchers onto the `useBillingOverview`
+singleton; split `ServerMap.vue` into `MapHoverCard` and extracted `useFleetRows`; fixed the
+stale enums (`InvoiceStatus` realigned to the DocType, `AssetStatus` `Resizing` made a
+first-class member — `Asset.status` itself already matched the DocType); `gateway.ts` is a
+discriminated union on `adapter_key`; `utils/`→`lib/`, flattened `composables/common/`; deduped
+`formatMemory`; lazy-mounted the search index; feature-flagged the addons area (Central
+Settings `enable_addons`); wired `/team/settings` + `/team/invitations` into the nav; dropped
+the discarded `useServers` reportview list.
+
+- **Not done — reshape `useBillingOverview`'s return** (it exposes raw `useCall` handles).
+  Deferred: cosmetic, and reshaping churns all eight consumers for no behavioural gain. The
+  dedupe (the substantive fix) landed; revisit only if a consumer needs the cleaner shape.
+- The **naming pass** (Asset/Server/VM, `Region` TS collapse) stays in the backend-refactors
+  section / deferred — untouched here.
 
 ## PR 8 — docs + tests
 
-`CAPABILITIES.md` / `spec/IAM.md` / `spec/EXECUTION_PLAN.md` are materially wrong (capability
-counts, retired `vm:*` vocabulary). Behavioural test gaps on the touched endpoints; fix
-`test_atlas_register._wipe` (deletes every Atlas Instance and commits); freeze the `2099` /
-`add_days` clocks; inject the `_verify_over_tunnel` retry delay; wire
-`scripts/lib/central/test_wireguard.py` into CI; settle the doctype-dir-vs-`tests/` convention.
+Done: `CAPABILITIES.md` / `spec/IAM.md` / `spec/EXECUTION_PLAN.md` corrected (15 caps incl.
+`service:*`, role totals, retired `vm:*` → `server:*`); `test_atlas_register._wipe` scoped to
+the regions each test creates (no longer deletes every Atlas Instance); `_verify_over_tunnel`
+retry delay lifted to a patchable `VERIFY_RETRY_DELAY` (0 in the test setUp); wired
+`scripts/lib/central/test_wireguard.py` into CI as a standalone job.
+
+Remaining (each wants a throwaway-site test run to verify — the shared bench tracks
+`develop`, and bench tests must not run against `central.localhost`):
+- **Freeze the `add_days`/`nowdate` clocks** across the ~10 billing test files (needs a
+  freezegun-style time fixture added first; applying it blind risks breaking those suites).
+  The literal `2099` sentinel wasn't found — confirm it's gone or locate it.
+- **Behavioural test gaps** on the touched endpoints (servers/teams/billing) — new tests.
+- **Settle the doctype-dir-vs-`tests/` convention** (organizational; low value).
 
 ## PR 8b — CI hardening
 


### PR DESCRIPTION
Stacked on #265. Docs + test-safety half of the refactor tail.

## Changes
- **Docs corrected** (were materially wrong): `CAPABILITIES.md` (13→15 caps, added `service:*`, fixed every per-role total + the implications table); `spec/IAM.md` + `spec/EXECUTION_PLAN.md` retired `vm:*` → `server:*`.
- **`test_atlas_register._wipe`** no longer deletes *every* Atlas Instance and commits (that would destroy real instances on a shared dev site) — scoped to the regions each test creates. Verified: 15/15 tests pass on ci-test.localhost (~2.3s).
- **`_verify_over_tunnel`** retry delay lifted to a patchable `VERIFY_RETRY_DELAY` (0 in test setUp) so rollback-path tests don't sleep ~16s each.
- **CI** — wired `scripts/lib/central/test_wireguard.py` in as a standalone job.

Remaining tail (recorded in `spec/refactor_todo.md`): freeze the billing-test clocks, endpoint behavioural-test gaps, doctype-dir convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)