### PR TITLE
refactor(servers): retire map zoom and pan, polish the servers pages

### DIFF
--- a/dashboard/src/components/servers/ServerListPanel.vue
+++ b/dashboard/src/components/servers/ServerListPanel.vue
@@ -27,7 +27,8 @@ const props = defineProps<{
 }>()
 
 defineEmits<{
-	focusRow: [row: ResourceRow]
+	/** Row click — the page opens the resource itself (bench/site/overview). */
+	openRow: [row: ResourceRow]
 	clearLocation: []
 	overview: [server: AssetRow]
 	open: [server: AssetRow]
@@ -71,7 +72,7 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 				<Button
 					variant="ghost"
 					icon="lucide-minimize-2"
-					aria-label="Collapse list"
+					label="Collapse list"
 					@click="open = false"
 				/>
 			</div>
@@ -115,7 +116,7 @@ const hoverId = defineModel<string | null>('hoverId', { required: true })
 					<div
 						class="sp-row group flex cursor-pointer items-center gap-3 rounded-lg px-2.5 py-2.5 transition-colors"
 						:style="{ animationDelay: `${Math.min(i * 25, 200)}ms` }"
-						@click="$emit('focusRow', row)"
+						@click="$emit('openRow', row)"
 						@mouseenter="hoverId = row.id"
 						@mouseleave="hoverId = null"
 					>

--- a/dashboard/src/components/servers/ServerMap.vue
+++ b/dashboard/src/components/servers/ServerMap.vue
@@ -19,7 +19,6 @@ import {
 	type MapPin,
 	type MapSpot,
 	project,
-	ZOOM_STEP,
 } from '@/lib/serverMap'
 
 // The interactive servers map, ported from the FC V2 prototype. Purely
@@ -36,9 +35,9 @@ const props = withDefaults(
 		selectedId?: string | null
 		/** Server id hovered elsewhere (the side panel) — bumps its node. */
 		highlightId?: string | null
-		/** Push the zoom controls left when a panel overlays the right edge (px). */
+		/** Width a panel overlays on the right edge (px) — cards clamp to the rest. */
 		panelOffset?: number
-		/** False = no drag/wheel/dblclick/controls; the map frames itself (markers). */
+		/** False = picker mode; the map frames its markers itself. */
 		interactive?: boolean
 		/** Show create affordances inside cards (page gates on server:create). */
 		allowCreate?: boolean
@@ -76,23 +75,28 @@ const emit = defineEmits<{
 	select: [region: string]
 }>()
 
-// Aliases for the projection frame the lib owns, so the pan/zoom math below reads
+// Aliases for the projection frame the lib owns, so the framing math below reads
 // unchanged. project() and computeNodes() (clustering) live in lib/serverMap.
 const W = MAP_WIDTH
 const H = MAP_HEIGHT
 const MAX_Z = MAX_ZOOM
-const STEP = ZOOM_STEP
+// User zoom and pan are retired: the map contain-fits the world and hover
+// cards carry the detail. The implementation stays commented in place rather
+// than deleted, so bringing it back is uncommenting these blocks, the handlers
+// on the root element, and the controls at the end of the template — plus
+// re-exporting ZOOM_STEP from lib/serverMap.
+// const STEP = ZOOM_STEP
 
-// — Viewport: contain-fit the world, then zoom/pan on top. At zoom 1 the map
-//   is centered and locked; zoomed in, it pans within the map's own bounds.
+// Contain-fit the world. There is no user zoom/pan; the zoom/translate state
+// below exists only so picker mode can frame its marker set.
 const el = ref<HTMLDivElement | null>(null)
 const cw = ref(0)
 const ch = ref(0)
 const zoom = ref(1)
 const tx = ref(0)
 const ty = ref(0)
-const dragging = ref(false)
-const wheeling = ref(false)
+// const dragging = ref(false)
+// const wheeling = ref(false)
 const focusing = ref(false)
 
 const base = computed(() =>
@@ -122,9 +126,9 @@ onBeforeUnmount(() => {
 	ro?.disconnect()
 	// Tear down every timer/RAF this component owns — the flyTo RAF loop
 	// (focusRaf) keeps writing zoom/tx/ty after unmount otherwise, and the
-	// hover/wheel debounces fire into a dead component.
+	// hover debounces fire into a dead component.
 	cancelAnimationFrame(focusRaf)
-	window.clearTimeout(wheelT)
+	// window.clearTimeout(wheelT)
 	window.clearTimeout(showT)
 	window.clearTimeout(hideT)
 })
@@ -149,26 +153,24 @@ const mapStyle = computed(() => ({
 	height: `${H * k.value}px`,
 }))
 
-function zoomAt(ax: number, ay: number, factor: number): void {
-	cancelFocus()
-	const zNew = Math.min(MAX_Z, Math.max(1, zoom.value * factor))
-	if (zNew === zoom.value) return
-	const kOld = k.value
-	const kNew = base.value * zNew
-	tx.value = ax - ((ax - tx.value) / kOld) * kNew
-	ty.value = ay - ((ay - ty.value) / kOld) * kNew
-	zoom.value = zNew
-	hideCard()
-	clampPan()
-}
-function zoomStep(dir: number): void {
-	zoomAt(cw.value / 2, ch.value / 2, dir > 0 ? STEP : 1 / STEP)
-}
+// function zoomAt(ax: number, ay: number, factor: number): void {
+// 	cancelFocus()
+// 	const zNew = Math.min(MAX_Z, Math.max(1, zoom.value * factor))
+// 	if (zNew === zoom.value) return
+// 	const kOld = k.value
+// 	const kNew = base.value * zNew
+// 	tx.value = ax - ((ax - tx.value) / kOld) * kNew
+// 	ty.value = ay - ((ay - ty.value) / kOld) * kNew
+// 	zoom.value = zNew
+// 	hideCard()
+// 	clampPan()
+// }
+// function zoomStep(dir: number): void {
+// 	zoomAt(cw.value / 2, ch.value / 2, dir > 0 ? STEP : 1 / STEP)
+// }
 
-// Focus a node in one continuous move: zoom to (at least) the stack level
-// while the node glides to the viewport centre. Driven frame-by-frame (CSS
-// transitions off) — zoom interpolates in log space and the node's on-screen
-// path is eased explicitly, so the combined motion never swings.
+// Reframe in one continuous move. Driven frame-by-frame rather than by CSS:
+// zoom interpolates in log space so the combined motion never swings.
 let focusRaf = 0
 function cancelFocus(): void {
 	cancelAnimationFrame(focusRaf)
@@ -196,9 +198,12 @@ function flyTo(wx: number, wy: number, z1: number): void {
 	}
 	focusRaf = requestAnimationFrame(frame)
 }
-function focusOn(n: MapNode): void {
-	flyTo(n.x, n.y, Math.min(MAX_Z, Math.max(zoom.value, STEP * STEP)))
-}
+
+// Focus a node in one continuous move: zoom to (at least) the stack level while
+// the node glides to the viewport centre.
+// function focusOn(n: MapNode): void {
+// 	flyTo(n.x, n.y, Math.min(MAX_Z, Math.max(zoom.value, STEP * STEP)))
+// }
 
 // Picker mode frames itself: fit the marker set (new provider = new frame).
 // First layout lands in place; later changes glide.
@@ -236,16 +241,16 @@ watch([() => props.markers, base], fitMarkers)
 
 // — Drag to pan (only when zoomed in). A real click is distinguished from a
 //   drag by a 4px slop; after a drag the trailing click is swallowed.
-interface DragState {
-	x: number
-	y: number
-	tx: number
-	ty: number
-	id: number
-	moved: boolean
-}
-let drag: DragState | null = null
-let suppressClick = false
+// interface DragState {
+// 	x: number
+// 	y: number
+// 	tx: number
+// 	ty: number
+// 	id: number
+// 	moved: boolean
+// }
+// let drag: DragState | null = null
+// let suppressClick = false
 function closestOf(e: Event, selector: string): Element | null {
 	return (e.target as Element | null)?.closest(selector) ?? null
 }
@@ -253,72 +258,72 @@ function onDown(e: PointerEvent): void {
 	if (e.button !== 0 || !props.interactive) return
 	// A locked card (its ⋯ menu was opened) closes on any press outside it.
 	if (cardLocked.value && !closestOf(e, '[data-map-card]')) hideCard()
-	if (zoom.value <= 1) return
-	if (closestOf(e, '[data-map-card],[data-map-controls]')) return
-	drag = {
-		x: e.clientX,
-		y: e.clientY,
-		tx: tx.value,
-		ty: ty.value,
-		id: e.pointerId,
-		moved: false,
-	}
+	// if (zoom.value <= 1) return
+	// if (closestOf(e, '[data-map-card],[data-map-controls]')) return
+	// drag = {
+	// 	x: e.clientX,
+	// 	y: e.clientY,
+	// 	tx: tx.value,
+	// 	ty: ty.value,
+	// 	id: e.pointerId,
+	// 	moved: false,
+	// }
 }
-function onMove(e: PointerEvent): void {
-	if (!drag) return
-	const dx = e.clientX - drag.x
-	const dy = e.clientY - drag.y
-	if (!drag.moved && Math.hypot(dx, dy) < 4) return
-	if (!drag.moved) {
-		drag.moved = true
-		dragging.value = true
-		cancelFocus() // don't fight the user for the viewport
-		hideCard()
-		el.value?.setPointerCapture?.(drag.id)
-	}
-	tx.value = drag.tx + dx
-	ty.value = drag.ty + dy
-	clampPan()
-}
-function onUp(): void {
-	if (drag?.moved) {
-		suppressClick = true
-		setTimeout(() => (suppressClick = false), 0)
-	}
-	drag = null
-	dragging.value = false
-}
-function onDblClick(e: MouseEvent): void {
-	if (!props.interactive) return
-	if (closestOf(e, '[data-map-card],[data-map-controls]')) return
-	if (!el.value) return
-	const r = el.value.getBoundingClientRect()
-	zoomAt(e.clientX - r.left, e.clientY - r.top, STEP)
-}
+// function onMove(e: PointerEvent): void {
+// 	if (!drag) return
+// 	const dx = e.clientX - drag.x
+// 	const dy = e.clientY - drag.y
+// 	if (!drag.moved && Math.hypot(dx, dy) < 4) return
+// 	if (!drag.moved) {
+// 		drag.moved = true
+// 		dragging.value = true
+// 		cancelFocus() // don't fight the user for the viewport
+// 		hideCard()
+// 		el.value?.setPointerCapture?.(drag.id)
+// 	}
+// 	tx.value = drag.tx + dx
+// 	ty.value = drag.ty + dy
+// 	clampPan()
+// }
+// function onUp(): void {
+// 	if (drag?.moved) {
+// 		suppressClick = true
+// 		setTimeout(() => (suppressClick = false), 0)
+// 	}
+// 	drag = null
+// 	dragging.value = false
+// }
+// function onDblClick(e: MouseEvent): void {
+// 	if (!props.interactive) return
+// 	if (closestOf(e, '[data-map-card],[data-map-controls]')) return
+// 	if (!el.value) return
+// 	const r = el.value.getBoundingClientRect()
+// 	zoomAt(e.clientX - r.left, e.clientY - r.top, STEP)
+// }
 
-// Trackpad: pinch (ctrl+wheel) zooms at the cursor; two-finger scroll pans
-// when zoomed in. Both move without the zoom transition.
-let wheelT: number | undefined
-function onWheel(e: WheelEvent): void {
-	if (!props.interactive) return
-	const pinch = e.ctrlKey || e.metaKey
-	if (!pinch && zoom.value <= 1) return
-	e.preventDefault()
-	wheeling.value = true
-	cancelFocus()
-	window.clearTimeout(wheelT)
-	wheelT = window.setTimeout(() => (wheeling.value = false), 140)
-	hideCard()
-	if (pinch) {
-		if (!el.value) return
-		const r = el.value.getBoundingClientRect()
-		zoomAt(e.clientX - r.left, e.clientY - r.top, Math.exp(-e.deltaY * 0.01))
-	} else {
-		tx.value -= e.deltaX
-		ty.value -= e.deltaY
-		clampPan()
-	}
-}
+// Trackpad: pinch (ctrl+wheel) zooms at the cursor; two-finger scroll pans when
+// zoomed in. Both move without the zoom transition.
+// let wheelT: number | undefined
+// function onWheel(e: WheelEvent): void {
+// 	if (!props.interactive) return
+// 	const pinch = e.ctrlKey || e.metaKey
+// 	if (!pinch && zoom.value <= 1) return
+// 	e.preventDefault()
+// 	wheeling.value = true
+// 	cancelFocus()
+// 	window.clearTimeout(wheelT)
+// 	wheelT = window.setTimeout(() => (wheeling.value = false), 140)
+// 	hideCard()
+// 	if (pinch) {
+// 		if (!el.value) return
+// 		const r = el.value.getBoundingClientRect()
+// 		zoomAt(e.clientX - r.left, e.clientY - r.top, Math.exp(-e.deltaY * 0.01))
+// 	} else {
+// 		tx.value -= e.deltaX
+// 		ty.value -= e.deltaY
+// 		clampPan()
+// 	}
+// }
 
 // Cluster the fleet into positioned nodes — pure, in lib/serverMap. Reclusters as
 // k/zoom change so groups split apart on zoom-in.
@@ -384,7 +389,7 @@ const cardLocked = ref(false)
 let showT: number | undefined
 let hideT: number | undefined
 function enterNode(n: MapNode): void {
-	if (dragging.value || cardLocked.value) return
+	if (cardLocked.value) return
 	window.clearTimeout(hideT)
 	window.clearTimeout(showT)
 	showT = window.setTimeout(() => (hoverKey.value = n.key), 40)
@@ -419,7 +424,7 @@ const card = computed<CardPlacement | null>(() => {
 	const { sx, sy } = screenOf(node)
 	const width = node.type === 'server' ? 320 : 288
 	// The side panel overlays the map's right edge, so the card clamps to the
-	// uncovered width — same treatment as the zoom controls.
+	// uncovered width.
 	const visibleW = cw.value - props.panelOffset
 	// Stacked avatars overlap sideways, so their card drops below instead of
 	// covering the neighbours to the right.
@@ -469,16 +474,16 @@ const card = computed<CardPlacement | null>(() => {
 	}
 })
 
-// Let the page focus the map from the side panel: glide to the node that
-// holds this server (its own pin, or the cluster it's grouped into).
-function focusPin(id: string): void {
-	const n = nodeForServer(id)
-	if (n) focusOn(n)
-}
-defineExpose({ focusPin })
+// Let the page focus the map from the side panel: glide to the node that holds
+// this server (its own pin, or the cluster it's grouped into).
+// function focusPin(id: string): void {
+// 	const n = nodeForServer(id)
+// 	if (n) focusOn(n)
+// }
+// defineExpose({ focusPin })
 
 function clickNode(n: MapNode): void {
-	if (suppressClick) return
+	// if (suppressClick) return
 	if (n.type === 'marker') {
 		emit('select', n.marker.id)
 	} else if (n.type === 'server') {
@@ -495,26 +500,28 @@ function clickNode(n: MapNode): void {
 	} else if (n.type === 'plus') {
 		emit('new-server', n.targets[0].id)
 	} else {
-		// A cluster focuses the map on itself, zooming to the stack level. The
-		// page narrows the list to this spot if the panel happens to be open.
-		focusOn(n)
+		// A cluster's members are browsed in its hover card; clicking locks the
+		// card open, and the page narrows its list if the panel is open. With
+		// zoom restored this focused the map on the stack instead: focusOn(n).
+		window.clearTimeout(showT)
+		hoverKey.value = n.key
+		cardLocked.value = true
 		emit('cluster-open', { ids: n.members.map((m) => m.id), label: n.title })
 	}
 }
 </script>
 
 <template>
+	<!-- With zoom and pan restored, this element also takes:
+	     :class="[ready && 'sm-anim', (dragging || wheeling || focusing) && 'sm-drag', dragging ? 'cursor-grabbing' : interactive && zoom > 1 ? 'cursor-grab' : '']"
+	     :style="interactive && zoom > 1 ? { touchAction: 'none' } : undefined"
+	     @pointermove="onMove" @pointerup="onUp" @pointercancel="onUp"
+	     @dblclick="onDblClick" @wheel="onWheel" -->
 	<div
 		ref="el"
 		class="relative isolate h-full w-full select-none overflow-hidden bg-surface-base"
-		:class="[ready && 'sm-anim', (dragging || wheeling || focusing) && 'sm-drag', dragging ? 'cursor-grabbing' : interactive && zoom > 1 ? 'cursor-grab' : '']"
-		:style="interactive && zoom > 1 ? { touchAction: 'none' } : undefined"
+		:class="[ready && 'sm-anim', focusing && 'sm-drag']"
 		@pointerdown="onDown"
-		@pointermove="onMove"
-		@pointerup="onUp"
-		@pointercancel="onUp"
-		@dblclick="onDblClick"
-		@wheel="onWheel"
 	>
 		<!-- Dotted world. Resize the SVG itself so it re-rasterizes at each zoom;
 		     nodes ride the same curve below so they track the dots. -->
@@ -654,7 +661,8 @@ function clickNode(n: MapNode): void {
 			</div>
 		</Transition>
 
-		<!-- Zoom controls; slide left when the server panel overlays the right edge -->
+		<!-- Zoom controls, retired with user zoom/pan. They slid left when the
+		     server panel overlaid the right edge.
 		<div
 			v-if="interactive"
 			data-map-controls
@@ -678,13 +686,14 @@ function clickNode(n: MapNode): void {
 				<span class="lucide-zoom-out size-4" />
 			</button>
 		</div>
+		-->
 	</div>
 </template>
 
 <style scoped>
 /* The map layer and every node share one curve, so pins track the dots
-   through the whole zoom. Transitions only arm after the first layout (the
-   map must appear in place, not animate in); dragging and pinching switch
+   through a reframe. Transitions only arm after the first layout (the map
+   must appear in place, not animate in); the frame-driven marker fit switches
    back to direct updates. */
 .sm-pos {
 	will-change: transform;
@@ -737,9 +746,9 @@ function clickNode(n: MapNode): void {
 	opacity: 0;
 }
 
-.sm-controls {
+/* .sm-controls {
 	transition: transform 300ms cubic-bezier(0.32, 0.72, 0, 1);
-}
+} */
 
 .sm-pulse {
 	animation: sm-pulse 1.8s ease-in-out infinite;
@@ -756,8 +765,7 @@ function clickNode(n: MapNode): void {
 
 @media (prefers-reduced-motion: reduce) {
 	.sm-pos,
-	.sm-center,
-	.sm-controls {
+	.sm-center {
 		transition: none;
 	}
 	.sm-pulse {

--- a/dashboard/src/components/servers/ServerOnboarding.vue
+++ b/dashboard/src/components/servers/ServerOnboarding.vue
@@ -29,7 +29,7 @@ defineEmits<{ create: []; dismiss: [] }>()
 				Create your first server
 			</p>
 			<p class="mt-1 text-p-sm text-ink-gray-5">
-				Spin one up to host your sites — or pick a
+				Your sites will run on it. Start here, or pick a
 				<span class="font-medium text-ink-gray-7">+</span>
 				spot on the map.
 			</p>

--- a/dashboard/src/components/servers/ServerOverviewDialog.vue
+++ b/dashboard/src/components/servers/ServerOverviewDialog.vue
@@ -63,14 +63,11 @@ const overviewCall = useCall<Overview, { team: string; resource_id: string }>({
 	immediate: false,
 })
 
+// No reset on close: the dialog is still fading out then, and blanking the
+// state mid-leave flashes the skeleton over the content. load() resets
+// everything at the start of the next open instead.
 watch([open, () => props.server?.resource_id], ([isOpen, resourceId]) => {
-	if (!isOpen) {
-		overview.value = null
-		overviewError.value = ''
-		hasLoaded.value = false
-		return
-	}
-	if (!resourceId || !activeTeam.value) return
+	if (!isOpen || !resourceId || !activeTeam.value) return
 	void load(resourceId)
 })
 

--- a/dashboard/src/composables/useServers.ts
+++ b/dashboard/src/composables/useServers.ts
@@ -126,7 +126,7 @@ async function runCommand(
 			resource_id: server.resource_id,
 		})
 		if (call.error) throw call.error
-		successToast(`${verb} requested for ${server.title || server.resource_id}.`)
+		successToast(`${verb} requested for ${server.title || server.resource_id}`)
 	} catch (e) {
 		errorToast(e)
 	} finally {
@@ -185,7 +185,7 @@ export function useServers() {
 			errorToast(createCall.error)
 			throw createCall.error
 		}
-		successToast(`Creating ${params.title} in ${params.region}.`)
+		successToast(`Creating ${params.title} in ${params.region}`)
 		return createCall.data?.resource_id ?? ''
 	}
 
@@ -198,7 +198,7 @@ export function useServers() {
 			errorToast(createComposedCall.error)
 			throw createComposedCall.error
 		}
-		successToast(`Creating ${params.title} in ${params.region}.`)
+		successToast(`Creating ${params.title} in ${params.region}`)
 		return createComposedCall.data?.resource_id ?? ''
 	}
 

--- a/dashboard/src/lib/serverMap.ts
+++ b/dashboard/src/lib/serverMap.ts
@@ -209,10 +209,12 @@ export const MAP_WIDTH = 879
 export const MAP_HEIGHT = 443
 const LAT_TOP = 83
 const LAT_BOTTOM = -56
+// User zoom is gone (hover cards carry the detail); this caps how far picker
+// mode may zoom while framing its marker set.
 export const MAX_ZOOM = 5
-export const ZOOM_STEP = 1.7
-// Past this zoom, servers sharing a spot stop counting ("3") and fan out into an
-// overlapping avatar stack. Two zoom-in clicks (1.7² ≈ 2.89) get you there.
+// export const ZOOM_STEP = 1.7 // restored with the map's zoom controls
+// Past this zoom, servers sharing a spot stop counting ("3") and fan out into
+// an overlapping avatar stack — only reachable via the picker's marker fit.
 export const STACK_ZOOM = 2.8
 
 // Greedy proximity-cluster thresholds in SCREEN pixels (divided by scale k), so

--- a/dashboard/src/lib/status.ts
+++ b/dashboard/src/lib/status.ts
@@ -62,9 +62,10 @@ export function invitationStatusTheme(status: InvitationStatus): BadgeTheme {
 }
 
 // Invoice status → Badge theme (case-insensitive), keyed by the Invoice DocType's
-// status options: Paid green, Open amber, Overdue red, Draft/Waived/Cancelled neutral.
+// status options. Paid is the normal state and stays gray — color is reserved
+// for states that need attention.
 const INVOICE_THEME: Record<string, BadgeTheme> = {
-	paid: 'green',
+	paid: 'gray',
 	open: 'orange',
 	overdue: 'red',
 	draft: 'gray',

--- a/dashboard/src/pages/onboarding/SiteReadyPage.vue
+++ b/dashboard/src/pages/onboarding/SiteReadyPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Button, ErrorMessage } from 'frappe-ui'
+import { Button, ErrorMessage, Spinner } from 'frappe-ui'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { API } from '@/api/methods'
@@ -72,10 +72,7 @@ onUnmounted(() => clearTimeout(timer))
 			</p>
 
 			<div class="mt-8 flex items-center gap-3 text-ink-gray-5">
-				<span
-					class="lucide-loader-circle size-5 animate-spin"
-					aria-hidden="true"
-				/>
+				<Spinner size="lg" />
 				<span class="text-base">Taking you to your site…</span>
 			</div>
 		</template>
@@ -103,10 +100,7 @@ onUnmounted(() => clearTimeout(timer))
 				a moment — hang tight.
 			</p>
 			<div class="mt-8 flex items-center gap-3 text-ink-gray-5">
-				<span
-					class="lucide-loader-circle size-5 animate-spin"
-					aria-hidden="true"
-				/>
+				<Spinner size="lg" />
 				<span class="text-base">{{ site?.status || 'Pending' }}…</span>
 			</div>
 			<ErrorMessage v-if="error" class="mt-6" :message="error" />

--- a/dashboard/src/pages/servers/ServersPage.vue
+++ b/dashboard/src/pages/servers/ServersPage.vue
@@ -105,7 +105,6 @@ const regionFilter = ref<{ provider: string; region: string }>({
 })
 const hoverId = ref<string | null>(null)
 const panelOpen = ref(false)
-const mapRef = ref<InstanceType<typeof ServerMap> | null>(null)
 
 // Servers and sites decorated into one sorted ResourceRow list (useFleetRows).
 const { rows } = useFleetRows(assets, sites, regions)
@@ -262,12 +261,7 @@ function canOpenBench(server: AssetRow): boolean {
 		canOpenServer.value && server.status === 'Running' && !!server.gateway_url
 	)
 }
-function onOpen(id: string): void {
-	const row = rows.value.find((r) => r.id === id)
-	if (!row) return
-	if (panelOpen.value) {
-		locationFilter.value = { ids: [id], label: row.name }
-	}
+function openResource(row: ResourceRow): void {
 	if (row.kind === 'site') {
 		if (canOpenServer.value && row.site?.url) openSite(row.site.name)
 		return
@@ -280,11 +274,16 @@ function onOpen(id: string): void {
 	// Not openable yet (still provisioning, stopped, …) — show the overview.
 	overviewServer.value = row.asset
 }
+function onOpen(id: string): void {
+	const row = rows.value.find((r) => r.id === id)
+	if (!row) return
+	if (panelOpen.value) {
+		locationFilter.value = { ids: [id], label: row.name }
+	}
+	openResource(row)
+}
 function onClusterOpen(payload: { ids: string[]; label: string }): void {
 	if (panelOpen.value) locationFilter.value = payload
-}
-function focusRow(row: ResourceRow): void {
-	mapRef.value?.focusPin(row.id)
 }
 function goNewServer(region: string): void {
 	router.push({ path: '/servers/new', query: { region } })
@@ -414,7 +413,6 @@ async function confirmSiteTerminate(): Promise<void> {
          the overlays' z-indexes from leaking above body-portaled menus. -->
 		<div v-else class="relative isolate flex-1 overflow-hidden">
 			<ServerMap
-				ref="mapRef"
 				class="absolute inset-0"
 				:pins="pins"
 				:spots="spots"
@@ -484,7 +482,7 @@ async function confirmSiteTerminate(): Promise<void> {
 				:busy="busy"
 				:opening="opening"
 				:opening-site="openingSite"
-				@focus-row="focusRow"
+				@open-row="openResource"
 				@clear-location="locationFilter = null"
 				@overview="overviewServer = $event"
 				@open="open"


### PR DESCRIPTION
## What this does

Simplifies the servers map to a single interaction model and polishes the servers pages. The map no longer zooms or pans by hand: hover cards carry the detail, clusters open their card in place, and only picker mode (choosing a region for a new server) still frames itself.

## Screenshots

![Servers map](https://raw.githubusercontent.com/sadiqxansari/frappe-central/497ee3aa1703e2edf279792a14dab9a48d9316b5/shots/servers-map.png)

## Changes in detail

- **Map**: drag-to-pan, wheel/pinch zoom, double-click zoom and the zoom control stack removed along with their state machine (drag slop, click suppression, wheel debounce); cluster click now locks the hover card open for browsing members instead of zooming into the stack
- **Pages**: side-panel row click opens the resource itself (bench, site, or overview dialog) instead of focusing its map pin; the server overview dialog no longer blanks mid-close (state resets on next open instead)
- **Copy and status**: onboarding card reads "Your sites will run on it. Start here, or pick a + spot on the map."; Paid invoices go quiet gray so color is reserved for states needing attention; spinners unified on frappe-ui `Spinner`

## For the reviewer

Logic commit: `server map: remove user zoom/pan, keep picker-mode framing` (mostly deletions). Visual: `servers pages and onboarding polish`.

**Stacked on #273**, review the top 2 commits.

## A note on the removed zoom and pan

The map's drag, wheel, double-click and zoom-control code is **commented out in place rather than deleted**, so bringing it back is uncommenting rather than digging through history. That covers the `zoomAt` / `zoomStep` / `focusOn` helpers, the drag and wheel handlers, `focusPin` and its `defineExpose`, the root element's bindings (listed in a comment right above it), the zoom controls at the end of the template, the `.sm-controls` transition, and `ZOOM_STEP` in `lib/serverMap.ts`. The commit that does it says the same thing, so it's findable from `git log` too.

That is why this commit reads as ~150 changed lines rather than ~170 deleted ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)