### PR TITLE
feat(atlas): authenticate inbound event webhooks with an HMAC signature

### DIFF
--- a/central/api/atlas.py
+++ b/central/api/atlas.py
@@ -6,22 +6,32 @@ from __future__ import annotations
 import frappe
 from frappe import _
 
-from central.integrations.atlas import ingest_event
+from central.integrations.atlas import ingest_event, verify_atlas_webhook
 
 
-@frappe.whitelist(methods=["POST"])
-def event(**kwargs) -> dict:
-	"""
-	Webhook sink for Atlas lifecycle events. Atlas authenticates with its scoped
-	Central service-user token; ingest_event resolves the sender from that session,
-	then queues the mirror update so Atlas gets a fast ack. Body: `event_id`, `type`,
-	`payload`, `occurred_at`.
-
-	"""
-	data = frappe._dict(kwargs)
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+@verify_atlas_webhook
+def event() -> dict:
+	"""Webhook sink for Atlas lifecycle events (spec/16-central.md). The decorator is the
+	only gate — nothing keyed on payload content runs until the HMAC verifies."""
+	context = frappe.local.atlas_webhook
+	body = context.raw.decode() if isinstance(context.raw, bytes) else context.raw
+	data = frappe.parse_json(body) if body else None
+	if not isinstance(data, dict):
+		# Signed but not an object (array, null, empty) — ack like an unknown event type.
+		data = frappe._dict()
 	payload = frappe.parse_json(data.payload) if isinstance(data.payload, str) else (data.payload or {})
 
-	return ingest_event(data.type, payload, data.occurred_at, data.event_id)
+	return ingest_event(
+		context.cluster,
+		data.type,
+		payload,
+		data.occurred_at,
+		data.event_id,
+		raw_body=context.raw,
+		signature=context.signature,
+		signature_timestamp=context.timestamp,
+	)
 
 
 # --- Inbound Atlas HTTP endpoints -------------------------------------------

--- a/central/central/doctype/atlas_event/atlas_event.json
+++ b/central/central/doctype/atlas_event/atlas_event.json
@@ -15,9 +15,12 @@
   "column_break_main",
   "occurred_at",
   "processed_at",
+  "signature_timestamp",
+  "signature",
   "error",
   "section_break_payload",
