### PR TITLE
feat(atlas): persist inbound events before processing, dedup on event_id

### DIFF
--- a/central/api/atlas.py
+++ b/central/api/atlas.py
@@ -14,14 +14,14 @@ def event(**kwargs) -> dict:
 	"""
 	Webhook sink for Atlas lifecycle events. Atlas authenticates with its scoped
 	Central service-user token; ingest_event resolves the sender from that session,
-	then queues the mirror update so Atlas gets a fast ack. Body: `type`, `payload`,
-	`occurred_at`.
+	then queues the mirror update so Atlas gets a fast ack. Body: `event_id`, `type`,
+	`payload`, `occurred_at`.
 
 	"""
 	data = frappe._dict(kwargs)
 	payload = frappe.parse_json(data.payload) if isinstance(data.payload, str) else (data.payload or {})
 
-	return ingest_event(data.type, payload, data.occurred_at)
+	return ingest_event(data.type, payload, data.occurred_at, data.event_id)
 
 
 # --- Inbound Atlas HTTP endpoints -------------------------------------------

--- a/central/central/doctype/atlas_event/atlas_event.json
+++ b/central/central/doctype/atlas_event/atlas_event.json
@@ -1,0 +1,106 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-08-03 00:00:00.000000",
+ "description": "Durable store of received Atlas events, written before background processing.",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "cluster",
+  "event_id",
+  "event_type",
+  "status",
+  "column_break_main",
+  "occurred_at",
+  "processed_at",
+  "error",
+  "section_break_payload",
+  "raw_payload"
+ ],
+ "fields": [
+  {
+   "fieldname": "cluster",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Cluster",
+   "options": "Atlas Instance",
+   "reqd": 1
+  },
+  {
+   "description": "The sending Atlas's own delivery id (its Central Event Log row name). Stable across a redelivery of the same event.",
+   "fieldname": "event_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Event ID"
+  },
+  {
+   "fieldname": "event_type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Event Type",
+   "reqd": 1
+  },
+  {
+   "default": "Received",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "Received\nProcessed\nFailed\nIgnored"
+  },
+  {
+   "fieldname": "column_break_main",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "occurred_at",
+   "fieldtype": "Datetime",
+   "label": "Occurred At"
+  },
+  {
+   "fieldname": "processed_at",
+   "fieldtype": "Datetime",
+   "label": "Processed At"
+  },
+  {
+   "fieldname": "error",
+   "fieldtype": "Small Text",
+   "label": "Error"
+  },
+  {
+   "fieldname": "section_break_payload",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "raw_payload",
+   "fieldtype": "Long Text",
+   "label": "Raw Payload"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-08-03 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Central",
+ "name": "Atlas Event",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/central/central/doctype/atlas_event/atlas_event.json
+++ b/central/central/doctype/atlas_event/atlas_event.json
@@ -29,7 +29,6 @@
    "reqd": 1
   },
   {
-   "description": "The sending Atlas's own delivery id (its Central Event Log row name). Stable across a redelivery of the same event.",
    "fieldname": "event_id",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -77,7 +76,7 @@
   },
   {
    "fieldname": "raw_payload",
-   "fieldtype": "Long Text",
+   "fieldtype": "JSON",
    "label": "Raw Payload"
   }
  ],

