### PR TITLE
feat(iam): PR9 — enforce scoped role grants (Central-side)

### DIFF
--- a/central/api/servers.py
+++ b/central/api/servers.py
@@ -6,7 +6,7 @@ import unicodedata
 import frappe
 from frappe import _
 
-from central.iam import can, resolve_team
+from central.iam import can, resolve_resource_scope, resolve_team, user_has_operator_bypass
 from central.integrations.atlas import AtlasClient, reconcile
 
 # Server endpoints for the console. Reads come from the Asset mirror; commands go
@@ -136,9 +136,20 @@ def registry(team: str | None = None) -> dict:
 	if not can(user, team, "server:view"):
 		frappe.throw(_("You can't view this team's servers."), frappe.PermissionError)
 
+	# Honor scoped grants: a member scoped to specific servers/sites sees only those.
+	# An all-resources (or operator) grant returns the scope "*" — the whole team.
+	asset_filters: dict = {"team": team}
+	server_scope = _viewable_names(user, team, "Server")
+	if server_scope != "*":
+		asset_filters["name"] = ["in", sorted(server_scope)]
+	site_filters: dict = {"team": team, "status": ["!=", "Terminated"]}
+	site_scope = _viewable_names(user, team, "Site")
+	if site_scope != "*":
+		site_filters["name"] = ["in", sorted(site_scope)]
+
 	assets = frappe.get_all(
 		"Asset",
-		filters={"team": team},
+		filters=asset_filters,
 		fields=[
 			"name",
 			"resource_id",
@@ -162,11 +173,24 @@ def registry(team: str | None = None) -> dict:
 	# (the stable id + terminate key); `subdomain` is the user-entered display name.
 	sites = frappe.get_all(
 		"Site",
-		filters={"team": team, "status": ["!=", "Terminated"]},
+		filters=site_filters,
 		fields=["name", "subdomain", "status", "url", "region"],
 		order_by="subdomain asc",
 	)
 	return {"team": team, "assets": assets, "sites": sites}
+
+
+def _viewable_names(user: str, team: str, resource_type: str) -> object:
+	"""`"*"` when the user may view every `resource_type` in `team` (an all-resources
+	or operator grant), else the set of resource names their scoped grants allow —
+	empty when none. `registry` uses this to filter the mirror to the member's scope."""
+	if user_has_operator_bypass(user):
+		return "*"
+	scope = resolve_resource_scope(user, "server:view", resource_type)
+	allowed = scope.get(team)
+	if allowed == "*":
+		return "*"
+	return allowed or set()
 
 
 @frappe.whitelist(methods=["GET"])
@@ -174,10 +198,12 @@ def server_overview(team: str | None = None, resource_id: str | None = None) -> 
 	"""Return one server's Central mirror plus Pilot's cached operational metrics."""
 	user = frappe.session.user
 	team = resolve_team(user, team)
-	if not can(user, team, "server:view"):
-		frappe.throw(_("You can't view this team's servers."), frappe.PermissionError)
 	if not resource_id:
 		frappe.throw(_("resource_id is required."), frappe.ValidationError)
+	# resource_id is the Asset name (autoname field:resource_id), so a server-scoped
+	# grant is honored directly.
+	if not can(user, team, "server:view", "Server", resource_id):
+		frappe.throw(_("You can't view this server."), frappe.PermissionError)
 
 	row = _overview_asset_row(resource_id, team)
 	if not row:
@@ -588,10 +614,12 @@ def _run_command(
 	the asset belongs to the team, call Atlas, return the Task handle."""
 	user = frappe.session.user
 	team = resolve_team(user, team)
-	if not can(user, team, capability):
-		frappe.throw(_("You can't {0} servers for this team.").format(action), frappe.PermissionError)
 	if not resource_id:
 		frappe.throw(_("resource_id is required."), frappe.ValidationError)
+	# resource_id is the Asset name, so a grant scoped to this server authorizes it and
+	# one scoped to another server does not.
+	if not can(user, team, capability, "Server", resource_id):
+		frappe.throw(_("You can't {0} this server.").format(action), frappe.PermissionError)
 
 	# The asset must be in this team's mirror — also how we route to its Atlas.
 	asset = frappe.db.get_value(

--- a/central/api/sites.py
+++ b/central/api/sites.py
@@ -114,8 +114,10 @@ def terminate_site(name: str) -> dict:
 	site = frappe.db.get_value("Site", name, ["team", "cluster", "status"], as_dict=True)
 	if not site:
 		frappe.throw(_("Unknown site {0}.").format(name))
-	if not can(user, site.team, "server:terminate"):
-		frappe.throw(_("You can't terminate this team's sites."), frappe.PermissionError)
+	# `name` is the Site name, so a grant scoped to this site authorizes it and one
+	# scoped to another resource does not.
+	if not can(user, site.team, "server:terminate", "Site", name):
+		frappe.throw(_("You can't terminate this site."), frappe.PermissionError)
 
 	# Already gone — no-op, and never issue a second teardown to Atlas.
 	if site.status == "Terminated":

--- a/central/api/sso.py
+++ b/central/api/sso.py
@@ -46,8 +46,10 @@ def _asset_login_link(asset: str, team: str | None, user: str) -> dict:
 	doc = frappe.get_doc("Asset", asset)
 	if team and team != doc.team:
 		frappe.throw(_("That server isn't in this team."), frappe.PermissionError)
-	if not can(user, doc.team, "server:open"):
-		frappe.throw(_("You can't open servers for this team."), frappe.PermissionError)
+	# Scope-aware: doc.name is the Asset name (= resource_id), so a grant scoped to
+	# another server can't open this one even if get_doc's read perm let it be seen.
+	if not can(user, doc.team, "server:open", "Server", doc.name):
+		frappe.throw(_("You can't open this server."), frappe.PermissionError)
 	if doc.status != "Running":
 		frappe.throw(_("Server is {0}, not running.").format(doc.status.lower()), frappe.ValidationError)
 	if frappe.db.get_value("Atlas Instance", doc.cluster, "status") != "Active":

--- a/central/iam.py
+++ b/central/iam.py
@@ -126,6 +126,8 @@ def resolve_team(user: str, team: str | None = None) -> str:
 
 
 def get_user_team_names_with_capability(user: str, capability: str) -> list[str]:
+	"""Teams where the user holds `capability` on any resource — a team-level question
+	(does the cap appear at all), the same shape as `can()` with no resource named."""
 	grants = resolve_user_grants(user)
 	return sorted(
 		team
@@ -155,6 +157,8 @@ def _get_membership_capability_rows(user: str) -> list[dict[str, Any]]:
 		.select(
 			team.name.as_("team"),
 			member.role,
+			member.resource_type,
+			member.resource_name,
 			team_role.is_system,
 			team_role.team.as_("role_team"),
 			role_capability.capability,
@@ -186,6 +190,8 @@ def resolve_user_grants(user: str) -> dict[str, list[dict[str, Any]]]:
 				{
 					"role": OPERATOR_BYPASS_ROLE,
 					"source": "operator",
+					"resource_type": "*",
+					"resource_name": None,
 					"scope": "*",
 					"caps": caps,
 				}
@@ -197,12 +203,18 @@ def resolve_user_grants(user: str) -> dict[str, list[dict[str, Any]]]:
 		if not row.is_system and row.role_team != row.team:
 			continue
 
-		key = (row.team, row.role)
+		# A member can hold the same role scoped to several resources, so the grant
+		# key includes the resource scope — each (role, resource) pair is its own grant.
+		resource_type = row.resource_type or "*"
+		resource_name = row.resource_name if resource_type != "*" else None
+		key = (row.team, row.role, resource_type, resource_name)
 		if key not in grants_by_key:
 			grants_by_key[key] = {
 				"role": row.role,
 				"source": "member",
-				"scope": "*",
+				"resource_type": resource_type,
+				"resource_name": resource_name,
+				"scope": "*" if resource_type == "*" else f"{resource_type}:{resource_name}",
 				"caps": [],
 			}
 			grants_by_team[row.team].append(grants_by_key[key])
@@ -230,26 +242,85 @@ def clear_grants_cache() -> None:
 
 
 def get_fc_teams_claim(user: str | None = None) -> dict[str, list[dict[str, Any]]]:
+	"""The `fc_teams` OIDC claim benches mirror. The bench contract is not yet
+	scope-aware (spec/ATLAS_COORDINATION.md), so collapse each team's grants to one
+	entry per role with scope `"*"` and the union of caps — identical to what an
+	un-updated bench already expects. Emitting the real per-grant scope (and bumping
+	CAPABILITY_VERSION) is a coordinated follow-up with the bench reader."""
 	user = user or frappe.session.user
 	if not user or user == "Guest":
 		return {}
-	return resolve_user_grants(user)
+
+	claim: dict[str, list[dict[str, Any]]] = {}
+	for team, team_grants in resolve_user_grants(user).items():
+		by_role: dict[str, dict[str, Any]] = {}
+		for grant in team_grants:
+			entry = by_role.setdefault(
+				grant["role"],
+				{"role": grant["role"], "source": grant["source"], "scope": "*", "caps": []},
+			)
+			for cap in grant["caps"]:
+				if cap not in entry["caps"]:
+					entry["caps"].append(cap)
+		claim[team] = list(by_role.values())
+	return claim
 
 
-def can(user: str, team: str, capability: str) -> bool:
+def can(
+	user: str,
+	team: str,
+	capability: str,
+	resource_type: str | None = None,
+	resource_name: str | None = None,
+) -> bool:
 	# No pre-flight db.exists probes: resolve_user_grants only returns Active teams
 	# (the join filters team.status), so an inactive/unknown team yields no grants,
 	# and an unknown capability simply won't match any grant's caps — both fall
 	# through to False without a separate round-trip. resolve_user_grants is
 	# request-cached, so the per-row/per-member callers pay one join, not N.
+	#
+	# `resource_name` is None → "does the user hold this cap on any resource" (the
+	# team-level / list-gate question, unchanged from before scoped grants). Naming a
+	# resource narrows it: only an all-resources (`*`) grant or a grant scoped to
+	# exactly that (resource_type, resource_name) qualifies.
 	if user_has_operator_bypass(user):
 		return True
 
 	for grant in resolve_user_grants(user).get(team, []):
-		if capability in grant.get("caps", []):
+		if capability not in grant.get("caps", []):
+			continue
+		if resource_name is None:
+			return True
+		gtype = grant.get("resource_type", "*")
+		if gtype == "*" or (gtype == resource_type and grant.get("resource_name") == resource_name):
 			return True
 
 	return False
+
+
+def resolve_resource_scope(user: str, capability: str, resource_type: str) -> dict[str, Any]:
+	"""For a resource-level `capability` on a `resource_type` (`"Server"`/`"Site"`),
+	map each team the user may act in to either `"*"` (all resources of that type in
+	the team) or the set of resource names an explicit scoped grant allows. Teams with
+	no covering grant are omitted. Drives the Asset/Site list `permission_query_conditions`."""
+	scope: dict[str, Any] = {}
+	for team, team_grants in resolve_user_grants(user).items():
+		allowed: set[str] = set()
+		wildcard = False
+		for grant in team_grants:
+			if capability not in grant.get("caps", []):
+				continue
+			gtype = grant.get("resource_type", "*")
+			if gtype == "*":
+				wildcard = True
+				break
+			if gtype == resource_type and grant.get("resource_name"):
+				allowed.add(grant["resource_name"])
+		if wildcard:
+			scope[team] = "*"
+		elif allowed:
+			scope[team] = allowed
+	return scope
 
 
 def get_effective_permissions(user: str, team: str | None = None) -> dict[str, Any]:

--- a/central/permissions.py
+++ b/central/permissions.py
@@ -6,6 +6,7 @@ from central.iam import (
 	can,
 	get_user_team_names,
 	get_user_team_names_with_capability,
+	resolve_resource_scope,
 	user_has_operator_bypass,
 )
 
@@ -82,20 +83,25 @@ def team_invitation_has_permission(doc, user: str | None = None, ptype: str | No
 	return doc.email == user or can(user, doc.team, "team:manage_members")
 
 
+# The Manage Roles dialog scopes a grant to resource_type "Server" (an Asset) or
+# "Site"; the Team Member's resource_name holds that doc's name. So the Asset list
+# is scoped by "Server" grants, the Site list by "Site" grants.
+
+
 def asset_query_conditions(user: str | None = None) -> str:
-	return _team_field_query_conditions("Asset", "server:view", user)
+	return _team_field_query_conditions("Asset", "Server", "server:view", user)
 
 
 def asset_has_permission(doc, user: str | None = None, ptype: str | None = None, **kwargs) -> bool:
-	return _team_field_has_permission(doc, ("server:view",), (), user, ptype)
+	return _team_field_has_permission(doc, "Server", ("server:view",), (), user, ptype)
 
 
 def site_query_conditions(user: str | None = None) -> str:
-	return _team_field_query_conditions("Site", "server:view", user)
+	return _team_field_query_conditions("Site", "Site", "server:view", user)
 
 
 def site_has_permission(doc, user: str | None = None, ptype: str | None = None, **kwargs) -> bool:
-	return _team_field_has_permission(doc, ("server:view",), (), user, ptype)
+	return _team_field_has_permission(doc, "Site", ("server:view",), (), user, ptype)
 
 
 def iam_permission_probe_query_conditions(user: str | None = None) -> str:
@@ -114,21 +120,33 @@ def iam_permission_probe_has_permission(
 	return doc.user == user
 
 
-def _team_field_query_conditions(doctype: str, capability: str, user: str | None = None) -> str:
+def _team_field_query_conditions(
+	doctype: str, resource_type: str, capability: str, user: str | None = None
+) -> str:
 	user = user or frappe.session.user
 	if user_has_operator_bypass(user):
 		return ""
 
-	teams = get_user_team_names_with_capability(user, capability)
-	if not teams:
+	# Per team: either the whole team (an all-resources grant with the cap) or just
+	# the specific rows an explicit scoped grant names.
+	scope = resolve_resource_scope(user, capability, resource_type)
+	if not scope:
 		return "1 = 0"
 
-	escaped = ", ".join(frappe.db.escape(team) for team in teams)
-	return f"`tab{doctype}`.`team` in ({escaped})"
+	clauses = []
+	for team, allowed in scope.items():
+		team_sql = frappe.db.escape(team)
+		if allowed == "*":
+			clauses.append(f"`tab{doctype}`.`team` = {team_sql}")
+		else:
+			names = ", ".join(frappe.db.escape(name) for name in sorted(allowed))
+			clauses.append(f"(`tab{doctype}`.`team` = {team_sql} and `tab{doctype}`.`name` in ({names}))")
+	return f"({' or '.join(clauses)})"
 
 
 def _team_field_has_permission(
 	doc,
+	resource_type: str,
 	read_capabilities: tuple[str, ...],
 	write_capabilities: tuple[str, ...],
 	user: str | None = None,
@@ -142,11 +160,7 @@ def _team_field_has_permission(
 	if not team:
 		return False
 
-	if ptype in MUTATING_PERMISSION_TYPES:
-		return _can_any(user, team, write_capabilities)
-
-	return _can_any(user, team, read_capabilities)
-
-
-def _can_any(user: str, team: str, capabilities: tuple[str, ...]) -> bool:
-	return any(can(user, team, capability) for capability in capabilities)
+	capabilities = write_capabilities if ptype in MUTATING_PERMISSION_TYPES else read_capabilities
+	# Gate on this exact resource: a grant scoped to another server/site must not
+	# authorize it, and an all-resources grant covers it.
+	return any(can(user, team, capability, resource_type, doc.name) for capability in capabilities)

--- a/central/tests/test_iam.py
+++ b/central/tests/test_iam.py
@@ -205,6 +205,47 @@ class TestCentralIAM(IntegrationTestCase):
 		# The all-resources Owner grant covers any server.
 		self.assertTrue(can(self.owner, team.name, "server:power", "Server", "srv-y"))
 
+	def test_different_roles_on_different_servers(self):
+		# The headline case: one member, two servers, a different role on each.
+		team = frappe.get_doc(
+			{
+				"doctype": "Team",
+				"team_name": "IAM Mixed Scope Team",
+				"owner_user": self.owner,
+				"members": [
+					{"user": self.owner, "role": "Owner", "status": "Active"},
+					{
+						"user": self.developer,
+						"role": "Developer",
+						"resource_type": "Server",
+						"resource_name": "srv-x",
+						"status": "Active",
+					},
+					{
+						"user": self.developer,
+						"role": "Viewer",
+						"resource_type": "Server",
+						"resource_name": "srv-y",
+						"status": "Active",
+					},
+				],
+			}
+		).insert()
+
+		# Developer on srv-x → full lifecycle there; Viewer on srv-y → read-only there.
+		self.assertTrue(can(self.developer, team.name, "server:power", "Server", "srv-x"))
+		self.assertTrue(can(self.developer, team.name, "server:terminate", "Server", "srv-x"))
+		self.assertFalse(can(self.developer, team.name, "server:power", "Server", "srv-y"))
+		self.assertFalse(can(self.developer, team.name, "server:terminate", "Server", "srv-y"))
+		# But both are visible — the list shows exactly these two, nothing else.
+		self.assertTrue(can(self.developer, team.name, "server:view", "Server", "srv-x"))
+		self.assertTrue(can(self.developer, team.name, "server:view", "Server", "srv-y"))
+		self.assertFalse(can(self.developer, team.name, "server:view", "Server", "srv-z"))
+		self.assertEqual(
+			resolve_resource_scope(self.developer, "server:view", "Server").get(team.name),
+			{"srv-x", "srv-y"},
+		)
+
 	def test_resolve_resource_scope_maps_teams_to_allowed_names(self):
 		team = frappe.get_doc(
 			{

--- a/central/tests/test_iam.py
+++ b/central/tests/test_iam.py
@@ -1,7 +1,13 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from central.iam import can, expand_capabilities, get_effective_permissions, get_fc_teams_claim
+from central.iam import (
+	can,
+	expand_capabilities,
+	get_effective_permissions,
+	get_fc_teams_claim,
+	resolve_resource_scope,
+)
 from central.oauth import install_oauth_claim_patch
 
 
@@ -168,6 +174,118 @@ class TestCentralIAM(IntegrationTestCase):
 
 		self.assertFalse(probe.allowed)
 		self.assertIn(team.name, probe.resolved_grants)
+
+	def test_scoped_grant_narrows_can_to_its_resource(self):
+		# A Developer scoped to one server acts on that server only.
+		team = frappe.get_doc(
+			{
+				"doctype": "Team",
+				"team_name": "IAM Scoped Team",
+				"owner_user": self.owner,
+				"members": [
+					{"user": self.owner, "role": "Owner", "status": "Active"},
+					{
+						"user": self.developer,
+						"role": "Developer",
+						"resource_type": "Server",
+						"resource_name": "srv-x",
+						"status": "Active",
+					},
+				],
+			}
+		).insert()
+
+		# The named resource matches → allowed; a different server → denied.
+		self.assertTrue(can(self.developer, team.name, "server:power", "Server", "srv-x"))
+		self.assertFalse(can(self.developer, team.name, "server:power", "Server", "srv-y"))
+		# A Server-scoped grant does not cover a Site of the same name.
+		self.assertFalse(can(self.developer, team.name, "server:view", "Site", "srv-x"))
+		# No resource named is the team-level/list question — the cap is held somewhere.
+		self.assertTrue(can(self.developer, team.name, "server:power"))
+		# The all-resources Owner grant covers any server.
+		self.assertTrue(can(self.owner, team.name, "server:power", "Server", "srv-y"))
+
+	def test_resolve_resource_scope_maps_teams_to_allowed_names(self):
+		team = frappe.get_doc(
+			{
+				"doctype": "Team",
+				"team_name": "IAM Scope Map Team",
+				"owner_user": self.owner,
+				"members": [
+					{"user": self.owner, "role": "Owner", "status": "Active"},
+					{
+						"user": self.developer,
+						"role": "Developer",
+						"resource_type": "Server",
+						"resource_name": "srv-x",
+						"status": "Active",
+					},
+				],
+			}
+		).insert()
+
+		self.assertEqual(
+			resolve_resource_scope(self.developer, "server:view", "Server").get(team.name),
+			{"srv-x"},
+		)
+		# No Site-scoped grant → the team is absent from the Site scope entirely.
+		self.assertNotIn(team.name, resolve_resource_scope(self.developer, "server:view", "Site"))
+		# The Owner's all-resources grant resolves to the wildcard.
+		self.assertEqual(resolve_resource_scope(self.owner, "server:view", "Server").get(team.name), "*")
+
+	def test_scoped_grant_leaves_fc_teams_claim_backward_compatible(self):
+		# The bench contract isn't scope-aware yet, so the claim stays one entry per
+		# role with scope "*" (spec/ATLAS_COORDINATION.md).
+		team = frappe.get_doc(
+			{
+				"doctype": "Team",
+				"team_name": "IAM Claim Compat Team",
+				"owner_user": self.owner,
+				"members": [
+					{"user": self.owner, "role": "Owner", "status": "Active"},
+					{
+						"user": self.developer,
+						"role": "Developer",
+						"resource_type": "Server",
+						"resource_name": "srv-x",
+						"status": "Active",
+					},
+				],
+			}
+		).insert()
+
+		entries = get_fc_teams_claim(self.developer)[team.name]
+		self.assertTrue(all(entry["scope"] == "*" for entry in entries))
+		developer_entry = next(entry for entry in entries if entry["role"] == "Developer")
+		self.assertIn("server:power", developer_entry["caps"])
+
+	def test_asset_has_permission_respects_scope(self):
+		from central.permissions import asset_has_permission
+
+		team = frappe.get_doc(
+			{
+				"doctype": "Team",
+				"team_name": "IAM Asset Perm Team",
+				"owner_user": self.owner,
+				"members": [
+					{"user": self.owner, "role": "Owner", "status": "Active"},
+					{
+						"user": self.developer,
+						"role": "Developer",
+						"resource_type": "Server",
+						"resource_name": "srv-x",
+						"status": "Active",
+					},
+				],
+			}
+		).insert()
+
+		in_scope = frappe._dict(name="srv-x", team=team.name)
+		out_of_scope = frappe._dict(name="srv-y", team=team.name)
+		self.assertTrue(asset_has_permission(in_scope, self.developer, "read"))
+		self.assertFalse(asset_has_permission(out_of_scope, self.developer, "read"))
+		# The Owner's all-resources grant sees both.
+		self.assertTrue(asset_has_permission(out_of_scope, self.owner, "read"))
 
 	def test_oauth_userinfo_patch_adds_fc_teams(self):
 		team = self.make_team("IAM OAuth Team", self.viewer, "Viewer")

--- a/spec/refactor_todo.md
+++ b/spec/refactor_todo.md
@@ -67,14 +67,29 @@ Remaining (follow-up-sized; run against `ci-test.localhost`, never `central.loca
   CWD-sensitive `biome.json` with `root: false`) risks churn/regressions. Do it deliberately:
   land the correctness group first (mostly auto-fixable), then the style/a11y groups.
 
+## PR 9 — scoped grants (Central-side) ✅ delivered
+
+`Team Member.resource_type`/`resource_name` are now enforced on Central's server/site
+mirror: `resolve_user_grants` carries the resource scope, `can()` gained
+`resource_type`/`resource_name` args, and `resolve_resource_scope` drives Asset/Site
+`permission_query_conditions` + `has_permission` and the console endpoints (registry list,
+server_overview, start/stop/terminate, open-in-bench, terminate_site). A member scoped to
+one server now sees and acts on only that server. **Verified on `ci-test.localhost`:**
+test_iam 12/12 (4 new), test_team_management 25/25.
+
+Still needs bench coordination (`spec/ATLAS_COORDINATION.md`): the `fc_teams` claim stays
+one entry per role with `scope: "*"` (bench contract unchanged), so a bench SSO still
+over-permits a scoped member. Emitting the real per-grant `scope` + the `CAPABILITY_VERSION`
+bump land together with the bench reader.
+
+`resize_server` is gated by the billing `authz` (billing:manage, keyed on subscription),
+so it isn't resource-scoped here — scope it when the subscription→resource mapping is wired.
+
 ## Deferred / needs a decision
 
 - **Rest of the schema pass:** composite indexes (`Asset(team, status)`, `Asset(cluster,
   status)`, `Team Invitation(email, status)`) via `on_doctype_update`; `Site.pilot_credential_id`
   Data→Link; regenerate drifted DocType type blocks; collapse the two `Region` TS types.
-- **Scoped grants + `CAPABILITY_VERSION` bump** — needs bench-side coordination
-  (`spec/ATLAS_COORDINATION.md`): land the bench reader together and keep `scope` defaulting to
-  `"*"` so an un-updated bench keeps working.
 - **Security PR (separate):** `create_server` size clamp, `create_site` billing gate,
   orphan-VM-on-throw, dev-mode OTP bypass, `resend_signup_code` rate limit, the GET-reachable
   mutations, `get_site` gating, `setup_local` role check, pilot-enroll replay — and the


### PR DESCRIPTION
Stacked on #267. The last of the pre-1.0 refactor. Makes the Manage Roles dialog's per-resource grants real: a member scoped to one server/site now sees and acts on only that resource.

## What changed
`Team Member.resource_type`/`resource_name` were written + shown but never enforced (scope was hardcoded `"*"`). Now wired through:
- **`resolve_user_grants`** keys grants by `(role, resource_type, resource_name)` and carries the scope.
- **`can(user, team, cap, resource_type=None, resource_name=None)`** — naming a resource narrows to an all-resources or exactly-matching grant; no resource named stays the team-level/list question (unchanged).
- **`resolve_resource_scope`** → per-team `"*"` or allowed names; drives Asset/Site `permission_query_conditions` + `has_permission`.
- **Console endpoints** gate on the exact resource: `registry` (list is scope-filtered), `server_overview`, start/stop/terminate, open-in-bench (`sso._asset_login_link`), and `terminate_site`.

## Server-level only, by design
- **The bench/pilot gets no scoped access** — and isn't meant to yet. The `fc_teams` SSO claim stays one entry per role with `scope: "*"` (bench contract unchanged), so a scoped member's bench session behaves exactly as today. Access is scoped to *which server* a role applies to; it never reaches inside-bench permissions. Emitting real per-grant scope + the `CAPABILITY_VERSION` bump are a separate, coordinated bench change (`spec/ATLAS_COORDINATION.md`).
- **`resize_server`** is gated by the billing `authz` (billing:manage, keyed on subscription), so it isn't resource-scoped here.

## Verified
On `ci-test.localhost`: `test_iam` 13/13 (incl. `test_different_roles_on_different_servers` — one member, Developer on srv-x + Viewer on srv-y) and `test_team_management` 25/25 (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)