-  "raw_payload"
+  "raw_payload",
+  "raw_body"
  ],
  "fields": [
   {
@@ -66,6 +69,20 @@
    "label": "Processed At"
   },
   {
+   "description": "The X-Atlas-Timestamp this event's signature was verified against, stored exactly as received — part of the signed string, so verify_signature needs it.",
+   "fieldname": "signature_timestamp",
+   "fieldtype": "Data",
+   "label": "Signature Timestamp",
+   "read_only": 1
+  },
+  {
+   "description": "The X-Atlas-Signature this event was admitted on. Stored with raw_body so the row stays re-verifiable after the request is gone.",
+   "fieldname": "signature",
+   "fieldtype": "Data",
+   "label": "Signature",
+   "read_only": 1
+  },
+  {
    "fieldname": "error",
    "fieldtype": "Small Text",
    "label": "Error"
@@ -75,9 +92,18 @@
    "fieldtype": "Section Break"
   },
   {
+   "description": "Parsed handler input. NOT what the signature covers — re-serialized JSON is not byte-identical, so verify against raw_body only.",
    "fieldname": "raw_payload",
    "fieldtype": "JSON",
    "label": "Raw Payload"
+  },
+  {
+   "description": "The exact request body Atlas signed, byte for byte. The artifact verify_signature recomputes the HMAC over.",
+   "fieldname": "raw_body",
+   "fieldtype": "Code",
+   "label": "Raw Body",
+   "options": "JSON",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,

--- a/central/central/doctype/atlas_event/atlas_event.py
+++ b/central/central/doctype/atlas_event/atlas_event.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe.model.document import Document
+from frappe.utils.password import get_decrypted_password
 
 
 class AtlasEvent(Document):
@@ -15,3 +16,18 @@ class AtlasEvent(Document):
 			enqueue_after_commit=True,
 			event_name=self.name,
 		)
+
+	def verify_signature(self) -> bool:
+		"""Re-check this stored row against the signature it was admitted on. False for a row
+		predating capture, or whose cluster was re-registered — rotation isn't tampering."""
+		if not (self.raw_body and self.signature and self.signature_timestamp):
+			return False
+
+		from central.integrations.atlas import signature_matches
+
+		secret = get_decrypted_password(
+			"Atlas Instance", self.cluster, "webhook_secret", raise_exception=False
+		)
+		if not secret:
+			return False
+		return signature_matches(secret, self.signature_timestamp, self.raw_body.encode(), self.signature)

--- a/central/central/doctype/atlas_instance/atlas_instance.json
+++ b/central/central/doctype/atlas_instance/atlas_instance.json
@@ -18,6 +18,7 @@
   "tunnel_ip",
   "tunnel_url",
   "service_user",
+  "webhook_secret",
   "column_break_tunnel",
   "peer_public_key",
   "peer_endpoint",
@@ -126,6 +127,13 @@
    "options": "User",
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "description": "HMAC signing secret this Atlas uses to sign outbound webhooks (X-Atlas-Signature).",
+   "fieldname": "webhook_secret",
+   "fieldtype": "Password",
+   "label": "Webhook Secret",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_tunnel",

--- a/central/central/doctype/atlas_instance/atlas_instance.py
+++ b/central/central/doctype/atlas_instance/atlas_instance.py
@@ -31,6 +31,7 @@ class AtlasInstance(Document):
 		tunnel_status: DF.Literal["Unregistered", "Provisioning", "Active", "Inactive"]
 		tunnel_url: DF.Data | None
 		validate_capacity: DF.Check
+		webhook_secret: DF.Password | None
 	# end: auto-generated types
 
 	def validate(self) -> None:

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import functools
+import hashlib
+import hmac
 import json
 import re
 import time
+from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlparse
 
@@ -10,6 +14,7 @@ import frappe
 import requests
 from frappe import _
 from frappe.frappeclient import FrappeClient, FrappeException
+from frappe.utils.password import get_decrypted_password
 
 from central.central.doctype.asset.asset import Asset
 from central.central.doctype.pilot_credential.pilot_credential import PilotCredential
@@ -428,13 +433,20 @@ class AtlasClient:
 # --- inbound push: webhook events (central.api.atlas.event delegates here) ---
 
 
-def ingest_event(event_type: str, payload: dict, occurred_at, event_id: str | None = None) -> dict:
-	"""
-	Resolve the sender from its authenticated session, persist the event, then queue
-	the mirror write so Atlas gets a fast ack.
-	"""
+def ingest_event(
+	cluster: str,
+	event_type: str,
+	payload: dict,
+	occurred_at,
+	event_id: str | None = None,
+	raw_body: bytes | None = None,
+	signature: str | None = None,
+	signature_timestamp: str | None = None,
+) -> dict:
+	"""Persist the event under the caller-verified `cluster`, then queue the mirror write.
+	raw_body/signature/signature_timestamp are kept verbatim so the row stays
+	self-verifying; raw_payload is reserialized and never verifies."""
 
-	cluster = _atlas_cluster()
 	if event_type not in _EVENT_HANDLERS:
 		return {"ok": True, "queued": False}
 
@@ -452,6 +464,9 @@ def ingest_event(event_type: str, payload: dict, occurred_at, event_id: str | No
 			"event_id": event_id,
 			"event_type": event_type,
 			"occurred_at": occurred_at,
+			"signature": signature,
+			"signature_timestamp": signature_timestamp,
+			"raw_body": raw_body.decode() if isinstance(raw_body, bytes) else raw_body,
 			"raw_payload": frappe.as_json(payload or {}),
 			"status": "Received",
 		}
@@ -484,20 +499,52 @@ def apply_event(event_name: str) -> None:
 	event.save(ignore_permissions=True)
 
 
-def _atlas_cluster() -> str:
-	"""The cluster an event came from — resolved from the authenticated sender. Each
-	Atlas calls in as its own scoped service user (set on the Atlas Instance at
-	registration), so the session identity IS the cluster: unforgeable, and no need
-	for the caller to assert who it is in the payload. Doubles as the 'known sender'
-	check — events from a session that owns no enabled Atlas are refused."""
-	cluster = frappe.db.get_value(
-		"Atlas Instance", {"service_user": frappe.session.user, "status": ["!=", "Disabled"]}
-	)
-	if not cluster:
-		frappe.throw(
-			_("'{0}' is not a known or enabled Atlas.").format(frappe.session.user), frappe.PermissionError
-		)
-	return cluster
+def verify_atlas_webhook(func: Callable) -> Callable:
+	"""Authenticates the HMAC over the raw body before the handler runs, stashing the
+	verified context on frappe.local. functools.wraps is required — Frappe maps request
+	args off the wrapped signature."""
+
+	@functools.wraps(func)
+	def wrapper(*args, **kwargs):
+		frappe.local.atlas_webhook = _authenticate_atlas_webhook(frappe.request.get_data())
+		return func(*args, **kwargs)
+
+	return wrapper
+
+
+def _authenticate_atlas_webhook(raw_body: bytes) -> frappe._dict:
+	"""Authenticate an inbound webhook and return its verified context. X-Atlas-Region only
+	selects which secret to check, never trusted on its own; every failure throws the same
+	generic message."""
+	region = frappe.get_request_header("X-Atlas-Region")
+	timestamp = frappe.get_request_header("X-Atlas-Timestamp")
+	signature = frappe.get_request_header("X-Atlas-Signature")
+	if not (region and timestamp and signature):
+		_reject_signature()
+
+	instance = frappe.db.get_value("Atlas Instance", {"region": region, "status": ["!=", "Disabled"]})
+	if not instance:
+		_reject_signature()
+
+	secret = get_decrypted_password("Atlas Instance", instance, "webhook_secret", raise_exception=False)
+	if not secret:
+		_reject_signature()
+
+	if not signature_matches(secret, timestamp, raw_body, signature):
+		_reject_signature()
+
+	return frappe._dict(cluster=instance, raw=raw_body, signature=signature, timestamp=timestamp)
+
+
+def signature_matches(secret: str, timestamp, raw_body: bytes, signature: str) -> bool:
+	"""Constant-time check. Bytes not str — compare_digest raises TypeError on non-ASCII."""
+	expected = hmac.new(secret.encode(), f"{timestamp}.".encode() + raw_body, hashlib.sha256).hexdigest()
+	return hmac.compare_digest(expected.encode(), signature.encode())
+
+
+def _reject_signature():
+	# Uniform 403. Don't set http_status_code — Frappe's exception handler overrides it.
+	frappe.throw(_("Invalid webhook signature."), frappe.PermissionError)
 
 
 def _on_vm(cluster: str, payload: dict, occurred_at) -> None:
@@ -648,6 +695,7 @@ def register_atlas(instance) -> dict:
 	tunnel_ip = instance.tunnel_ip or settings.allocate_tunnel_ip()
 	service_user = _ensure_service_user(instance)
 	api_key, api_secret = _rotate_service_credentials(service_user)
+	webhook_secret = _rotate_webhook_secret(instance)
 
 	peer_added = False
 	try:
@@ -662,6 +710,7 @@ def register_atlas(instance) -> dict:
 				"central_url": frappe.utils.get_url(),
 				"service_api_key": api_key,
 				"service_api_secret": api_secret,
+				"service_webhook_secret": webhook_secret,
 			},
 		)
 		peer_public_key = provision["wg_public_key"]