--- a/central/central/doctype/atlas_event/atlas_event.json
+++ b/central/central/doctype/atlas_event/atlas_event.json
@@ -29,11 +29,12 @@
    "reqd": 1
   },
   {
-   "description": "The sending Atlas's own delivery id (its Central Event Log row name). Stable across a redelivery of the same event.",
+   "description": "The sending Atlas's own delivery id (its Central Event Log row name). Stable across a redelivery of the same event. Empty for an Atlas build predating event_id — dedup is skipped for those, not enforced.",
    "fieldname": "event_id",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Event ID"
+   "label": "Event ID",
+   "unique": 1
   },
   {
    "fieldname": "event_type",

--- a/central/central/doctype/atlas_event/atlas_event.json
+++ b/central/central/doctype/atlas_event/atlas_event.json
@@ -29,11 +29,12 @@
    "reqd": 1
   },
   {
-   "description": "The sending Atlas's own delivery id (its Central Event Log row name). Stable across a redelivery of the same event. Empty for an Atlas build predating event_id — dedup is skipped for those, not enforced.",
+   "description": "The sending Atlas's own delivery id (its Central Event Log row name). Stable across a redelivery of the same event.",
    "fieldname": "event_id",
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Event ID",
+   "reqd": 1,
    "unique": 1
   },
   {

--- a/central/central/doctype/atlas_event/atlas_event.py
+++ b/central/central/doctype/atlas_event/atlas_event.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class AtlasEvent(Document):
+	pass

--- a/central/central/doctype/atlas_event/atlas_event.py
+++ b/central/central/doctype/atlas_event/atlas_event.py
@@ -1,8 +1,17 @@
 # Copyright (c) 2026, Frappe and contributors
 # For license information, please see license.txt
 
+import frappe
 from frappe.model.document import Document
 
 
 class AtlasEvent(Document):
-	pass
+	def after_insert(self):
+		"""Queue the mirror write once the row is durably committed, so the inbound
+		webhook gets a fast ack and processing survives a lost immediate job."""
+		frappe.enqueue(
+			"central.integrations.atlas.apply_event",
+			queue="short",
+			enqueue_after_commit=True,
+			event_name=self.name,
+		)

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -438,27 +438,23 @@ def ingest_event(event_type: str, payload: dict, occurred_at, event_id: str | No
 	if event_type not in _EVENT_HANDLERS:
 		return {"ok": True, "queued": False}
 
-	# fast check by checking if the event_id already exists in the DB. If it does, we don't need to queue it again.
+	# A redelivery carries the same event_id, so skip anything we've already stored.
+	# The unique constraint on event_id is the backstop against a concurrent double
+	# delivery slipping past this check.
 	if frappe.db.exists("Atlas Event", {"event_id": event_id}):
 		return {"ok": True, "queued": False}
 
-	# the exists() check above already covers the common case, but two requests
-	# for the same event_id can still race between the check and the insert;
-	# that's rare, so we just try the insert and catch the unique violation
-	try:
-		event = frappe.get_doc(
-			{
-				"doctype": "Atlas Event",
-				"cluster": cluster,
-				"event_id": event_id,
-				"event_type": event_type,
-				"occurred_at": occurred_at,
-				"raw_payload": frappe.as_json(payload or {}),
-				"status": "Received",
-			}
-		).insert(ignore_permissions=True)
-	except frappe.UniqueValidationError:
-		return {"ok": True, "queued": False}
+	event = frappe.get_doc(
+		{
+			"doctype": "Atlas Event",
+			"cluster": cluster,
+			"event_id": event_id,
+			"event_type": event_type,
+			"occurred_at": occurred_at,
+			"raw_payload": frappe.as_json(payload or {}),
+			"status": "Received",
+		}
+	).insert(ignore_permissions=True)
 
 	frappe.enqueue(
 		apply_event,
@@ -477,10 +473,16 @@ def apply_event(event_name: str) -> None:
 
 	try:
 		_EVENT_HANDLERS[event.event_type](event.cluster, payload, event.occurred_at)
-	except Exception as e:
-		event.status = "Failed"
-		event.error = str(e)
-		event.save(ignore_permissions=True)
+	except Exception as exception:
+		# Commit the failure stamp before re-raising: the job runner rolls back on the
+		# way out, which would otherwise discard it and leave the row stuck at Received.
+		frappe.db.set_value(
+			"Atlas Event",
+			event_name,
+			{"status": "Failed", "error": str(exception)},
+			update_modified=False,
+		)
+		frappe.db.commit()
 		raise
 
 	event.status = "Processed"

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -439,25 +439,32 @@ def ingest_event(event_type: str, payload: dict, occurred_at, event_id: str | No
 
 	event_id is the sending Atlas's own delivery id (its Central Event Log row
 	name) — stable across a redelivery of the same event, distinct per genuine new
-	event. Stored as-is for now; dedup enforcement on it is a follow-up.
+	event. Empty for an Atlas build predating event_id, so dedup is skipped rather
+	than enforced for those (the unique constraint tolerates multiple NULLs).
 	"""
 
 	cluster = _atlas_cluster()
-
 	if event_type not in _EVENT_HANDLERS:
 		return {"ok": True, "queued": False}
 
-	event = frappe.get_doc(
-		{
-			"doctype": "Atlas Event",
-			"cluster": cluster,
-			"event_id": event_id,
-			"event_type": event_type,
-			"occurred_at": occurred_at,
-			"raw_payload": frappe.as_json(payload or {}),
-			"status": "Received",
-		}
-	).insert(ignore_permissions=True)
+	if event_id and frappe.db.exists("Atlas Event", {"event_id": event_id}):
+		return {"ok": True, "queued": False}
+
+	try:
+		event = frappe.get_doc(
+			{
+				"doctype": "Atlas Event",
+				"cluster": cluster,
+				"event_id": event_id,
+				"event_type": event_type,
+				"occurred_at": occurred_at,
+				"raw_payload": frappe.as_json(payload or {}),
+				"status": "Received",
+			}
+		).insert(ignore_permissions=True)
+	except frappe.UniqueValidationError:
+		# lost the race — another request stored this event_id first
+		return {"ok": True, "queued": False}
 
 	frappe.enqueue(
 		apply_event,

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -444,7 +444,8 @@ def ingest_event(event_type: str, payload: dict, occurred_at, event_id: str | No
 	if frappe.db.exists("Atlas Event", {"event_id": event_id}):
 		return {"ok": True, "queued": False}
 
-	event = frappe.get_doc(
+	# after_insert enqueues the mirror write once this row commits.
+	frappe.get_doc(
 		{
 			"doctype": "Atlas Event",
 			"cluster": cluster,
@@ -455,13 +456,6 @@ def ingest_event(event_type: str, payload: dict, occurred_at, event_id: str | No
 			"status": "Received",
 		}
 	).insert(ignore_permissions=True)
-
-	frappe.enqueue(
-		apply_event,
-		queue="short",
-		enqueue_after_commit=True,
-		event_name=event.name,
-	)
 
 	return {"ok": True, "queued": True}
 

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -428,13 +428,18 @@ class AtlasClient:
 # --- inbound push: webhook events (central.api.atlas.event delegates here) ---
 
 
-def ingest_event(event_type: str, payload: dict, occurred_at) -> dict:
+def ingest_event(event_type: str, payload: dict, occurred_at, event_id: str | None = None) -> dict:
 	"""
-	Resolve the sender from its authenticated session, then queue the mirror write so
-	Atlas gets a fast ack. The write runs in a background job — it's idempotent and
-	last-writer-wins, and the periodic reconcile is the backstop if a job is ever lost.
-	ping and unknown event types have nothing to mirror, so they're acknowledged
-	without queuing.
+	Resolve the sender from its authenticated session, persist the event, then queue
+	the mirror write so Atlas gets a fast ack. Persisting first means a lost or failed
+	background job leaves a row to inspect/retry instead of vanishing silently. The
+	write itself is idempotent and last-writer-wins, and the periodic reconcile is the
+	backstop if a job is ever lost. ping and unknown event types have nothing to
+	mirror, so they're acknowledged without storing or queuing.
+
+	event_id is the sending Atlas's own delivery id (its Central Event Log row
+	name) — stable across a redelivery of the same event, distinct per genuine new
+	event. Stored as-is for now; dedup enforcement on it is a follow-up.
 	"""
 
 	cluster = _atlas_cluster()
@@ -442,22 +447,44 @@ def ingest_event(event_type: str, payload: dict, occurred_at) -> dict:
 	if event_type not in _EVENT_HANDLERS:
 		return {"ok": True, "queued": False}
 
+	event = frappe.get_doc(
+		{
+			"doctype": "Atlas Event",
+			"cluster": cluster,
+			"event_id": event_id,
+			"event_type": event_type,
+			"occurred_at": occurred_at,
+			"raw_payload": frappe.as_json(payload or {}),
+			"status": "Received",
+		}
+	).insert(ignore_permissions=True)
+
 	frappe.enqueue(
 		apply_event,
 		queue="short",
 		enqueue_after_commit=True,
-		cluster=cluster,
-		event_type=event_type,
-		payload=payload or {},
-		occurred_at=occurred_at,
+		event_name=event.name,
 	)
 
 	return {"ok": True, "queued": True}
 
 
-def apply_event(cluster: str, event_type: str, payload: dict, occurred_at) -> None:
-	"""Background job: apply one verified Atlas event to the Asset mirror."""
-	_EVENT_HANDLERS[event_type](cluster, payload or {}, occurred_at)
+def apply_event(event_name: str) -> None:
+	"""Background job: apply one stored Atlas event to the Asset mirror."""
+	event = frappe.get_doc("Atlas Event", event_name)
+	payload = frappe.parse_json(event.raw_payload) if event.raw_payload else {}
+
+	try:
+		_EVENT_HANDLERS[event.event_type](event.cluster, payload, event.occurred_at)
+	except Exception as e:
+		event.status = "Failed"
+		event.error = str(e)
+		event.save(ignore_permissions=True)
+		raise
+
+	event.status = "Processed"
+	event.processed_at = frappe.utils.now_datetime()
+	event.save(ignore_permissions=True)
 
 
 def _atlas_cluster() -> str:

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -431,24 +431,20 @@ class AtlasClient:
 def ingest_event(event_type: str, payload: dict, occurred_at, event_id: str | None = None) -> dict:
 	"""
 	Resolve the sender from its authenticated session, persist the event, then queue
-	the mirror write so Atlas gets a fast ack. Persisting first means a lost or failed
-	background job leaves a row to inspect/retry instead of vanishing silently. The
-	write itself is idempotent and last-writer-wins, and the periodic reconcile is the
-	backstop if a job is ever lost. ping and unknown event types have nothing to
-	mirror, so they're acknowledged without storing or queuing.
-
-	event_id is the sending Atlas's own delivery id (its Central Event Log row
-	name) — stable across a redelivery of the same event, distinct per genuine new
-	event.
+	the mirror write so Atlas gets a fast ack.
 	"""
 
 	cluster = _atlas_cluster()
 	if event_type not in _EVENT_HANDLERS:
 		return {"ok": True, "queued": False}
 
+	# fast check by checking if the event_id already exists in the DB. If it does, we don't need to queue it again.
 	if frappe.db.exists("Atlas Event", {"event_id": event_id}):
 		return {"ok": True, "queued": False}
 
+	# the exists() check above already covers the common case, but two requests
+	# for the same event_id can still race between the check and the insert;
+	# that's rare, so we just try the insert and catch the unique violation
 	try:
 		event = frappe.get_doc(
 			{
@@ -462,7 +458,6 @@ def ingest_event(event_type: str, payload: dict, occurred_at, event_id: str | No
 			}
 		).insert(ignore_permissions=True)
 	except frappe.UniqueValidationError:
-		# lost the race — another request stored this event_id first
 		return {"ok": True, "queued": False}
 
 	frappe.enqueue(

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -439,15 +439,14 @@ def ingest_event(event_type: str, payload: dict, occurred_at, event_id: str | No
 
 	event_id is the sending Atlas's own delivery id (its Central Event Log row
 	name) — stable across a redelivery of the same event, distinct per genuine new
-	event. Empty for an Atlas build predating event_id, so dedup is skipped rather
-	than enforced for those (the unique constraint tolerates multiple NULLs).
+	event.
 	"""
 
 	cluster = _atlas_cluster()
 	if event_type not in _EVENT_HANDLERS:
 		return {"ok": True, "queued": False}
 
-	if event_id and frappe.db.exists("Atlas Event", {"event_id": event_id}):
+	if frappe.db.exists("Atlas Event", {"event_id": event_id}):
 		return {"ok": True, "queued": False}
 
 	try:

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -53,10 +53,20 @@ class TestAtlasMirror(IntegrationTestCase):
 		frappe.set_user("Administrator")
 
 	def _push(self, event_type, vm, occurred_at):
-		# ingest_event verifies the sender then queues the work; here we run the
-		# worker (apply_event) directly to assert its mirror effect. The
-		# verify-and-queue path is covered by the dispatch tests below.
-		apply_event(self.region, event_type, vm, occurred_at)
+		# ingest_event verifies the sender, persists the event, then queues the work;
+		# here we store the row and run the worker (apply_event) directly to assert
+		# its mirror effect. The verify-and-queue path is covered by the dispatch
+		# tests below.
+		event = frappe.get_doc(
+			{
+				"doctype": "Atlas Event",
+				"cluster": self.region,
+				"event_type": event_type,
+				"occurred_at": occurred_at,
+				"raw_payload": frappe.as_json(vm),
+			}
+		).insert(ignore_permissions=True)
+		apply_event(event.name)
 
 	# --- push -----------------------------------------------------------------
 

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -644,6 +644,31 @@ class TestAtlasMirror(IntegrationTestCase):
 		enqueue.assert_called_once()
 		self.assertEqual(frappe.db.count("Atlas Event", {"event_id": "evt-dup-1"}), 1)
 
+	def test_apply_event_stamps_failed_when_handler_raises(self):
+		# A handler error must be recorded durably and re-raised. The stamp is committed
+		# before the re-raise so the job runner's rollback can't strand the row at Received.
+		event = frappe.get_doc(
+			{
+				"doctype": "Atlas Event",
+				"cluster": self.region,
+				"event_id": frappe.generate_hash(length=12),
+				"event_type": "vm.created",
+				"occurred_at": "2026-06-18 10:00:00",
+				"raw_payload": frappe.as_json({"name": "vm-fail"}),
+			}
+		).insert(ignore_permissions=True)
+
+		def boom(*args, **kwargs):
+			raise RuntimeError("handler boom")
+
+		with patch.dict("central.integrations.atlas._EVENT_HANDLERS", {"vm.created": boom}):
+			with self.assertRaises(RuntimeError):
+				apply_event(event.name)
+
+		event.reload()
+		self.assertEqual(event.status, "Failed")
+		self.assertIn("handler boom", event.error)
+
 	def test_mirror_recovers_when_exists_check_loses_insert_race(self):
 		# Same event arrives twice at the same time.
 		from central.central.doctype.asset.asset import Asset

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -629,6 +629,51 @@ class TestAtlasMirror(IntegrationTestCase):
 		self.assertEqual(result, {"ok": True, "queued": False})
 		enqueue.assert_not_called()
 
+	def test_duplicate_event_id_is_deduped_not_requeued(self):
+		vm = {"name": "vm-dup", "team": self.team.name, "status": "Running"}
+		frappe.set_user(self.service_user)
+		try:
+			with patch("frappe.enqueue") as enqueue:
+				first = ingest_event("vm.created", vm, "2026-06-18 10:00:00", "evt-dup-1")
+				second = ingest_event("vm.created", vm, "2026-06-18 10:00:01", "evt-dup-1")
+		finally:
+			frappe.set_user("Administrator")
+		self.assertTrue(first["queued"])
+		self.assertFalse(second["queued"])
+		enqueue.assert_called_once()
+		self.assertEqual(frappe.db.count("Atlas Event", {"event_id": "evt-dup-1"}), 1)
+
+	def test_events_without_event_id_are_never_deduped_against_each_other(self):
+		vm = {"name": "vm-noid", "team": self.team.name, "status": "Running"}
+		frappe.set_user(self.service_user)
+		try:
+			with patch("frappe.enqueue") as enqueue:
+				first = ingest_event("vm.created", vm, "2026-06-18 10:00:00")
+				second = ingest_event("vm.created", vm, "2026-06-18 10:00:01")
+		finally:
+			frappe.set_user("Administrator")
+		self.assertTrue(first["queued"])
+		self.assertTrue(second["queued"])
+		self.assertEqual(enqueue.call_count, 2)
+
+	def test_ingest_event_recovers_when_exists_check_loses_insert_race(self):
+		# Simulate the same REPEATABLE READ race as mirror writes: a concurrent
+		# request's exists-check misses a row another request just committed, so it
+		# takes the insert path and hits the duplicate key. ingest_event must treat
+		# that as an already-stored replay, not let UniqueValidationError escape.
+		vm = {"name": "vm-race-evt", "team": self.team.name, "status": "Running"}
+		frappe.set_user(self.service_user)
+		try:
+			ingest_event("vm.created", vm, "2026-06-18 10:00:00", "evt-race-1")
+			with patch("frappe.db.exists", return_value=False):
+				with patch("frappe.enqueue") as enqueue:
+					result = ingest_event("vm.created", vm, "2026-06-18 10:00:01", "evt-race-1")
+		finally:
+			frappe.set_user("Administrator")
+		self.assertFalse(result["queued"])
+		enqueue.assert_not_called()
+		self.assertEqual(frappe.db.count("Atlas Event", {"event_id": "evt-race-1"}), 1)
+
 	def test_mirror_recovers_when_exists_check_loses_insert_race(self):
 		from central.central.doctype.asset.asset import Asset
 

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -61,6 +61,7 @@ class TestAtlasMirror(IntegrationTestCase):
 			{
 				"doctype": "Atlas Event",
 				"cluster": self.region,
+				"event_id": frappe.generate_hash(length=12),
 				"event_type": event_type,
 				"occurred_at": occurred_at,
 				"raw_payload": frappe.as_json(vm),
@@ -611,7 +612,7 @@ class TestAtlasMirror(IntegrationTestCase):
 		frappe.set_user(self.service_user)
 		try:
 			with patch("frappe.enqueue") as enqueue:
-				result = ingest_event("vm.created", vm, "2026-06-18 10:00:00")
+				result = ingest_event("vm.created", vm, "2026-06-18 10:00:00", "evt-q-1")
 		finally:
 			frappe.set_user("Administrator")
 		self.assertTrue(result["queued"])
@@ -642,19 +643,6 @@ class TestAtlasMirror(IntegrationTestCase):
 		self.assertFalse(second["queued"])
 		enqueue.assert_called_once()
 		self.assertEqual(frappe.db.count("Atlas Event", {"event_id": "evt-dup-1"}), 1)
-
-	def test_events_without_event_id_are_never_deduped_against_each_other(self):
-		vm = {"name": "vm-noid", "team": self.team.name, "status": "Running"}
-		frappe.set_user(self.service_user)
-		try:
-			with patch("frappe.enqueue") as enqueue:
-				first = ingest_event("vm.created", vm, "2026-06-18 10:00:00")
-				second = ingest_event("vm.created", vm, "2026-06-18 10:00:01")
-		finally:
-			frappe.set_user("Administrator")
-		self.assertTrue(first["queued"])
-		self.assertTrue(second["queued"])
-		self.assertEqual(enqueue.call_count, 2)
 
 	def test_ingest_event_recovers_when_exists_check_loses_insert_race(self):
 		# Simulate the same REPEATABLE READ race as mirror writes: a concurrent

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -644,25 +644,8 @@ class TestAtlasMirror(IntegrationTestCase):
 		enqueue.assert_called_once()
 		self.assertEqual(frappe.db.count("Atlas Event", {"event_id": "evt-dup-1"}), 1)
 
-	def test_ingest_event_recovers_when_exists_check_loses_insert_race(self):
-		# Simulate the same REPEATABLE READ race as mirror writes: a concurrent
-		# request's exists-check misses a row another request just committed, so it
-		# takes the insert path and hits the duplicate key. ingest_event must treat
-		# that as an already-stored replay, not let UniqueValidationError escape.
-		vm = {"name": "vm-race-evt", "team": self.team.name, "status": "Running"}
-		frappe.set_user(self.service_user)
-		try:
-			ingest_event("vm.created", vm, "2026-06-18 10:00:00", "evt-race-1")
-			with patch("frappe.db.exists", return_value=False):
-				with patch("frappe.enqueue") as enqueue:
-					result = ingest_event("vm.created", vm, "2026-06-18 10:00:01", "evt-race-1")
-		finally:
-			frappe.set_user("Administrator")
-		self.assertFalse(result["queued"])
-		enqueue.assert_not_called()
-		self.assertEqual(frappe.db.count("Atlas Event", {"event_id": "evt-race-1"}), 1)
-
 	def test_mirror_recovers_when_exists_check_loses_insert_race(self):
+		# Same event arrives twice at the same time.
 		from central.central.doctype.asset.asset import Asset
 
 		self._push(
@@ -671,9 +654,6 @@ class TestAtlasMirror(IntegrationTestCase):
 			"2026-06-18 10:00:00",
 		)
 
-		# Simulate the REPEATABLE READ race: a concurrent writer's exists-check misses
-		# the row, so it takes the insert path and hits the duplicate key. mirror_vm
-		# must recover by updating, not raise DuplicateEntryError.
 		real_exists = frappe.db.exists
 
 		def blind_to_asset(dt, *a, **k):

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -55,18 +55,20 @@ class TestAtlasMirror(IntegrationTestCase):
 	def _push(self, event_type, vm, occurred_at):
 		# ingest_event verifies the sender, persists the event, then queues the work;
 		# here we store the row and run the worker (apply_event) directly to assert
-		# its mirror effect. The verify-and-queue path is covered by the dispatch
+		# its mirror effect. after_insert's enqueue is stubbed so the only apply is the
+		# explicit one below. The verify-and-queue path is covered by the dispatch
 		# tests below.
-		event = frappe.get_doc(
-			{
-				"doctype": "Atlas Event",
-				"cluster": self.region,
-				"event_id": frappe.generate_hash(length=12),
-				"event_type": event_type,
-				"occurred_at": occurred_at,
-				"raw_payload": frappe.as_json(vm),
-			}
-		).insert(ignore_permissions=True)
+		with patch("frappe.enqueue"):
+			event = frappe.get_doc(
+				{
+					"doctype": "Atlas Event",
+					"cluster": self.region,
+					"event_id": frappe.generate_hash(length=12),
+					"event_type": event_type,
+					"occurred_at": occurred_at,
+					"raw_payload": frappe.as_json(vm),
+				}
+			).insert(ignore_permissions=True)
 		apply_event(event.name)
 
 	# --- push -----------------------------------------------------------------
@@ -647,16 +649,17 @@ class TestAtlasMirror(IntegrationTestCase):
 	def test_apply_event_stamps_failed_when_handler_raises(self):
 		# A handler error must be recorded durably and re-raised. The stamp is committed
 		# before the re-raise so the job runner's rollback can't strand the row at Received.
-		event = frappe.get_doc(
-			{
-				"doctype": "Atlas Event",
-				"cluster": self.region,
-				"event_id": frappe.generate_hash(length=12),
-				"event_type": "vm.created",
-				"occurred_at": "2026-06-18 10:00:00",
-				"raw_payload": frappe.as_json({"name": "vm-fail"}),
-			}
-		).insert(ignore_permissions=True)
+		with patch("frappe.enqueue"):
+			event = frappe.get_doc(
+				{
+					"doctype": "Atlas Event",
+					"cluster": self.region,
+					"event_id": frappe.generate_hash(length=12),
+					"event_type": "vm.created",
+					"occurred_at": "2026-06-18 10:00:00",
+					"raw_payload": frappe.as_json({"name": "vm-fail"}),
+				}
+			).insert(ignore_permissions=True)
 
 		def boom(*args, **kwargs):
 			raise RuntimeError("handler boom")


### PR DESCRIPTION
ref: frappe/central#199
Adds an Atlas Event doctype so inbound Atlas events are durably persisted before handling, with a unique constraint + race-safe insert on event_id to dedup retried deliveries. Companion to frappe/atlas#146, which is what now sends event_id on outbound events.