### PR TITLE
ci: PR8b — src-scoped vue-tsc type-check gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,22 @@ jobs:
         working-directory: scripts/lib
         run: python3 -m unittest central.test_wireguard -v
 
+  console-types:
+    runs-on: ubuntu-latest
+    name: Console type-check
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          check-latest: true
+      - name: Install console deps
+        working-directory: dashboard
+        run: yarn install --frozen-lockfile
+      - name: Type-check src (vue-tsc, scoped to our code)
+        working-directory: dashboard
+        run: yarn type-check:src
+
   tests:
     runs-on: ubuntu-latest
     strategy:

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -7,6 +7,7 @@
 		"dev": "vite",
 		"build": "vite build",
 		"type-check": "vue-tsc --noEmit",
+		"type-check:src": "node scripts/type-check-src.mjs",
 		"preview": "vite preview"
 	},
 	"dependencies": {

--- a/dashboard/scripts/type-check-src.mjs
+++ b/dashboard/scripts/type-check-src.mjs
@@ -1,0 +1,40 @@
+// Type-check gate scoped to our own code. `vue-tsc --noEmit` also type-checks
+// frappe-ui's shipped .vue/.ts source (imported through the graph; skipLibCheck
+// only skips .d.ts), which carries pre-existing errors we can't fix. Run it, then
+// fail only on diagnostics in our src/ — so the gate guards our code, not the
+// library's internals.
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+
+// Invoke the local binary directly: run standalone (`node scripts/...`) the
+// node_modules/.bin shims aren't on PATH, and a missing binary must fail the gate
+// loudly rather than look green.
+const bin = process.platform === 'win32' ? 'vue-tsc.cmd' : 'vue-tsc'
+const binPath = `node_modules/.bin/${bin}`
+if (!existsSync(binPath)) {
+	console.error(`✗ ${binPath} not found — run yarn install first.`)
+	process.exit(1)
+}
+
+let output = ''
+try {
+	output = execFileSync(binPath, ['--noEmit', '--pretty', 'false'], {
+		encoding: 'utf8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+	})
+} catch (error) {
+	// vue-tsc exits non-zero whenever there are any errors (ours or frappe-ui's).
+	output = `${error.stdout ?? ''}${error.stderr ?? ''}`
+	if (!output.includes('error TS')) {
+		console.error('✗ vue-tsc failed to run:\n', output)
+		process.exit(1)
+	}
+}
+
+const ours = output.split('\n').filter((line) => line.startsWith('src/'))
+if (ours.length) {
+	console.error(ours.join('\n'))
+	console.error(`\n✗ ${ours.length} type error(s) in src/`)
+	process.exit(1)
+}
+console.log('✓ No type errors in src/')

--- a/dashboard/src/components/billing/CollectionActionBanner.vue
+++ b/dashboard/src/components/billing/CollectionActionBanner.vue
@@ -75,7 +75,7 @@ const options = [
 		v-if="show && s"
 		theme="yellow"
 		title="Action required — choose how to keep paying"
-		:action="canManageBilling ? { label: 'Choose how to pay', onClick: () => (choosing = true) } : null"
+		:action="canManageBilling ? { label: 'Choose how to pay', onClick: () => (choosing = true) } : undefined"
 	>
 		<template #description>
 			Your usage is trending to

--- a/dashboard/src/components/billing/SubscriptionsCard.vue
+++ b/dashboard/src/components/billing/SubscriptionsCard.vue
@@ -9,6 +9,7 @@ import EmptyState from '@/components/common/EmptyState.vue'
 import { useBillingOverview } from '@/composables/useBillingOverview'
 import { useCapabilities } from '@/composables/useCapabilities'
 import { money } from '@/lib/format'
+import type { BadgeTheme } from '@/lib/status'
 import { errorToast, successToast } from '@/lib/toast'
 import type { SubscriptionRow } from '@/types/billing'
 
@@ -55,7 +56,7 @@ function subtitle(sub: SubscriptionRow): string {
 // Paused), a dunning one Suspended, a billing-paused one Paused, else its op state.
 function statusInfo(
 	sub: SubscriptionRow,
-): { label: string; theme: string } | null {
+): { label: string; theme: BadgeTheme } | null {
 	if (sub.status === 'Terminated') return { label: 'Terminated', theme: 'red' }
 	if (sub.account_standing === 'Suspended')
 		return { label: 'Suspended', theme: 'orange' }

--- a/dashboard/src/components/common/Alert.vue
+++ b/dashboard/src/components/common/Alert.vue
@@ -72,10 +72,18 @@
 	</div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { computed, useSlots } from 'vue'
 
 // Drop-in for frappe-ui's Alert: same theme names, props and slots.
+// Slots are declared so consumers type-check `#description`/`#action`/etc.
+defineSlots<{
+	icon?: () => unknown
+	description?: () => unknown
+	action?: () => unknown
+	footer?: () => unknown
+}>()
+
 const props = defineProps({
 	theme: { type: String, default: '' }, // 'blue' | 'green' | 'yellow' | 'red'
 	title: { type: String, default: '' },
@@ -85,7 +93,7 @@ const props = defineProps({
 	// One action object, or an array of them — each { label, onClick, icon? }.
 	action: { type: [Object, Array], default: null },
 })
-const visible = defineModel({ default: true })
+const visible = defineModel<boolean>({ default: true })
 const emit = defineEmits(['dismiss'])
 const slots = useSlots()
 

--- a/spec/refactor_todo.md
+++ b/spec/refactor_todo.md
@@ -43,11 +43,11 @@ the discarded `useServers` reportview list.
 Done: `CAPABILITIES.md` / `spec/IAM.md` / `spec/EXECUTION_PLAN.md` corrected (15 caps incl.
 `service:*`, role totals, retired `vm:*` → `server:*`); `test_atlas_register._wipe` scoped to
 the regions each test creates (no longer deletes every Atlas Instance); `_verify_over_tunnel`
-retry delay lifted to a patchable `VERIFY_RETRY_DELAY` (0 in the test setUp); wired
-`scripts/lib/central/test_wireguard.py` into CI as a standalone job.
+retry delay lifted to a patchable `VERIFY_RETRY_DELAY` (0 in the test setUp) — **verified: the
+15 atlas-register tests pass on `ci-test.localhost` in ~2.3s**; wired
+`scripts/lib/central/test_wireguard.py` into CI as a standalone job (passes).
 
-Remaining (each wants a throwaway-site test run to verify — the shared bench tracks
-`develop`, and bench tests must not run against `central.localhost`):
+Remaining (follow-up-sized; run against `ci-test.localhost`, never `central.localhost`):
 - **Freeze the `add_days`/`nowdate` clocks** across the ~10 billing test files (needs a
   freezegun-style time fixture added first; applying it blind risks breaking those suites).
   The literal `2099` sentinel wasn't found — confirm it's gone or locate it.
@@ -56,8 +56,16 @@ Remaining (each wants a throwaway-site test run to verify — the shared bench t
 
 ## PR 8b — CI hardening
 
-Flip the deferred gates on once the cleanup above lands green: `vue-tsc --noEmit` (scope to
-`src/`, exclude frappe-ui internals) and biome `preset: recommended`.
+- **Done — `vue-tsc` gate scoped to `src/`.** `scripts/type-check-src.mjs` (npm
+  `type-check:src`) runs `vue-tsc --noEmit` and fails only on `src/` diagnostics — frappe-ui
+  ships `.vue` source that gets type-checked through the import graph and carries errors we
+  can't fix, so a raw `--noEmit` is never green. Wired as the `console-types` CI job. Cleared
+  the two pre-existing `src/` errors (typed `Alert`'s slots; `statusInfo` theme → `BadgeTheme`).
+- **Not done — biome `recommended`.** Under the correct config it surfaces ~94 errors + ~68
+  warnings (unused vars/imports, `noNonNullAssertion`, a11y `useButtonType`, Vue duplicate
+  keys). That's a dedicated cleanup PR, not a gate-flip — enabling it blind (or via a
+  CWD-sensitive `biome.json` with `root: false`) risks churn/regressions. Do it deliberately:
+  land the correctness group first (mostly auto-fixable), then the style/a11y groups.
 
 ## Deferred / needs a decision
 


### PR DESCRIPTION
Stacked on #266. Turns on the deferred type-check gate.

## Changes
- **`type-check:src` gate** (`scripts/type-check-src.mjs`) runs `vue-tsc --noEmit` and fails only on `src/` diagnostics — frappe-ui ships `.vue` source that's type-checked through the import graph and carries errors we can't fix, so a raw `--noEmit` is never green. Wired as the `console-types` CI job.
- Cleared the two pre-existing `src/` errors it surfaced: typed the local `Alert`'s slots (lang=ts + `defineSlots`, so consumers can use `#description`) and `statusInfo`'s theme (`BadgeTheme`, not `string`).

Not done — biome `recommended`: under the correct config it surfaces ~94 errors + ~68 warnings (unused code, `noNonNullAssertion`, a11y). That's a deliberate cleanup PR, not a gate-flip (also blocked by the CWD-sensitive `biome.json` `root: false`). Scoped as a follow-up in `spec/refactor_todo.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)