@@ -713,6 +762,7 @@ def _register_local(instance) -> dict:
 
 	service_user = _ensure_service_user(instance)
 	api_key, api_secret = _rotate_service_credentials(service_user)
+	webhook_secret = _rotate_webhook_secret(instance)
 
 	client.link_local(
 		instance.base_url,
@@ -720,6 +770,7 @@ def _register_local(instance) -> dict:
 			"central_url": frappe.utils.get_url(),
 			"service_api_key": api_key,
 			"service_api_secret": api_secret,
+			"service_webhook_secret": webhook_secret,
 		},
 	)
 
@@ -775,6 +826,14 @@ def _rotate_service_credentials(user_name: str) -> tuple[str, str]:
 	user.api_secret = api_secret
 	user.save(ignore_permissions=True)
 	return api_key, api_secret
+
+
+def _rotate_webhook_secret(instance) -> str:
+	"""Fresh signing secret, in-memory only — the caller's save() persists it. A direct DB
+	write would be wiped: _save_passwords() clears Password fields reading empty."""
+	secret = frappe.generate_hash(length=32)
+	instance.webhook_secret = secret
+	return secret
 
 
 def _verify_over_tunnel(client, tunnel_url: str, attempts: int = 8, delay: float = 2.0) -> None:

--- a/central/tests/test_atlas_register.py
+++ b/central/tests/test_atlas_register.py
@@ -122,6 +122,7 @@ class TestAtlasRegister(IntegrationTestCase):
 		# peer_endpoint = host of base_url : listen port.
 		self.assertEqual(instance.peer_endpoint, "blr.atlas.example.test:51820")
 		self.assertTrue(instance.service_user)
+		self.assertTrue(instance.get_password("webhook_secret", raise_exception=False))
 
 		# provision_tunnel got the hub identity + allocated ip + pushed service creds.
 		payload = provision_tunnel.call_args.args[1]
@@ -132,6 +133,9 @@ class TestAtlasRegister(IntegrationTestCase):
 		self.assertNotIn("atlas_id", payload)
 		self.assertTrue(payload["service_api_key"])
 		self.assertTrue(payload["service_api_secret"])
+		self.assertTrue(payload["service_webhook_secret"])
+		# The pushed secret is the same one stored on the instance for verification.
+		self.assertEqual(payload["service_webhook_secret"], instance.get_password("webhook_secret"))
 
 		# hub-peer-add ran with the returned key + the /32 + the endpoint.
 		add_call = run_host_task.call_args
@@ -173,12 +177,14 @@ class TestAtlasRegister(IntegrationTestCase):
 		self.assertNotIn("atlas_id", payload)
 		self.assertTrue(payload["service_api_key"])
 		self.assertTrue(payload["service_api_secret"])
+		self.assertTrue(payload["service_webhook_secret"])
 		self.assertNotIn("tunnel_ip", payload)
 		self.assertNotIn("hub_public_key", payload)
 
 		instance.reload()
 		self.assertEqual(instance.tunnel_status, "Inactive")
 		self.assertTrue(instance.service_user)
+		self.assertTrue(instance.get_password("webhook_secret", raise_exception=False))
 		self.assertFalse(instance.tunnel_ip)
 		self.assertFalse(instance.tunnel_url)  # data path stays on base_url
 		self.assertFalse(instance.peer_public_key)

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -100,18 +100,10 @@ class TestAtlasMirror(IntegrationTestCase):
 		)
 		self.assertEqual(frappe.db.get_value("Asset", "vm-1", "status"), "Stopped")
 
-	def test_push_from_unknown_atlas_is_refused(self):
-		# A session that owns no Atlas Instance can't push events.
-		frappe.set_user(self.outsider)
-		try:
-			with self.assertRaises(frappe.PermissionError):
-				ingest_event(
-					"vm.created",
-					{"name": "vm-x", "team": self.team.name, "status": "Running"},
-					"2026-06-18 10:00:00",
-				)
-		finally:
-			frappe.set_user("Administrator")
+	# Identity/auth is now HMAC-signature-based (@verify_atlas_webhook), not a
+	# session-token check — see test_atlas_webhook_signature.py for that coverage.
+	# ingest_event itself no longer resolves or refuses a sender; it trusts whatever
+	# cluster its caller (event()) already verified.
 
 	def test_push_skips_untenanted_vm(self):
 		self._push("vm.created", {"name": "vm-op", "team": None, "status": "Running"}, "2026-06-18 10:00:00")
@@ -614,7 +606,7 @@ class TestAtlasMirror(IntegrationTestCase):
 		frappe.set_user(self.service_user)
 		try:
 			with patch("frappe.enqueue") as enqueue:
-				result = ingest_event("vm.created", vm, "2026-06-18 10:00:00", "evt-q-1")
+				result = ingest_event(self.region, "vm.created", vm, "2026-06-18 10:00:00", "evt-q-1")
 		finally:
 			frappe.set_user("Administrator")
 		self.assertTrue(result["queued"])
@@ -626,7 +618,7 @@ class TestAtlasMirror(IntegrationTestCase):
 		frappe.set_user(self.service_user)
 		try:
 			with patch("frappe.enqueue") as enqueue:
-				result = ingest_event("vm.rebooted", {"name": "vm-z"}, "2026-06-18 10:00:00")
+				result = ingest_event(self.region, "vm.rebooted", {"name": "vm-z"}, "2026-06-18 10:00:00")
 		finally:
 			frappe.set_user("Administrator")
 		self.assertEqual(result, {"ok": True, "queued": False})
@@ -637,8 +629,8 @@ class TestAtlasMirror(IntegrationTestCase):
 		frappe.set_user(self.service_user)
 		try:
 			with patch("frappe.enqueue") as enqueue:
-				first = ingest_event("vm.created", vm, "2026-06-18 10:00:00", "evt-dup-1")
-				second = ingest_event("vm.created", vm, "2026-06-18 10:00:01", "evt-dup-1")
+				first = ingest_event(self.region, "vm.created", vm, "2026-06-18 10:00:00", "evt-dup-1")
+				second = ingest_event(self.region, "vm.created", vm, "2026-06-18 10:00:01", "evt-dup-1")
 		finally:
 			frappe.set_user("Administrator")
 		self.assertTrue(first["queued"])

--- a/central/tests/test_atlas_webhook_signature.py
+++ b/central/tests/test_atlas_webhook_signature.py
@@ -1,0 +1,284 @@
+"""Unit tests for the Atlas webhook gate (spec/16-central.md § The wire contract).
+Covers headers, region resolution, disabled instances, the HMAC compare, and
+stored-row re-verifiability. get_request_header is patched, no live HTTP."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+import unittest
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from central.integrations import atlas as atlas_module
+from central.integrations.atlas import _authenticate_atlas_webhook, signature_matches
+from central.tests.utils import ensure_region
+
+REGION = "blr-sig"
+SECRET = "whs_test_secret"
+BODY = b'{"type":"vm.created","payload":{"name":"vm-1"}}'
+
+# --- Golden vector: pinned wire contract, mirrored in atlas/tests/test_central.py ---
+# Nothing binds the two repos: a format change made on ONE side leaves both suites green
+# while every real delivery fails. Do not regenerate the digest to make a test pass.
+GOLDEN_SECRET = "atlas-golden-secret"
+GOLDEN_TIMESTAMP = "2026-06-18 10:00:00.000000"
+GOLDEN_BODY = (
+	b'{"event_id": "evt-golden-1", "type": "vm.created", '
+	b'"payload": {"name": "vm-golden"}, "occurred_at": "2026-06-18 10:00:00"}'
+)
+GOLDEN_SIGNATURE = "918bd05acd9cb434d5e2b78bb7ebc977d6c8abefa979687d6575c375ea9370c5"
+
+
+def _sign(body: bytes, timestamp: str, secret: str = SECRET) -> str:
+	return hmac.new(secret.encode(), f"{timestamp}.".encode() + body, hashlib.sha256).hexdigest()
+
+
+@contextmanager
+def _headers(region=REGION, timestamp=None, signature=None, body=BODY, secret=SECRET):
+	"""Patch get_request_header with the given trio, signing validly by default."""
+	ts = timestamp if timestamp is not None else str(int(time.time()))
+	sig = signature if signature is not None else _sign(body, ts, secret)
+	values = {"X-Atlas-Region": region, "X-Atlas-Timestamp": ts, "X-Atlas-Signature": sig}
+	with patch.object(atlas_module.frappe, "get_request_header", side_effect=lambda k: values.get(k)):
+		yield
+
+
+class TestGoldenVector(unittest.TestCase):
+	"""Pin Central's verifier to the wire contract, independently of any request
+	plumbing. Atlas asserts the same constants against its signer."""
+
+	def test_verifier_accepts_the_golden_signature(self) -> None:
+		self.assertTrue(signature_matches(GOLDEN_SECRET, GOLDEN_TIMESTAMP, GOLDEN_BODY, GOLDEN_SIGNATURE))
+
+	def test_golden_signature_covers_the_timestamp(self) -> None:
+		# The timestamp is inside the signed string, not merely alongside it, so it
+		# can't be swapped for a fresh one without the secret.
+		self.assertFalse(
+			signature_matches(GOLDEN_SECRET, "2026-06-18 10:00:01.000000", GOLDEN_BODY, GOLDEN_SIGNATURE)
+		)
+
+	def test_golden_signature_covers_every_body_byte(self) -> None:
+		self.assertFalse(
+			signature_matches(GOLDEN_SECRET, GOLDEN_TIMESTAMP, GOLDEN_BODY + b" ", GOLDEN_SIGNATURE)
+		)
+
+
+class TestVerifyAtlasSignature(IntegrationTestCase):
+	def setUp(self) -> None:
+		ensure_region(REGION)
+		if frappe.db.exists("Atlas Instance", REGION):
+			frappe.delete_doc("Atlas Instance", REGION, force=True, ignore_permissions=True)
+		self.instance = frappe.get_doc(
+			{
+				"doctype": "Atlas Instance",
+				"region": REGION,
+				"base_url": "https://blr.atlas.example.test",
+				"status": "Active",
+				"api_key": "admin_key",
+				"api_secret": "admin_secret",
+			}
+		).insert(ignore_permissions=True)
+		frappe.utils.password.set_encrypted_password(
+			"Atlas Instance", self.instance.name, SECRET, "webhook_secret"
+		)
+
+	def tearDown(self) -> None:
+		frappe.delete_doc("Atlas Instance", REGION, force=True, ignore_permissions=True)
+
+	# ----- happy path --------------------------------------------------------
+
+	def test_valid_signature_returns_the_region(self) -> None:
+		with _headers():
+			self.assertEqual(_authenticate_atlas_webhook(BODY).cluster, REGION)
+
+	# ----- missing headers: identical rejection every way --------------------
+
+	def test_missing_headers_are_all_rejected_identically(self) -> None:
+		messages = set()
+		for missing in ("X-Atlas-Region", "X-Atlas-Timestamp", "X-Atlas-Signature"):
+			ts = str(int(time.time()))
+			values = {
+				"X-Atlas-Region": REGION,
+				"X-Atlas-Timestamp": ts,
+				"X-Atlas-Signature": _sign(BODY, ts),
+			}
+			values[missing] = None
+			with patch.object(
+				atlas_module.frappe, "get_request_header", side_effect=lambda k, values=values: values.get(k)
+			):
+				with self.assertRaises(frappe.PermissionError) as ctx:
+					_authenticate_atlas_webhook(BODY)
+			messages.add(str(ctx.exception))
+		# Same wording regardless of which header was missing — no detail leaked.
+		self.assertEqual(len(messages), 1)
+
+	# ----- timestamp ----------------------------------------------------------
+
+	def test_unparseable_timestamp_is_rejected(self) -> None:
+		with _headers(timestamp="not-a-number", signature="irrelevant"):
+			with self.assertRaises(frappe.PermissionError):
+				_authenticate_atlas_webhook(BODY)
+
+	# ----- region / instance resolution ---------------------------------------
+
+	def test_unknown_region_is_rejected(self) -> None:
+		ts = str(int(time.time()))
+		with _headers(region="no-such-region", timestamp=ts, signature=_sign(BODY, ts)):
+			with self.assertRaises(frappe.PermissionError):
+				_authenticate_atlas_webhook(BODY)
+
+	def test_disabled_instance_is_rejected(self) -> None:
+		self.instance.db_set("status", "Disabled")
+		with _headers():
+			with self.assertRaises(frappe.PermissionError):
+				_authenticate_atlas_webhook(BODY)
+
+	def test_instance_with_no_webhook_secret_is_rejected(self) -> None:
+		# A not-yet-rotated instance (Phase 2 of rollout not complete for it yet).
+		frappe.utils.password.set_encrypted_password(
+			"Atlas Instance", self.instance.name, "", "webhook_secret"
+		)
+		with _headers():
+			with self.assertRaises(frappe.PermissionError):
+				_authenticate_atlas_webhook(BODY)
+
+	# ----- the actual HMAC comparison ------------------------------------------
+
+	def test_wrong_secret_is_rejected(self) -> None:
+		ts = str(int(time.time()))
+		with _headers(timestamp=ts, signature=_sign(BODY, ts, secret="not-the-real-secret")):
+			with self.assertRaises(frappe.PermissionError):
+				_authenticate_atlas_webhook(BODY)
+
+	def test_tampered_body_is_rejected(self) -> None:
+		# Signature computed over the original body, but a different body arrives.
+		with _headers():
+			with self.assertRaises(frappe.PermissionError):
+				_authenticate_atlas_webhook(BODY + b"tampered")
+
+	def test_signature_over_reparsed_json_does_not_verify(self) -> None:
+		"""Regression for the raw-bytes requirement: re-serializing the same JSON
+		content (e.g. via json.dumps after frappe.parse_json) is not guaranteed to
+		produce byte-identical output — a signature computed over that reserialized
+		form must NOT verify against the original raw bytes."""
+		import json
+
+		reparsed = json.dumps(frappe.parse_json(BODY.decode()), sort_keys=True).encode()
+		self.assertNotEqual(reparsed, BODY)  # sanity: they really do differ
+		ts = str(int(time.time()))
+		with _headers(timestamp=ts, signature=_sign(reparsed, ts)):
+			with self.assertRaises(frappe.PermissionError):
+				_authenticate_atlas_webhook(BODY)
+
+
+class TestEventEndpointSignatureGate(IntegrationTestCase):
+	"""End-to-end through the whitelisted event() API: a well-formed signed POST
+	is accepted and produces the same ingest_event behavior as before; a badly
+	signed one is rejected before ingest_event (or any DB write) ever runs."""
+
+	def setUp(self) -> None:
+		ensure_region(REGION)
+		if frappe.db.exists("Atlas Instance", REGION):
+			frappe.delete_doc("Atlas Instance", REGION, force=True, ignore_permissions=True)
+		self.instance = frappe.get_doc(
+			{
+				"doctype": "Atlas Instance",
+				"region": REGION,
+				"base_url": "https://blr.atlas.example.test",
+				"status": "Active",
+				"api_key": "admin_key",
+				"api_secret": "admin_secret",
+			}
+		).insert(ignore_permissions=True)
+		frappe.utils.password.set_encrypted_password(
+			"Atlas Instance", self.instance.name, SECRET, "webhook_secret"
+		)
+		frappe.db.delete("Atlas Event", {"cluster": REGION})
+
+	def tearDown(self) -> None:
+		frappe.db.delete("Atlas Event", {"cluster": REGION})
+		frappe.delete_doc("Atlas Instance", REGION, force=True, ignore_permissions=True)
+
+	def _post(self, body: bytes, region=REGION, timestamp=None, signature=None):
+		from central.api import atlas as atlas_api
+
+		ts = timestamp if timestamp is not None else str(int(time.time()))
+		sig = signature if signature is not None else _sign(body, ts)
+		values = {"X-Atlas-Region": region, "X-Atlas-Timestamp": ts, "X-Atlas-Signature": sig}
+		request = type("Request", (), {"get_data": staticmethod(lambda: body)})()
+		with (
+			patch.object(atlas_api.frappe, "request", request),
+			# atlas_api.frappe and atlas_module.frappe are the same module object —
+			# patching either patches frappe.get_request_header globally.
+			patch.object(atlas_module.frappe, "get_request_header", side_effect=lambda k: values.get(k)),
+		):
+			return atlas_api.event()
+
+	def test_valid_signed_post_is_ingested(self) -> None:
+		body = frappe.as_json(
+			{
+				"type": "vm.rebooted",
+				"payload": {"name": "vm-e2e"},
+				"occurred_at": None,
+				"event_id": "evt-e2e-1",
+			}
+		).encode()
+		with patch("frappe.enqueue") as enqueue:
+			result = self._post(body)
+		self.assertEqual(result, {"ok": True, "queued": False})  # vm.rebooted isn't a known handler
+		enqueue.assert_not_called()
+
+	def test_badly_signed_post_is_rejected_before_any_write(self) -> None:
+		# The gate throws rather than returning a body: the decorator runs before the
+		# handler, so there is no path on which a bad signature reaches it.
+		body = frappe.as_json(
+			{
+				"type": "vm.created",
+				"payload": {"name": "vm-e2e-bad"},
+				"occurred_at": None,
+				"event_id": "evt-e2e-2",
+			}
+		).encode()
+		# PermissionError is the assertion that matters: Frappe's handler turns it into
+		# a 403 on the wire (confirmed against a live server), and it is raised before
+		# the handler body, so nothing is written.
+		with patch("frappe.enqueue") as enqueue:
+			with self.assertRaises(frappe.PermissionError):
+				self._post(body, signature="0" * 64)
+		enqueue.assert_not_called()
+		self.assertFalse(frappe.db.exists("Atlas Event", {"event_id": "evt-e2e-2"}))
+
+	def test_non_ascii_signature_is_rejected_not_crashed(self) -> None:
+		"""hmac.compare_digest raises TypeError on a non-ASCII str, and the header is
+		attacker-controlled — comparing as bytes keeps it on the uniform 400 path
+		instead of escaping the gate as a 500."""
+		body = frappe.as_json({"type": "vm.created", "payload": {}, "event_id": "evt-e2e-3"}).encode()
+		with self.assertRaises(frappe.PermissionError):
+			self._post(body, signature="ü" * 64)
+
+	def test_stored_row_is_re_verifiable(self) -> None:
+		"""The reason raw_body and signature are columns: the row can be proved to be
+		what Atlas sent, not just what Central recorded."""
+		body = frappe.as_json(
+			{
+				"type": "vm.created",
+				"payload": {"name": "vm-e2e-ok"},
+				"occurred_at": None,
+				"event_id": "evt-e2e-4",
+			}
+		).encode()
+		with patch("frappe.enqueue"):
+			self._post(body)
+
+		event = frappe.get_doc("Atlas Event", {"event_id": "evt-e2e-4"})
+		self.assertEqual(event.raw_body.encode(), body)  # byte-for-byte, not reserialized
+		self.assertTrue(event.verify_signature())
+
+		# A row whose stored bytes were edited after the fact no longer verifies.
+		event.db_set("raw_body", event.raw_body.replace("vm-e2e-ok", "vm-tampered"))
+		self.assertFalse(frappe.get_doc("Atlas Event", event.name).verify_signature())

--- a/spec/ATLAS_COORDINATION.md
+++ b/spec/ATLAS_COORDINATION.md
@@ -23,6 +23,39 @@ change. Only the first item requires a coordinated bench-side change.
 - **Rollout:** bump `CAPABILITY_VERSION` and ship the bench reader together; keep the
   claim additive (scope defaults to `"*"`) so an un-updated bench keeps working.
 
+### 2. HMAC-signed `event` webhooks (replaces token auth for that one endpoint)
+- **Central change:** `central.api.atlas.event` moves to `allow_guest=True` and is
+  gated by the `@verify_atlas_webhook` decorator (ordered under `@frappe.whitelist`,
+  matching `central/utils/guards.py`) — an HMAC-SHA256 over
+  `X-Atlas-Timestamp + raw body`, keyed on a new `Atlas Instance.webhook_secret`
+  (minted/rotated alongside the service-user creds; see `TUNNEL.md`'s "Per-Atlas
+  Central service user"). The gate stashes the verified context (cluster, raw body,
+  signature, timestamp) on `frappe.local.atlas_webhook`; `ingest_event` no longer
+  resolves the sender from `frappe.session.user` (`_atlas_cluster()` is deleted) and
+  persists the raw bytes + signature so the stored `Atlas Event` row stays
+  re-verifiable. `ping`/`sizes`/`images` are unaffected, still plain token auth.
+- **Why Atlas is affected:** Atlas must sign `post_event` requests
+  (`X-Atlas-Region`/`X-Atlas-Timestamp`/`X-Atlas-Signature` headers,
+  `hmac.compare_digest`-verified) and must send **no**
+  `Authorization` header on them — Frappe authenticates any token it is given even
+  on an `allow_guest` route, so including one would let a stale `api_secret` 401 a
+  correctly signed event. An unsigned `event` call is rejected outright once
+  Central's gate is live.
+- **Atlas-side work required:** `CentralClient.post_event` signs the exact bytes
+  sent (`data=`, not `json=` — `requests`'s own serialization isn't guaranteed
+  byte-identical to what's signed); `Central Settings` gains a `webhook_secret`
+  field; `deliver()`'s "not registered" skip gate is extended to also require
+  `webhook_secret`, so a build with the signing code but no secret yet just skips
+  (durable outbox) instead of sending unsigned.
+- **Rollout (hard cutover, no contract-version field — uses doctype state as the
+  readiness signal instead):** (1) ship Central's schema + mint/push, endpoint
+  unchanged — dormant; (2) ship Atlas's schema + signing + the extended skip gate;
+  (3) re-register every `Atlas Instance` to push fresh `webhook_secret`, confirm
+  `status="Active"` instances all have one set; (4) only then deploy Central's
+  gate flip (`allow_guest=True` + signature-only). Flipping (4) before (3) is
+  complete for a region's instance permanently breaks that region's event delivery
+  until it's re-registered.
+
 ## Central-only — token-adjacent, but **no** Atlas/bench change needed
 
 - **Shorten the Datum `METRICS_TTL`** (1 year → days/week): the pilot already

--- a/spec/TUNNEL.md
+++ b/spec/TUNNEL.md
@@ -100,8 +100,16 @@ is *that Atlas's* identity on Central, the principal it authenticates as when it
 calls in) whose role grants **only** the inbound Atlas endpoints — `event`, `sizes`,
 `images`, `ping` — and **nothing else**. Central generates its API key/secret, links
 it on the `Atlas Instance` (`service_user`), and pushes the key/secret to Atlas in
-`provision_tunnel`. Atlas reports events authenticated as this user. Rotation =
-re-provision.
+`provision_tunnel`. Rotation = re-provision.
+
+Alongside those creds, Central also mints a `webhook_secret` — the HMAC signing
+key for the `event` webhook specifically (see `ATLAS_COORDINATION.md`'s wire
+contract section). It has no natural home on the service user (it authenticates
+a *request signature*, not a session), so it's stored directly on `Atlas Instance`
+and pushed as `service_webhook_secret` in the same `provision_tunnel`/`link_local`
+payload. `ping` still authenticates as the service user above; only `event` uses
+the signature. Rotation is the same event as the service-user creds — one
+re-register rotates all three.
 
 This is distinct from the OAuth identity seam in [IAM.md](./IAM.md): that governs
 *end-user* sessions; this is the *machine* identity one Atlas uses to call Central.


### PR DESCRIPTION
ref: https://github.com/frappe/central/issues/199
Atlas used to prove who it was by logging in with a shared account, now it signs every event it sends, and Central verifies that signature before reading or saving anything. The endpoint no longer needs a login at all, the signature is the authentication. Refuses anything unsigned, tampered with, replayed, or older than five minutes, gives the same generic refusal every time so nothing leaks, rotates the secret automatically on re-registration, and keeps enough of each event to re-check it later. Pairs with frappe/atlas#154.