### PR TITLE
Stripe-first billing: fallback rules, Amex/Diners routing, and the payment order card

### DIFF
--- a/central/billing/api/dashboard/account.py
+++ b/central/billing/api/dashboard/account.py
@@ -193,10 +193,15 @@ def get_collection_status(team: str | None = None) -> dict:
 	Re-checks an e-mandate team against the ₹15,000 silent-debit threshold using the
 	month-to-date forecast (so we warn before the bill lands), then returns the state
 	the banner renders from: the mode, whether action is required and why, the
-	threshold, and the numbers (projected total, wallet balance, shortfall)."""
+	threshold, and the numbers (projected total, wallet balance, shortfall).
+
+	It also carries `mandate_gap_note`: the networks no rail will auto-charge. This
+	is the screen where a customer decides how they want to pay, so it is the honest
+	place to say that an Amex or Diners card leaves the wallet as their option —
+	before they pick auto-pay and discover it at authorisation (ADR 0023)."""
 	team = _resolve_team(team)
 	from central.billing.api.dashboard.invoices import get_forecast
-	from central.billing.payments import collection_mode
+	from central.billing.payments import collection_mode, instruments
 	from central.billing.revenue import credits
 
 	projected = frappe.utils.flt(get_forecast(team).get("projected_total"))
@@ -208,6 +213,7 @@ def get_collection_status(team: str | None = None) -> dict:
 		"wallet_balance": wallet,
 		"shortfall": max(0.0, frappe.utils.flt(projected - wallet, 2)),
 		"currency": _team_currency(team),
+		"mandate_gap_note": instruments.mandate_gap_note(_team_currency(team)),
 	}
 
 

--- a/central/billing/api/dashboard/account.py
+++ b/central/billing/api/dashboard/account.py
@@ -219,7 +219,8 @@ def get_collection_status(team: str | None = None) -> dict:
 
 @frappe.whitelist(methods=["POST"])
 def set_collection_mode(team: str | None = None, mode: str | None = None) -> dict:
-	"""Customer resolves Action Required (or switches) — manual_checkout / prepaid."""
+	"""Customer picks how they are collected — Manual Checkout, Prepaid, or back to
+	Auto Charge once there is a method that can be charged."""
 	team = _resolve_team(team, authz.MANAGE)
 	from central.billing.payments import collection_mode
 

--- a/central/billing/api/dashboard/methods.py
+++ b/central/billing/api/dashboard/methods.py
@@ -184,6 +184,7 @@ def setup_payment_method_order(
 	method_type: str = "UPI Autopay",
 	contact: str | None = None,
 	instrument: str | None = None,
+	after_decline: bool = False,
 ) -> dict:
 	"""Begin saving a Razorpay-rail method — a UPI Autopay mandate, or a card token
 	for a network Stripe will not register a mandate on.
@@ -192,7 +193,11 @@ def setup_payment_method_order(
 	the gateway is resolved from it rather than from the currency default. Callers
 	that predate the tiles still pass `method_type`. `contact` is the phone the UI
 	collects inline for a card mandate when the billing profile has none (Razorpay
-	requires a customer contact for recurring cards)."""
+	requires a customer contact for recurring cards).
+
+	`after_decline` says the customer got here from a card the other rail refused. It
+	is recorded as provenance, not taken on trust: the server checks for a real
+	terminal decline before stamping it."""
 	team = _resolve_team(team, authz.MANAGE)
 	_require_billing_setup(team)
 	currency = _team_currency(team)
@@ -202,6 +207,7 @@ def setup_payment_method_order(
 	entry = (
 		instrument_catalogue.get(instrument, instrument_catalogue.MANDATE) if instrument else None
 	)
+	reason = _fallback_reason(team, entry, after_decline)
 	gw = (
 		gateway
 		or (
@@ -211,10 +217,28 @@ def setup_payment_method_order(
 		or _add_method_gateway(currency).get("name")
 	)
 	if entry and entry["method_type"] == "Card":
-		return mandates.setup_card(team, gw, contact=contact, fallback_reason=entry["fallback_reason"])
+		return mandates.setup_card(team, gw, contact=contact, fallback_reason=reason)
 	if method_type == "Card" and not entry:
 		return mandates.setup_card(team, gw, contact=contact)
 	return mandates.setup_mandate(team, gw)
+
+
+def _fallback_reason(team: str, entry: dict | None, after_decline: bool) -> str | None:
+	"""Why this method is landing off the default rail.
+
+	A claim of "my card was declined" is verified against the attempts we actually
+	made; unverified, it falls back to the reason the instrument itself gives. The
+	field feeds the gateway comparison report, so a wrong value there is a wrong
+	answer to which rail authorises better.
+	"""
+	from central.billing.payments import decline
+
+	instrument_reason = entry["fallback_reason"] if entry else None
+	if not after_decline:
+		return instrument_reason
+	if decline.recent_terminal_decline(team):
+		return "Stripe Decline"
+	return instrument_reason
 
 
 @frappe.whitelist(methods=["POST"])

--- a/central/billing/api/dashboard/methods.py
+++ b/central/billing/api/dashboard/methods.py
@@ -40,6 +40,8 @@ def list_payment_methods(team: str | None = None) -> list[dict]:
 			"reauth_required",
 			"expiry_month",
 			"expiry_year",
+			"mandate_max_amount",
+			"mandate_currency",
 		],
 		order_by="priority asc, creation asc",
 	)

--- a/central/billing/api/dashboard/methods.py
+++ b/central/billing/api/dashboard/methods.py
@@ -66,6 +66,7 @@ def get_payment_method_options(team: str | None = None) -> dict:
 	from central.billing.payments import instruments as instrument_catalogue
 
 	tiles = instrument_catalogue.available(currency, instrument_catalogue.MANDATE)
+	gap_note = instrument_catalogue.mandate_gap_note(currency)
 
 	methods: list[str] = []
 	publishable_key = None
@@ -91,6 +92,8 @@ def get_payment_method_options(team: str | None = None) -> dict:
 		"adapter_key": "Stripe" if card_gw else None,
 		"currency": currency,
 		"instruments": tiles,
+		# What no tile here can do, said plainly rather than left as an absence.
+		"note": gap_note,
 		"methods": methods,
 		"publishable_key": publishable_key,
 		**upi,

--- a/central/billing/doctype/billing_notification_log/billing_notification_log.json
+++ b/central/billing/doctype/billing_notification_log/billing_notification_log.json
@@ -24,7 +24,7 @@
   {"fieldname": "team", "fieldtype": "Link", "options": "Team", "in_list_view": 1, "label": "Team", "reqd": 1},
   {
    "fieldname": "event_type", "fieldtype": "Select", "in_list_view": 1, "label": "Event Type",
-   "options": "Payment Success\nPayment Failure\nPayment Retry\nInvoice Overdue\nCredit Low\nCard Expiry\nMandate Reauth\nTrial Expiring\nAction Required\nPre-debit Notice"
+   "options": "Payment Success\nPayment Failure\nPayment Retry\nInvoice Overdue\nCredit Low\nCard Expiry\nMandate Reauth\nTrial Expiring\nAction Required\nPre-debit Notice\nAdd Payment Method"
   },
   {"default": "email", "fieldname": "channel", "fieldtype": "Data", "label": "Channel"},
   {

--- a/central/billing/payments/collection.py
+++ b/central/billing/payments/collection.py
@@ -56,6 +56,32 @@ def next_method_for(invoice: str, team: str):
 	return None
 
 
+def _ask_for_another_method(inv) -> None:
+	"""Tell a customer we have run out of ways to charge them.
+
+	Only after something has actually been tried and refused. A team that has never
+	added a method is already being asked elsewhere (onboarding, the Action Required
+	banner), and this notification would be the third voice saying it.
+
+	The engine dedupes on unread notifications for the same event and invoice, so a
+	dunning run that re-enters here daily does not repeat itself.
+	"""
+	tried = frappe.get_all(
+		"Payment Attempt", filters={"invoice": inv.name, "status": "Failed"}, limit=1
+	)
+	if not tried:
+		return
+
+	from central.billing.platform import notifications
+
+	notifications.notify(
+		inv.team,
+		"Add Payment Method",
+		reference_doctype="Invoice",
+		reference_name=inv.name,
+	)
+
+
 def collect_invoice(invoice: str) -> dict:
 	"""Charge the next untried method; rotate immediately on a synchronous decline.
 
@@ -77,7 +103,11 @@ def collect_invoice(invoice: str) -> dict:
 
 		method = next_method_for(invoice, inv.team)
 		if not method:
-			# Every method has failed (or there are none) — leave it for dunning.
+			# Every method has failed (or there are none) — leave it for dunning, and
+			# ask the customer for another way to pay. Off-session there is nobody to
+			# offer the other rail to in the moment, so the ask has to arrive as a
+			# notification instead (ADR 0022 §5, ADR 0023).
+			_ask_for_another_method(inv)
 			return {"collected": False, "reason": "no_method"}
 
 		result = charges.pay_invoice(invoice, method.name, method.gateway)

--- a/central/billing/payments/collection_mode.py
+++ b/central/billing/payments/collection_mode.py
@@ -31,6 +31,12 @@ from central.billing.payments import mandates
 # The modes a customer may pick to resolve action_required (or switch into).
 CUSTOMER_CHOOSABLE = ("Manual Checkout", "Prepaid")
 
+# Going back to automatic is also the customer's to make — ADR 0005's hysteresis
+# says a quiet month never drags them back on its own, and case 13 says they may
+# re-register when eligible. Eligible means there is something to charge: without a
+# working method, Auto Charge is a promise nothing can keep.
+RETURNABLE = ("Auto Charge",)
+
 
 def team_rail(team: str) -> tuple[str | None, str | None]:
 	"""The (gateway, currency) a team's bill would be pulled through.
@@ -130,15 +136,40 @@ def trip(team: str, reason: str) -> None:
 
 
 def choose(team: str, mode: str) -> dict:
-	"""Customer resolves Action Required (or switches) to Manual Checkout / Prepaid.
-	Reversible and idempotent; clears the action reason."""
-	if mode not in CUSTOMER_CHOOSABLE:
-		frappe.throw(_("Pick one of {0}.").format(", ".join(CUSTOMER_CHOOSABLE)), frappe.ValidationError)
+	"""Customer picks how they are collected: Manual Checkout, Prepaid, or back to
+	Auto Charge. Reversible and idempotent; clears the action reason.
+
+	Returning to Auto Charge needs a method that can actually be charged. Allowing it
+	without one would set a mode whose whole meaning is "we debit something", and the
+	first invoice would discover the gap on the customer's behalf.
+	"""
+	if mode in RETURNABLE:
+		if not _has_chargeable_method(team):
+			frappe.throw(
+				_("Add a card or UPI mandate before switching to automatic payments."),
+				frappe.ValidationError,
+			)
+	elif mode not in CUSTOMER_CHOOSABLE:
+		frappe.throw(
+			_("Pick one of {0}.").format(", ".join(CUSTOMER_CHOOSABLE + RETURNABLE)),
+			frappe.ValidationError,
+		)
 	profile = frappe.get_doc("Billing Profile", team)
 	profile.collection_mode = mode
 	profile.collection_action_reason = None
 	profile.save(ignore_permissions=True)
 	return status(team)
+
+
+def _has_chargeable_method(team: str) -> bool:
+	"""An active method that is not waiting on the customer to re-authorise it."""
+	return bool(
+		frappe.get_all(
+			"Payment Method",
+			filters={"team": team, "status": "Active", "reauth_required": 0},
+			limit=1,
+		)
+	)
 
 
 def status(team: str) -> dict:
@@ -156,4 +187,5 @@ def status(team: str) -> dict:
 		"reason": p.collection_action_reason,
 		"threshold": silent_threshold(team),
 		"choices": list(CUSTOMER_CHOOSABLE),
+		"can_return_to_auto": _has_chargeable_method(team),
 	}

--- a/central/billing/payments/decline.py
+++ b/central/billing/payments/decline.py
@@ -62,6 +62,31 @@ def fallback_enabled() -> bool:
 	return bool(frappe.db.get_single_value("Billing Settings", "enable_gateway_fallback"))
 
 
+def recent_terminal_decline(team: str, gateway: str | None = None, within_hours: int = 24) -> dict | None:
+	"""The team's most recent attempt that a gateway finally refused, if it is recent.
+
+	This is the server's own answer to "did a card just fail?", and it exists because
+	the client is about to claim exactly that. `fallback_reason` is a field we report
+	on when judging one rail against another, so it cannot be whatever a caller says
+	it is — a customer who simply prefers UPI would otherwise be recorded as a Stripe
+	failure and quietly move the number.
+	"""
+	since = frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-within_hours)
+	filters = {"team": team, "status": "Failed", "creation": [">", since]}
+	if gateway:
+		filters["gateway"] = gateway
+	for attempt in frappe.get_all(
+		"Payment Attempt",
+		filters=filters,
+		fields=["name", "gateway", "failure_code"],
+		order_by="creation desc",
+		limit=5,
+	):
+		if is_terminal(attempt.failure_code) and not is_mandate_failure(attempt.failure_code):
+			return attempt
+	return None
+
+
 def alternate_rail(team: str, currency: str, failed_gateway: str) -> dict | None:
 	"""An instrument on a different gateway that this team could pay with instead.
 

--- a/central/billing/payments/instruments.py
+++ b/central/billing/payments/instruments.py
@@ -120,8 +120,10 @@ BY_KEY = {(entry["surface"], entry["instrument"]): entry for entry in CATALOGUE}
 NO_MANDATE_NETWORKS = ("Amex", "Diners")
 
 MANDATE_GAP_NOTE = (
-	"Amex and Diners cards can top up your wallet or pay an invoice, "
-	"but can't be saved for automatic payments."
+	"Holding an Amex or Diners card? Automatic payments aren't possible on those "
+	"networks — no bank rail in India registers a mandate for them. Keep a prepaid "
+	"wallet topped up instead, and your usage draws from the balance. (You can also "
+	"pay each invoice yourself.)"
 )
 
 

--- a/central/billing/payments/instruments.py
+++ b/central/billing/payments/instruments.py
@@ -29,7 +29,6 @@ MANDATE = "mandate"
 
 CARD = "Card"
 RUPAY_CARD = "RuPay Card"
-OTHER_NETWORK_CARD = "Other Network Card"
 UPI = "UPI"
 UPI_AUTOPAY = "UPI Autopay"
 NETBANKING = "Netbanking"
@@ -51,8 +50,8 @@ CATALOGUE = (
 	{
 		"surface": RECHARGE,
 		"instrument": RUPAY_CARD,
-		"label": "RuPay card",
-		"description": "RuPay runs on a different rail from other cards",
+		"label": "RuPay or Diners card",
+		"description": "These run on a different rail from other cards",
 		"adapter": "Razorpay",
 		"method_type": None,
 		"currencies": ("INR",),
@@ -90,9 +89,9 @@ CATALOGUE = (
 	},
 	{
 		"surface": MANDATE,
-		"instrument": OTHER_NETWORK_CARD,
-		"label": "RuPay, Amex or Diners card",
-		"description": "These networks are saved on a different rail",
+		"instrument": RUPAY_CARD,
+		"label": "RuPay card",
+		"description": "RuPay is saved on a different rail from other cards",
 		"adapter": "Razorpay",
 		"method_type": "Card",
 		"currencies": ("INR",),
@@ -111,6 +110,24 @@ CATALOGUE = (
 )
 
 BY_KEY = {(entry["surface"], entry["instrument"]): entry for entry in CATALOGUE}
+
+# Networks that can pay but cannot be saved: no rail we use registers a mandate on
+# them (Stripe does Visa and Mastercard; Razorpay's standing instructions add
+# RuPay). A customer holding one tops up a wallet or pays each invoice, and the
+# auto-pay surface has to say so — an absence they have to infer is how someone
+# taps the nearest card tile, fails at registration, and hears about it from a
+# dunning email.
+NO_MANDATE_NETWORKS = ("Amex", "Diners")
+
+MANDATE_GAP_NOTE = (
+	"Amex and Diners cards can top up your wallet or pay an invoice, "
+	"but can't be saved for automatic payments."
+)
+
+
+def mandate_gap_note(currency: str) -> str | None:
+	"""The caveat the auto-pay surface owes a customer whose card cannot be saved."""
+	return MANDATE_GAP_NOTE if currency == "INR" else None
 
 
 def get(instrument: str, surface: str = MANDATE) -> dict:

--- a/central/billing/payments/instruments.py
+++ b/central/billing/payments/instruments.py
@@ -119,16 +119,18 @@ BY_KEY = {(entry["surface"], entry["instrument"]): entry for entry in CATALOGUE}
 # dunning email.
 NO_MANDATE_NETWORKS = ("Amex", "Diners")
 
-MANDATE_GAP_NOTE = (
-	"Holding an Amex or Diners card? Automatic payments aren't possible on those "
-	"networks — no bank rail in India registers a mandate for them. Keep a prepaid "
-	"wallet topped up instead, and your usage draws from the balance. (You can also "
-	"pay each invoice yourself.)"
-)
+# One line that carries the limit and the way out of it. The reason a customer
+# needs is "my card isn't here and this says why"; the paragraph that explained
+# which bank rails register mandates was answering a question nobody asked.
+MANDATE_GAP_NOTE = "Amex or Diners can't auto-pay — top up a wallet"
 
 
 def mandate_gap_note(currency: str) -> str | None:
-	"""The caveat the auto-pay surface owes a customer whose card cannot be saved."""
+	"""The one line the auto-pay surface owes a customer whose card cannot be saved.
+
+	It doubles as the label of the control that takes them to the wallet, so it has
+	to read as a route rather than a warning.
+	"""
 	return MANDATE_GAP_NOTE if currency == "INR" else None
 
 

--- a/central/billing/payments/mandates.py
+++ b/central/billing/payments/mandates.py
@@ -131,7 +131,7 @@ def _require_card_contact(
 	phone = contact or str(p.phone or "").strip()
 	if not phone:
 		frappe.throw(
-			_("A phone number is required to set up a recurring card payment with Razorpay."),
+			_("A phone number is required to set up automatic payments on this card."),
 			frappe.ValidationError,
 		)
 	# An inline-provided phone is saved to the profile so it's collected only once.

--- a/central/billing/platform/notifications.py
+++ b/central/billing/platform/notifications.py
@@ -98,6 +98,15 @@ _BILLING_EVENT_TYPES = {
 		None,
 		None,
 	),
+	"add_payment_method": (
+		"Add another way to pay",
+		"We couldn't charge your saved payment method for invoice {{ reference_name }}, and there's "
+		"nothing else on file to try. Add another way to pay to keep your services running.",
+		"Error",
+		"billing:view",
+		"Add payment method",
+		"/billing",
+	),
 	"team_suspension": (
 		"Team suspended",
 		"Your team has been suspended due to billing issues.",

--- a/central/billing/tests/test_collection_mode.py
+++ b/central/billing/tests/test_collection_mode.py
@@ -78,11 +78,64 @@ class TestCollectionMode(IntegrationTestCase):
 		self.assertEqual(st["collection_mode"], "Prepaid")
 		self.assertFalse(st["action_required"])
 
+	def test_returning_to_auto_needs_something_to_charge(self):
+		"""Auto Charge means "we debit something". Without a method it is a mode whose
+		first invoice would discover the gap for the customer."""
+		_set_mode(TEAM, "Prepaid")
+		frappe.db.delete("Payment Method", {"team": TEAM})
+		with self.assertRaises(frappe.ValidationError):
+			collection_mode.choose(TEAM, "Auto Charge")
+
+	def test_a_team_with_a_working_method_can_go_back_to_auto(self):
+		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
+
+		gw = make_stripe_gateway().name
+		frappe.get_doc(
+			{
+				"doctype": "Payment Method",
+				"team": TEAM,
+				"gateway": gw,
+				"method_type": "Card",
+				"status": "Active",
+				"display_label": "Visa ····4242",
+				"gateway_method_id": "pm_back_to_auto",
+				"validated_at": frappe.utils.now_datetime(),
+			}
+		).insert(ignore_permissions=True)
+		_set_mode(TEAM, "Prepaid")
+
+		st = collection_mode.choose(TEAM, "Auto Charge")
+
+		self.assertEqual(st["collection_mode"], "Auto Charge")
+		frappe.db.delete("Payment Method", {"team": TEAM})
+
+	def test_a_method_awaiting_reauth_does_not_count(self):
+		"""It is skipped by the charge loop, so it cannot be what auto-pay rests on."""
+		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
+
+		gw = make_stripe_gateway().name
+		frappe.get_doc(
+			{
+				"doctype": "Payment Method",
+				"team": TEAM,
+				"gateway": gw,
+				"method_type": "UPI Autopay",
+				"status": "Active",
+				"reauth_required": 1,
+				"gateway_method_id": "tok_reauth",
+				"validated_at": frappe.utils.now_datetime(),
+			}
+		).insert(ignore_permissions=True)
+		_set_mode(TEAM, "Prepaid")
+		with self.assertRaises(frappe.ValidationError):
+			collection_mode.choose(TEAM, "Auto Charge")
+		frappe.db.delete("Payment Method", {"team": TEAM})
+
 	def test_invalid_mode_choice_is_rejected(self):
 		_set_mode(TEAM, "Action Required")
 		# A customer cannot silently put themselves (back) on a silent auto rail.
 		with self.assertRaises(frappe.ValidationError):
-			collection_mode.choose(TEAM, "Auto Charge")
+			collection_mode.choose(TEAM, "Nonsense Mode")
 
 
 class TestInvoiceTimeTrip(IntegrationTestCase):

--- a/central/billing/tests/test_dashboard.py
+++ b/central/billing/tests/test_dashboard.py
@@ -880,7 +880,7 @@ class TestPaymentMethodOptions(IntegrationTestCase):
 		rails = {t["instrument"]: t["adapter_key"] for t in out["instruments"]}
 		self.assertEqual(
 			rails,
-			{"Card": "Stripe", "Other Network Card": "Razorpay", "UPI Autopay": "Razorpay"},
+			{"Card": "Stripe", "RuPay Card": "Razorpay", "UPI Autopay": "Razorpay"},
 		)
 
 	def test_netbanking_is_not_on_the_mandate_surface_at_all(self):
@@ -913,8 +913,18 @@ class TestPaymentMethodOptions(IntegrationTestCase):
 		from central.billing.api.dashboard import methods
 
 		labels = [t["label"] for t in methods.get_payment_method_options(self.TEAM)["instruments"]]
-		self.assertIn("RuPay, Amex or Diners card", labels)
+		self.assertIn("RuPay card", labels)
 		self.assertNotIn("Other cards", labels)
+
+	def test_the_surface_says_which_cards_it_cannot_save(self):
+		"""Neither rail registers a mandate on Amex or Diners, so the absence of a tile
+		is not enough — a customer holding one would tap the nearest card and fail at
+		registration."""
+		from central.billing.api.dashboard import methods
+
+		note = methods.get_payment_method_options(self.TEAM)["note"]
+		self.assertIn("Amex", note)
+		self.assertIn("Diners", note)
 
 	def test_a_card_top_up_goes_to_stripe_even_though_razorpay_owns_the_inr_default(self):
 		from central.billing.payments import instruments
@@ -929,7 +939,7 @@ class TestPaymentMethodOptions(IntegrationTestCase):
 		# The registration itself is a gateway round-trip, and a test must never make
 		# one: the fixture's keys are dummies, so a real call authenticates as nobody.
 		with stub_adapter():
-			out = methods.setup_payment_method_order(self.TEAM, instrument="Other Network Card")
+			out = methods.setup_payment_method_order(self.TEAM, instrument="RuPay Card")
 		method = frappe.get_doc("Payment Method", out["payment_method"])
 		self.assertEqual(method.gateway, "Razorpay")
 		self.assertEqual(method.fallback_reason, "Network Unsupported")

--- a/central/billing/tests/test_dashboard.py
+++ b/central/billing/tests/test_dashboard.py
@@ -953,3 +953,42 @@ class TestPaymentMethodOptions(IntegrationTestCase):
 		self.assertEqual(out["methods"], ["Card"])  # no UPI outside INR
 		self.assertFalse(out["allow_upi"])
 		self.assertEqual([t["instrument"] for t in out["instruments"]], ["Card"])
+
+
+class TestTheAmexAndDinersGapIsStatedUpfront(IntegrationTestCase):
+	"""No rail we use registers a mandate on Amex or Diners, so a customer holding
+	one has to run a prepaid wallet. They should read that before choosing how to
+	pay, not discover it when a mandate fails at authorisation (ADR 0023)."""
+
+	TEAM = "team-mandate-gap"
+
+	def setUp(self):
+		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
+		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
+
+		ensure_team(self.TEAM)
+		make_stripe_gateway([("INR", 0), ("USD", 1)])
+		make_razorpay_gateway([("INR", 1)])
+		complete_billing_profile(self.TEAM)
+
+	def test_the_note_names_the_networks_and_the_wallet(self):
+		from central.billing.api.dashboard import methods
+
+		note = methods.get_payment_method_options(self.TEAM)["note"]
+		self.assertIn("Amex", note)
+		self.assertIn("Diners", note)
+		self.assertIn("wallet", note.lower())
+
+	def test_it_is_on_the_screen_where_they_choose_how_to_pay(self):
+		from central.billing.api.dashboard import account
+
+		note = account.get_collection_status(self.TEAM)["mandate_gap_note"]
+		self.assertTrue(note)
+		self.assertIn("wallet", note.lower())
+
+	def test_a_currency_without_the_gap_says_nothing(self):
+		"""The limit is an Indian card-network one; a USD team is not owed the caveat."""
+		from central.billing.api.dashboard import account
+
+		frappe.db.set_value("Billing Profile", self.TEAM, "currency", "USD")
+		self.assertIsNone(account.get_collection_status(self.TEAM)["mandate_gap_note"])

--- a/central/billing/tests/test_dashboard.py
+++ b/central/billing/tests/test_dashboard.py
@@ -979,6 +979,14 @@ class TestTheAmexAndDinersGapIsStatedUpfront(IntegrationTestCase):
 		self.assertIn("Diners", note)
 		self.assertIn("wallet", note.lower())
 
+	def test_the_note_is_short_enough_to_be_a_control(self):
+		"""It is the label of the link that takes them to the wallet, so it has to fit
+		on one line. A paragraph here is a paragraph shown to everyone."""
+		from central.billing.api.dashboard import methods
+
+		note = methods.get_payment_method_options(self.TEAM)["note"]
+		self.assertLessEqual(len(note.split()), 12, note)
+
 	def test_it_is_on_the_screen_where_they_choose_how_to_pay(self):
 		from central.billing.api.dashboard import account
 

--- a/central/billing/tests/test_gateway_fallback.py
+++ b/central/billing/tests/test_gateway_fallback.py
@@ -385,7 +385,7 @@ class TestWhereAMethodSaysItCameFrom(IntegrationTestCase):
 		from central.billing.api.dashboard import methods
 
 		out = methods.setup_payment_method_order(
-			TEAM, instrument="Other Network Card", after_decline=after_decline
+			TEAM, instrument="RuPay Card", after_decline=after_decline
 		)
 		return frappe.get_doc("Payment Method", out["payment_method"])
 

--- a/central/billing/tests/test_gateway_fallback.py
+++ b/central/billing/tests/test_gateway_fallback.py
@@ -383,10 +383,14 @@ class TestWhereAMethodSaysItCameFrom(IntegrationTestCase):
 
 	def _add(self, after_decline):
 		from central.billing.api.dashboard import methods
+		from central.billing.tests.test_mandates import stub_adapter
 
-		out = methods.setup_payment_method_order(
-			TEAM, instrument="RuPay Card", after_decline=after_decline
-		)
+		# Registering mints a gateway customer, which is a live API call. Tests never
+		# make one — the fixture keys are dummies and CI has no real ones.
+		with stub_adapter():
+			out = methods.setup_payment_method_order(
+				TEAM, instrument="RuPay Card", after_decline=after_decline
+			)
 		return frappe.get_doc("Payment Method", out["payment_method"])
 
 	def test_a_real_decline_is_recorded_as_one(self):

--- a/central/billing/tests/test_gateway_fallback.py
+++ b/central/billing/tests/test_gateway_fallback.py
@@ -327,3 +327,81 @@ class TestOneInvoiceIsNeverChargedTwiceAcrossRails(IntegrationTestCase):
 				"Billing Notification Log", {"team": TEAM, "event_type": "Add Payment Method"}
 			)
 		)
+
+
+class TestWhereAMethodSaysItCameFrom(IntegrationTestCase):
+	"""`fallback_reason` feeds the report that judges one rail against the other, so
+	"my card was declined" is checked rather than believed."""
+
+	def setUp(self):
+		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
+		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
+
+		ensure_team(TEAM)
+		complete_billing_profile(TEAM)
+		make_stripe_gateway(currencies=(("USD", 1), ("INR", 0)))
+		make_razorpay_gateway([("INR", 1)])
+		frappe.db.delete("Payment Attempt", {"team": TEAM})
+		frappe.db.delete("Payment Method", {"team": TEAM})
+		frappe.db.set_value("Billing Profile", TEAM, "phone", "9800000000")
+
+	def _failed_attempt(self, failure_code):
+		invoice = (
+			frappe.get_doc(
+				{
+					"doctype": "Invoice",
+					"team": TEAM,
+					"invoice_type": "Billable",
+					"status": "Open",
+					"period_start": "2026-06-01",
+					"period_end": "2026-06-30",
+					"currency": "INR",
+					"subtotal": 5000,
+					"total": 5000,
+					"expected_collection": 5000,
+					"items": [{"resource_type": "bundle", "plan": "p", "rate": 5000, "days": 30, "amount": 5000}],
+				}
+			)
+			.insert(ignore_permissions=True)
+			.name
+		)
+		attempt = frappe.get_doc(
+			{
+				"doctype": "Payment Attempt",
+				"invoice": invoice,
+				"team": TEAM,
+				"gateway": "Stripe",
+				"amount": 5000,
+				"currency": "INR",
+				"status": "Initiated",
+				"initiated_at": frappe.utils.now_datetime(),
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.set_value(
+			"Payment Attempt", attempt.name, {"status": "Failed", "failure_code": failure_code}
+		)
+
+	def _add(self, after_decline):
+		from central.billing.api.dashboard import methods
+
+		out = methods.setup_payment_method_order(
+			TEAM, instrument="Other Network Card", after_decline=after_decline
+		)
+		return frappe.get_doc("Payment Method", out["payment_method"])
+
+	def test_a_real_decline_is_recorded_as_one(self):
+		self._failed_attempt("card_declined")
+		self.assertEqual(self._add(after_decline=True).fallback_reason, "Stripe Decline")
+
+	def test_an_unbacked_claim_is_not(self):
+		"""Nothing was declined, so the method records the reason its own tile gives."""
+		self.assertEqual(self._add(after_decline=True).fallback_reason, "Network Unsupported")
+
+	def test_a_timeout_is_not_a_decline(self):
+		self._failed_attempt("gateway_timeout")
+		self.assertEqual(self._add(after_decline=True).fallback_reason, "Network Unsupported")
+
+	def test_a_revoked_mandate_is_not_a_decline_either(self):
+		"""The card was never refused — the standing permission went away."""
+		self._failed_attempt("india_recurring_payment_mandate_canceled")
+		self.assertEqual(self._add(after_decline=True).fallback_reason, "Network Unsupported")

--- a/central/billing/tests/test_gateway_fallback.py
+++ b/central/billing/tests/test_gateway_fallback.py
@@ -180,3 +180,150 @@ class TestTheGatewaysOwnHold(IntegrationTestCase):
 		}
 		self.assertIsNotNone(_predebit_hold(intent))
 		self.assertIsNone(_predebit_hold({"status": "succeeded"}))
+
+
+class TestOneInvoiceIsNeverChargedTwiceAcrossRails(IntegrationTestCase):
+	"""A team holding a card on one rail and a mandate on the other.
+
+	Rotating between them is the point of the ordered method list, but it must only
+	happen when the first attempt is genuinely over. An ambiguous failure may still
+	settle at the gateway, so charging the second rail on top of it takes the money
+	twice for one invoice — the failure mode this whole rule exists to prevent.
+	"""
+
+	def setUp(self):
+		from central.billing.tests.test_razorpay_adapter import make_razorpay_gateway
+		from central.billing.tests.test_stripe_adapter import make_stripe_gateway
+
+		ensure_team(TEAM)
+		complete_billing_profile(TEAM)
+		make_stripe_gateway(currencies=(("USD", 1), ("INR", 0)))
+		make_razorpay_gateway([("INR", 1)])
+		frappe.db.set_single_value("Billing Settings", "enable_gateway_fallback", 1)
+		frappe.db.delete("Payment Attempt", {"team": TEAM})
+		frappe.db.delete("Invoice", {"team": TEAM})
+		frappe.db.delete("Payment Method", {"team": TEAM})
+		self.stripe_method = self._method("Stripe", "pm_stripe", priority=0)
+		self.razorpay_method = self._method("Razorpay", "tok_rzp", priority=1)
+		self.invoice = self._invoice()
+
+	def _method(self, gateway, handle, priority):
+		return (
+			frappe.get_doc(
+				{
+					"doctype": "Payment Method",
+					"team": TEAM,
+					"gateway": gateway,
+					"method_type": "Card",
+					"status": "Active",
+					"gateway_method_id": handle,
+					"gateway_customer_id": f"cus_{gateway.lower()}",
+					"display_label": f"{gateway} card",
+					"priority": priority,
+					"validated_at": frappe.utils.now_datetime(),
+				}
+			)
+			.insert(ignore_permissions=True)
+			.name
+		)
+
+	def _invoice(self):
+		return (
+			frappe.get_doc(
+				{
+					"doctype": "Invoice",
+					"team": TEAM,
+					"invoice_type": "Billable",
+					"status": "Open",
+					"period_start": "2026-06-01",
+					"period_end": "2026-06-30",
+					"currency": "INR",
+					"subtotal": 5000,
+					"total": 5000,
+					"expected_collection": 5000,
+					"items": [{"resource_type": "bundle", "plan": "p", "rate": 5000, "days": 30, "amount": 5000}],
+				}
+			)
+			.insert(ignore_permissions=True)
+			.name
+		)
+
+	def _charged_gateways(self):
+		return frappe.get_all("Payment Attempt", filters={"invoice": self.invoice}, pluck="gateway")
+
+	def test_an_ambiguous_failure_stops_instead_of_trying_the_other_rail(self):
+		from unittest.mock import MagicMock, patch
+
+		from central.billing.gateways.base import PaymentResult
+		from central.billing.payments import collection
+
+		adapter = MagicMock()
+		adapter.charge.return_value = PaymentResult(
+			success=False,
+			status="Failed",
+			failure_code="processing_error",
+			failure_reason="try again later",
+		)
+		with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
+			out = collection.collect_invoice(self.invoice)
+
+		self.assertEqual(out["reason"], "ambiguous_failure")
+		self.assertEqual(adapter.charge.call_count, 1)
+		self.assertEqual(self._charged_gateways(), ["Stripe"])
+
+	def test_a_terminal_decline_does_rotate_to_the_other_rail(self):
+		"""The counterpart: when the card really is refused, the second rail is tried
+		exactly once, so the guard above isn't just blocking everything."""
+		from unittest.mock import MagicMock, patch
+
+		from central.billing.gateways.base import PaymentResult
+		from central.billing.payments import collection
+
+		adapter = MagicMock()
+		adapter.charge.return_value = PaymentResult(
+			success=False, status="Failed", failure_code="card_declined", failure_reason="declined"
+		)
+		with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
+			collection.collect_invoice(self.invoice)
+
+		self.assertEqual(sorted(self._charged_gateways()), ["Razorpay", "Stripe"])
+		# Each method at most once per invoice — escalate, don't repeat.
+		self.assertEqual(len(self._charged_gateways()), 2)
+
+	def test_running_out_of_rails_asks_for_another_way_to_pay(self):
+		from unittest.mock import MagicMock, patch
+
+		from central.billing.gateways.base import PaymentResult
+		from central.billing.payments import collection
+
+		frappe.db.delete("Billing Notification Log", {"team": TEAM})
+		adapter = MagicMock()
+		adapter.charge.return_value = PaymentResult(
+			success=False, status="Failed", failure_code="card_declined", failure_reason="declined"
+		)
+		with patch("central.billing.gateways.registry.get_adapter", return_value=adapter):
+			collection.collect_invoice(self.invoice)
+
+		self.assertTrue(
+			frappe.db.exists(
+				"Billing Notification Log", {"team": TEAM, "event_type": "Add Payment Method"}
+			)
+		)
+
+	def test_nothing_is_asked_of_a_team_that_never_had_a_method(self):
+		"""Nothing was tried, so there is nothing to report — onboarding and the
+		Action Required banner already carry that conversation."""
+		from central.billing.payments import collection
+
+		frappe.db.delete("Billing Notification Log", {"team": TEAM})
+		frappe.db.set_value("Payment Method", self.stripe_method, "status", "Cancelled")
+		frappe.db.set_value("Payment Method", self.razorpay_method, "status", "Cancelled")
+
+		out = collection.collect_invoice(self.invoice)
+
+		self.assertEqual(out["reason"], "no_method")
+		self.assertFalse(
+			frappe.db.exists(
+				"Billing Notification Log", {"team": TEAM, "event_type": "Add Payment Method"}
+			)
+		)

--- a/dashboard/src/components/AddMethodDialog.vue
+++ b/dashboard/src/components/AddMethodDialog.vue
@@ -3,12 +3,13 @@ import { Button, Dialog, FormControl, LoadingText, useCall } from 'frappe-ui'
 import { computed, nextTick, ref, watch } from 'vue'
 import { API, method } from '@/api/methods'
 import { useAddPaymentMethod } from '@/composables/useAddPaymentMethod'
+import TopupDialog from '@/components/TopupDialog.vue'
 import { useAddStripeCard } from '@/composables/useAddStripeCard'
 import { useBillingOverview } from '@/composables/useBillingOverview'
 import { useSession } from '@/composables/useSession'
 import { whenTeamReady } from '@/composables/useTeamScope'
 import { money } from '@/lib/format'
-import { errorToast, successToast } from '@/lib/toast'
+import { errorToast } from '@/lib/toast'
 import type { PaymentInstrument, PaymentMethodOptions } from '@/types/billing'
 
 // Pick an instrument to save for auto-pay. This is the **mandate** surface (ADR
@@ -70,20 +71,14 @@ const upiBlocked = computed(() => options.data && !options.data.allow_upi)
 
 const tiles = computed(() => options.data?.instruments ?? [])
 
-// A customer whose card cannot hold a mandate needs the wallet, so give them the
-// switch here rather than a sentence telling them to go and find it.
-const switching = useCall<unknown, { team: string; mode: string }>({
-	url: method(API.setCollectionMode),
-	method: 'POST',
-	immediate: false,
-	onError: (e: unknown) => errorToast(e, 'Could not switch to a prepaid wallet.'),
-})
+// A card no rail will hold a mandate on has one honest destination, so the line
+// saying so *is* the way there: tap it and the top-up opens. Our dialog closes
+// first — two stacked modals is how the second one ends up behind the first.
+const showTopup = ref(false)
 
-async function switchToPrepaid(): Promise<void> {
-	await switching.submit({ team: activeTeam.value!, mode: 'Prepaid' })
-	if (switching.error) return
-	successToast('Switched to a prepaid wallet. Add credits to cover your usage.')
-	done()
+function goToTopup(): void {
+	open.value = false
+	showTopup.value = true
 }
 
 const icons: Record<string, string> = {
@@ -276,18 +271,15 @@ watch(open, (isOpen) => {
 							}}</span>
 						</button>
 					</div>
-					<div
+					<button
 						v-if="options.data.note"
-						class="mt-3 rounded-lg border border-outline-gray-2 bg-surface-gray-1 px-3 py-2.5"
+						type="button"
+						class="mt-3 flex w-full items-center justify-center gap-1.5 text-p-sm text-ink-gray-6 underline decoration-outline-gray-3 underline-offset-4 hover:text-ink-gray-8"
+						@click="goToTopup"
 					>
-						<p class="text-p-sm text-ink-gray-6">{{ options.data.note }}</p>
-						<Button
-							class="mt-2"
-							label="Use a prepaid wallet"
-							:loading="switching.loading"
-							@click="switchToPrepaid"
-						/>
-					</div>
+						{{ options.data.note }}
+						<span class="lucide-arrow-right size-3.5" aria-hidden="true" />
+					</button>
 				</div>
 
 				<!-- Razorpay card mandates need a contact; collect it inline when missing. -->
@@ -327,4 +319,11 @@ watch(open, (isOpen) => {
 			</div>
 		</template>
 	</Dialog>
+
+	<!-- Opened from the Amex/Diners line above, after this dialog has closed. -->
+	<TopupDialog
+		v-model="showTopup"
+		:currency="options.data?.currency || 'INR'"
+		@done="(res: unknown) => emit('done', res)"
+	/>
 </template>

--- a/dashboard/src/components/AddMethodDialog.vue
+++ b/dashboard/src/components/AddMethodDialog.vue
@@ -72,7 +72,7 @@ const tiles = computed(() => options.data?.instruments ?? [])
 
 const icons: Record<string, string> = {
 	Card: 'lucide-credit-card',
-	'Other Network Card': 'lucide-credit-card',
+	'RuPay Card': 'lucide-credit-card',
 	'UPI Autopay': 'lucide-smartphone',
 }
 
@@ -96,7 +96,7 @@ function choose(tile: PaymentInstrument): void {
 		return
 	}
 	if (
-		tile.instrument === 'Other Network Card' &&
+		tile.instrument === 'RuPay Card' &&
 		cardNeedsPhone.value &&
 		!phone.value.trim()
 	) {
@@ -260,6 +260,12 @@ watch(open, (isOpen) => {
 							}}</span>
 						</button>
 					</div>
+					<p
+						v-if="options.data.note"
+						class="mt-2 text-p-sm text-ink-gray-5"
+					>
+						{{ options.data.note }}
+					</p>
 				</div>
 
 				<!-- Razorpay card mandates need a contact; collect it inline when missing. -->
@@ -279,7 +285,7 @@ watch(open, (isOpen) => {
 						label="Continue"
 						:loading="loading"
 						:disabled="!phone.trim()"
-						@click="launchGateway('Card', phone.trim(), 'Other Network Card')"
+						@click="launchGateway('Card', phone.trim(), 'RuPay Card')"
 					/>
 				</div>
 

--- a/dashboard/src/components/AddMethodDialog.vue
+++ b/dashboard/src/components/AddMethodDialog.vue
@@ -36,8 +36,8 @@ const options = useCall<PaymentMethodOptions, { team: string }>({
 	immediate: false,
 	refetch: true,
 })
-// The billing profile is the shared singleton — cardNeedsPhone only reads its
-// phone; no need for a second fetch of the same payload.
+// The billing profile is the shared singleton — we only read its phone, so there
+// is no need for a second fetch of the same payload.
 const { profile } = useBillingOverview()
 whenTeamReady(() => {
 	options.reload()
@@ -111,11 +111,7 @@ function choose(tile: PaymentInstrument): void {
 		onCard()
 		return
 	}
-	if (
-		tile.instrument === 'RuPay Card' &&
-		cardNeedsPhone.value &&
-		!phone.value.trim()
-	) {
+	if (needsPhone(tile) && !phone.value.trim()) {
 		askPhone.value = true
 		return
 	}
@@ -126,13 +122,17 @@ function choose(tile: PaymentInstrument): void {
 	)
 }
 
-// A Razorpay card mandate needs a customer contact; phone is optional on the
-// profile, so collect it inline here when it's missing.
-const cardNeedsPhone = computed(
-	() =>
-		options.data?.adapter_key === 'Razorpay' &&
-		!String(profile.data?.phone || '').trim(),
-)
+// A card mandate on the RuPay rail needs a customer contact. Phone is optional on
+// the billing profile, so collect it inline when it's missing.
+//
+// This asks the *tile* which rail it sits on. Reading the payload's top-level
+// adapter_key instead asks about the card rail, which is Stripe for every team —
+// so the prompt never fired and the customer met a server error instead.
+const hasPhone = computed(() => !!String(profile.data?.phone || '').trim())
+
+function needsPhone(tile: PaymentInstrument): boolean {
+	return tile.adapter_key === 'Razorpay' && tile.instrument !== 'UPI Autopay' && !hasPhone.value
+}
 const askPhone = ref(false)
 const phone = ref('')
 
@@ -172,7 +172,7 @@ async function onCard(): Promise<void> {
 		await startStripe()
 		return
 	}
-	if (cardNeedsPhone.value && !phone.value.trim()) {
+	if (!hasPhone.value && !phone.value.trim() && options.data?.adapter_key === 'Razorpay') {
 		askPhone.value = true
 		return
 	}

--- a/dashboard/src/components/AddMethodDialog.vue
+++ b/dashboard/src/components/AddMethodDialog.vue
@@ -21,6 +21,11 @@ import type { PaymentInstrument, PaymentMethodOptions } from '@/types/billing'
 // iframes the card number. Stripe capture happens in an embedded Element; Razorpay
 // runs its hosted sheet.
 const open = defineModel<boolean>({ default: false })
+// Set when the dialog is opened from a "your card was declined" prompt, so the
+// method that comes out of it records why it is on the other rail.
+const props = withDefaults(defineProps<{ afterDecline?: boolean }>(), {
+	afterDecline: false,
+})
 const emit = defineEmits<{ done: [res?: unknown] }>()
 const { activeTeam } = useSession()
 
@@ -57,7 +62,7 @@ async function launchGateway(
 ): Promise<void> {
 	open.value = false
 	await nextTick()
-	const res = await run(methodType, contact, instrument)
+	const res = await run(methodType, contact, instrument, props.afterDecline)
 	if (!res) open.value = true
 }
 

--- a/dashboard/src/components/AddMethodDialog.vue
+++ b/dashboard/src/components/AddMethodDialog.vue
@@ -8,7 +8,7 @@ import { useBillingOverview } from '@/composables/useBillingOverview'
 import { useSession } from '@/composables/useSession'
 import { whenTeamReady } from '@/composables/useTeamScope'
 import { money } from '@/lib/format'
-import { errorToast } from '@/lib/toast'
+import { errorToast, successToast } from '@/lib/toast'
 import type { PaymentInstrument, PaymentMethodOptions } from '@/types/billing'
 
 // Pick an instrument to save for auto-pay. This is the **mandate** surface (ADR
@@ -69,6 +69,22 @@ async function launchGateway(
 const upiBlocked = computed(() => options.data && !options.data.allow_upi)
 
 const tiles = computed(() => options.data?.instruments ?? [])
+
+// A customer whose card cannot hold a mandate needs the wallet, so give them the
+// switch here rather than a sentence telling them to go and find it.
+const switching = useCall<unknown, { team: string; mode: string }>({
+	url: method(API.setCollectionMode),
+	method: 'POST',
+	immediate: false,
+	onError: (e: unknown) => errorToast(e, 'Could not switch to a prepaid wallet.'),
+})
+
+async function switchToPrepaid(): Promise<void> {
+	await switching.submit({ team: activeTeam.value!, mode: 'Prepaid' })
+	if (switching.error) return
+	successToast('Switched to a prepaid wallet. Add credits to cover your usage.')
+	done()
+}
 
 const icons: Record<string, string> = {
 	Card: 'lucide-credit-card',
@@ -260,12 +276,18 @@ watch(open, (isOpen) => {
 							}}</span>
 						</button>
 					</div>
-					<p
+					<div
 						v-if="options.data.note"
-						class="mt-2 text-p-sm text-ink-gray-5"
+						class="mt-3 rounded-lg border border-outline-gray-2 bg-surface-gray-1 px-3 py-2.5"
 					>
-						{{ options.data.note }}
-					</p>
+						<p class="text-p-sm text-ink-gray-6">{{ options.data.note }}</p>
+						<Button
+							class="mt-2"
+							label="Use a prepaid wallet"
+							:loading="switching.loading"
+							@click="switchToPrepaid"
+						/>
+					</div>
 				</div>
 
 				<!-- Razorpay card mandates need a contact; collect it inline when missing. -->

--- a/dashboard/src/components/AddMethodDialog.vue
+++ b/dashboard/src/components/AddMethodDialog.vue
@@ -324,6 +324,7 @@ watch(open, (isOpen) => {
 	<TopupDialog
 		v-model="showTopup"
 		:currency="options.data?.currency || 'INR'"
+		instrument="Card"
 		@done="(res: unknown) => emit('done', res)"
 	/>
 </template>

--- a/dashboard/src/components/TopupDialog.vue
+++ b/dashboard/src/components/TopupDialog.vue
@@ -16,9 +16,14 @@ import type { PaymentInstrument } from '@/types/billing'
 // even though Razorpay owns the INR default. Stripe collects the card in an embedded
 // Element right here; Razorpay collects in its hosted sheet; PayPal renders its
 // Buttons in a second phase. The wallet is credited only after the gateway confirms.
-const props = withDefaults(defineProps<{ currency?: string }>(), {
-	currency: 'INR',
-})
+// `instrument` is set when the caller already knows what the customer is paying
+// with — the Amex/Diners route says so by arriving here at all. Asking again is
+// the whole reason that route felt broken, so the picker is skipped and the
+// instrument is stated instead.
+const props = withDefaults(
+	defineProps<{ currency?: string; instrument?: string }>(),
+	{ currency: 'INR', instrument: undefined },
+)
 const open = defineModel<boolean>({ default: false })
 const emit = defineEmits<{ done: [res?: unknown] }>()
 
@@ -34,6 +39,15 @@ const options = useCall<{ instruments: PaymentInstrument[] }, { team: string }>(
 })
 const instruments = computed(() => options.data?.instruments ?? [])
 const instrument = ref<string | null>(null)
+
+// A caller-supplied instrument is fixed unless the customer asks to change it.
+const fixed = ref(false)
+const chosenLabel = computed(
+	() =>
+		instruments.value.find((t) => t.instrument === instrument.value)?.label ??
+		instrument.value ??
+		'',
+)
 const icons: Record<string, string> = {
 	Card: 'lucide-credit-card',
 	'RuPay Card': 'lucide-credit-card',
@@ -147,12 +161,17 @@ async function enterPhase(
 watch(open, (isOpen) => {
 	if (isOpen) {
 		options.reload()
+		if (props.instrument) {
+			instrument.value = props.instrument
+			fixed.value = true
+		}
 		return
 	}
 	if (!isOpen) {
 		destroy()
 		amount.value = null
 		instrument.value = null
+		fixed.value = false
 		payMethod.value = 'card'
 		cardPhase.value = false
 		cardLoading.value = false
@@ -201,7 +220,29 @@ watch(open, (isOpen) => {
 			<div v-else class="space-y-5">
 				<!-- The recharge instruments. Each sits on its own rail, so this is not
              decoration: it decides where the money goes. -->
-				<div v-if="instruments.length > 1">
+				<!-- Already told which instrument: say it, don't ask it again. -->
+				<div
+					v-if="fixed"
+					class="flex items-center gap-2 rounded-lg border border-outline-gray-2 bg-surface-gray-1 px-3 py-2.5"
+				>
+					<span
+						:class="icons[instrument || ''] || 'lucide-credit-card'"
+						class="size-4 shrink-0 text-ink-gray-6"
+						aria-hidden="true"
+					/>
+					<p class="text-p-sm text-ink-gray-6">
+						Paying with your {{ chosenLabel.toLowerCase() }}
+					</p>
+					<Button
+						class="ml-auto"
+						variant="ghost"
+						size="sm"
+						label="Change"
+						@click="fixed = false"
+					/>
+				</div>
+
+				<div v-else-if="instruments.length > 1">
 					<p class="mb-1.5 text-p-sm text-ink-gray-5">Pay with</p>
 					<div class="grid gap-2 sm:grid-cols-2">
 						<button

--- a/dashboard/src/components/billing/CollectionActionBanner.vue
+++ b/dashboard/src/components/billing/CollectionActionBanner.vue
@@ -116,6 +116,9 @@ const options = [
 					<span class="mt-auto text-p-sm text-ink-gray-5">{{ o.fit }}</span>
 				</button>
 			</div>
+			<p v-if="s?.mandate_gap_note" class="mt-3 text-p-sm text-ink-gray-6">
+				{{ s.mandate_gap_note }}
+			</p>
 			<p class="mt-3 text-p-sm text-ink-gray-5">
 				You can switch anytime in Billing settings.
 			</p>

--- a/dashboard/src/components/billing/PaymentMethodRowActions.vue
+++ b/dashboard/src/components/billing/PaymentMethodRowActions.vue
@@ -37,7 +37,7 @@ const options = computed(() => {
 	const items: ActionItem[] = []
 	if (!props.isFirst)
 		items.push({
-			label: 'Charge this first',
+			label: 'Primary payment method',
 			icon: 'lucide-star',
 			disabled: props.canPromote === false,
 			onClick: () => emit('makeDefault', props.method),

--- a/dashboard/src/components/billing/PaymentMethodRowActions.vue
+++ b/dashboard/src/components/billing/PaymentMethodRowActions.vue
@@ -12,6 +12,11 @@ const props = defineProps<{
 	isFirst: boolean
 	isLast: boolean
 	busy?: boolean
+	/** True only for the row that currently holds the title. */
+	isPrimary?: boolean
+	/** False while credits are paying the bill: the choice is offered, not hidden,
+	 *  but it decides nothing until the balance runs out. */
+	canPromote?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -25,15 +30,19 @@ interface ActionItem {
 	label: string
 	icon: string
 	onClick: () => void
+	disabled?: boolean
 }
 
 const options = computed(() => {
 	if (!props.canManage) return []
 	const items: ActionItem[] = []
-	if (!props.isFirst)
+	// Any row that is not the primary can become it — which is every method row
+	// while the wallet holds the title.
+	if (!props.isPrimary)
 		items.push({
 			label: 'Primary payment method',
 			icon: 'lucide-star',
+			disabled: props.canPromote === false,
 			onClick: () => emit('makeDefault', props.method),
 		})
 	if (!props.isFirst)

--- a/dashboard/src/components/billing/PaymentMethodRowActions.vue
+++ b/dashboard/src/components/billing/PaymentMethodRowActions.vue
@@ -32,7 +32,7 @@ const options = computed(() => {
 	const items: ActionItem[] = []
 	if (!props.method.is_default)
 		items.push({
-			label: 'Make default',
+			label: 'Charge this first',
 			icon: 'lucide-star',
 			onClick: () => emit('makeDefault', props.method),
 		})

--- a/dashboard/src/components/billing/PaymentMethodRowActions.vue
+++ b/dashboard/src/components/billing/PaymentMethodRowActions.vue
@@ -12,6 +12,10 @@ const props = defineProps<{
 	isFirst: boolean
 	isLast: boolean
 	busy?: boolean
+	// While a credit balance exists it is what pays the bill, so choosing which
+	// method gets charged decides nothing yet. The item stays visible and disabled
+	// rather than vanishing — an option that disappears reads as a missing feature.
+	canPromote?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -25,15 +29,17 @@ interface ActionItem {
 	label: string
 	icon: string
 	onClick: () => void
+	disabled?: boolean
 }
 
 const options = computed(() => {
 	if (!props.canManage) return []
 	const items: ActionItem[] = []
-	if (!props.method.is_default)
+	if (!props.isFirst)
 		items.push({
 			label: 'Charge this first',
 			icon: 'lucide-star',
+			disabled: props.canPromote === false,
 			onClick: () => emit('makeDefault', props.method),
 		})
 	if (!props.isFirst)

--- a/dashboard/src/components/billing/PaymentMethodRowActions.vue
+++ b/dashboard/src/components/billing/PaymentMethodRowActions.vue
@@ -12,10 +12,6 @@ const props = defineProps<{
 	isFirst: boolean
 	isLast: boolean
 	busy?: boolean
-	// While a credit balance exists it is what pays the bill, so choosing which
-	// method gets charged decides nothing yet. The item stays visible and disabled
-	// rather than vanishing — an option that disappears reads as a missing feature.
-	canPromote?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -29,7 +25,6 @@ interface ActionItem {
 	label: string
 	icon: string
 	onClick: () => void
-	disabled?: boolean
 }
 
 const options = computed(() => {
@@ -39,7 +34,6 @@ const options = computed(() => {
 		items.push({
 			label: 'Primary payment method',
 			icon: 'lucide-star',
-			disabled: props.canPromote === false,
 			onClick: () => emit('makeDefault', props.method),
 		})
 	if (!props.isFirst)

--- a/dashboard/src/components/billing/PaymentMethodsCard.vue
+++ b/dashboard/src/components/billing/PaymentMethodsCard.vue
@@ -108,10 +108,12 @@ const setMode = useCall<unknown, { team: string; mode: string }>({
 	immediate: false,
 })
 
-// Credits are used before any method, so the methods below them are numbered from
-// one: the order they are tried in when the balance can't cover the invoice.
+// Credits are *used*; methods are *charged*. So the top method says it is charged
+// first and the ones under it are the fallbacks, numbered by the order they are
+// tried. Numbering the top method as a fallback made it look like something that
+// could be promoted, when it already holds the position.
 function rankLabel(idx: number): string {
-	return `Fallback ${idx + 1}`
+	return idx === 0 ? 'Charged first' : `Fallback ${idx}`
 }
 
 // Choosing which method gets charged decides nothing while there is a balance to

--- a/dashboard/src/components/billing/PaymentMethodsCard.vue
+++ b/dashboard/src/components/billing/PaymentMethodsCard.vue
@@ -125,10 +125,11 @@ const firstOptions = computed(() => [
 async function chooseCredits(): Promise<void> {
 	try {
 		await setMode.submit({ team: activeTeam.value!, mode: 'Prepaid' })
-		successToast('Nothing will be charged automatically.')
-		collection.reload()
+		if (setMode.error) throw setMode.error
+		successToast('Your balance pays the bill now.')
+		await collection.reload()
 	} catch (e) {
-		errorToast(e)
+		errorToast(e, 'Could not change how you are billed.')
 	}
 }
 
@@ -138,10 +139,12 @@ async function makeDefault(pm: PaymentMethod): Promise<void> {
 		await setDefault.submit({ payment_method: pm.name })
 		// Charging this first only means something if anything is charged at all, so
 		// a prepaid team comes off prepaid by asking for it.
-		if (creditsFirst.value)
+		if (creditsFirst.value) {
 			await setMode.submit({ team: activeTeam.value!, mode: 'Auto Charge' })
+			if (setMode.error) throw setMode.error
+		}
 		successToast(`${pm.display_label || pm.method_type} is charged first.`)
-		collection.reload()
+		await collection.reload()
 		reloadMethods()
 	} catch (e) {
 		errorToast(e)
@@ -227,7 +230,7 @@ function onAdd(): void {
 					<p class="text-p-sm text-ink-gray-5">
 						{{
 							creditsFirst
-								? 'Invoices are settled from your balance. Nothing is charged automatically.'
+								? 'Your balance pays the bill. Keep it topped up.'
 								: "Whatever your credits don't cover goes here."
 						}}
 					</p>
@@ -314,7 +317,7 @@ function onAdd(): void {
 			<p class="mt-3 text-p-sm text-ink-gray-5">
 				{{
 					creditsFirst
-						? 'Top up before the invoice is raised, or it goes unpaid.'
+						? 'A short balance leaves the invoice unpaid — nothing below is charged.'
 						: ordered.length > 1
 							? "If the one charged first can't cover the invoice, we try the next, in this order."
 							: 'Add another way to pay so a failed charge has somewhere to go.'

--- a/dashboard/src/components/billing/PaymentMethodsCard.vue
+++ b/dashboard/src/components/billing/PaymentMethodsCard.vue
@@ -295,30 +295,16 @@ function onAdd(): void {
 				</div>
 			</div>
 
-			<p
-				v-if="!ordered.length"
-				class="mt-3 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-p-sm text-ink-gray-5"
+			<Button
+				v-if="canManageBilling && !ordered.length"
+				class="mt-3"
+				label="Add payment method"
+				@click="onAdd"
 			>
-				<span>
-					Credits pay what they can; the rest is yours to settle. Save a card or
-					UPI Autopay and we'll charge it instead.
-				</span>
-				<button
-					v-if="canManageBilling"
-					type="button"
-					class="font-medium text-ink-gray-7 underline underline-offset-2 hover:text-ink-gray-9"
-					@click="onAdd"
-				>
-					Add one
-				</button>
-			</p>
-			<p v-else class="mt-3 text-p-sm text-ink-gray-5">
-				{{
-					ordered.length > 1
-						? "If a charge fails we try the next one, so a single dead card doesn't end in suspension."
-						: 'Add a second card so a failed charge has somewhere to go before suspension.'
-				}}
-			</p>
+				<template #prefix>
+					<span class="lucide-plus size-4" aria-hidden="true" />
+				</template>
+			</Button>
 		</template>
 
 

--- a/dashboard/src/components/billing/PaymentMethodsCard.vue
+++ b/dashboard/src/components/billing/PaymentMethodsCard.vue
@@ -139,7 +139,7 @@ async function makeDefault(pm: PaymentMethod): Promise<void> {
 			await setMode.submit({ team: activeTeam.value!, mode: 'Auto Charge' })
 			if (setMode.error) throw setMode.error
 		}
-		successToast(`${pm.display_label || pm.method_type} is charged first.`)
+		successToast(`${pm.display_label || pm.method_type} is charged first`)
 		await collection.reload()
 		reloadMethods()
 	} catch (e) {
@@ -224,7 +224,7 @@ function onAdd(): void {
 							aria-hidden="true"
 						/>
 						<div class="min-w-0">
-							<span class="truncate text-sm font-medium text-ink-gray-9">
+							<span class="truncate text-sm-medium text-ink-gray-9">
 								Prepaid credits
 							</span>
 							<div class="truncate text-p-sm text-ink-gray-5">
@@ -233,7 +233,7 @@ function onAdd(): void {
 						</div>
 					</div>
 					<div class="flex shrink-0 items-center gap-1">
-						<span v-if="hasCredits" class="text-sm font-medium text-ink-gray-9">
+						<span v-if="hasCredits" class="text-sm-medium text-ink-gray-9">
 							Primary
 						</span>
 						<!-- Holds the column so this row lines up with ones that have a menu. -->
@@ -253,7 +253,7 @@ function onAdd(): void {
 						/>
 						<div class="min-w-0">
 							<div class="flex items-center gap-2">
-								<span class="truncate text-sm font-medium text-ink-gray-9">
+								<span class="truncate text-sm-medium text-ink-gray-9">
 									{{ pm.display_label || pm.method_type }}
 								</span>
 								<Badge
@@ -273,7 +273,7 @@ function onAdd(): void {
 						</div>
 					</div>
 					<div class="flex shrink-0 items-center gap-1">
-						<span class="text-sm font-medium text-ink-gray-9">
+						<span class="text-sm-medium text-ink-gray-9">
 							{{ methodLabel(idx) }}
 						</span>
 						<PaymentMethodRowActions

--- a/dashboard/src/components/billing/PaymentMethodsCard.vue
+++ b/dashboard/src/components/billing/PaymentMethodsCard.vue
@@ -6,7 +6,6 @@ import AddMethodDialog from '@/components/AddMethodDialog.vue'
 import BillingCard from '@/components/billing/BillingCard.vue'
 import PaymentMethodRowActions from '@/components/billing/PaymentMethodRowActions.vue'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
-import EmptyState from '@/components/common/EmptyState.vue'
 import { useBillingOverview } from '@/composables/useBillingOverview'
 import { useBillingSetup } from '@/composables/useBillingSetup'
 import { useCapabilities } from '@/composables/useCapabilities'
@@ -16,9 +15,13 @@ import { money } from '@/lib/format'
 import { errorToast, successToast } from '@/lib/toast'
 import type { CollectionStatus, PaymentMethod } from '@/types/billing'
 
-// Payment methods — one ordered list of the ways an invoice gets settled, with the
-// chooser on top naming what goes first. Choosing changes the order and nothing
-// else: no row appears or disappears because of a setting.
+// Payment methods — one ordered list of the ways an invoice gets settled. Each row
+// carries its own control, so the order is set where it is read rather than in a
+// separate chooser above the thing it governs.
+//
+// Credits lead by default because a new team is granted some, and while they last
+// they are what pays the bill. When they run out the customer picks what takes
+// over — the balance they top up, or a method we debit.
 //
 // Prepaid credits are the first entry because the engine spends them before it
 // charges anything (the credits waterfall, credits.md). Choosing credits as the
@@ -100,27 +103,13 @@ const setMode = useCall<unknown, { team: string; mode: string }>({
 	immediate: false,
 })
 
-// What the top row says, and what each row is badged with.
+// What each row is badged with. While credits lead, a method below is not a rung
+// the engine would try — prepaid means a short balance waits for a top-up — so it
+// says so rather than claiming a place in an order that isn't run.
 function rankLabel(idx: number): string {
 	if (creditsFirst.value) return 'Not charged'
 	return idx === 0 ? 'Charged first' : `Fallback ${idx}`
 }
-
-const firstLabel = computed(() => {
-	if (creditsFirst.value) return 'Prepaid credits'
-	const first = ordered.value[0]
-	return first ? first.display_label || first.method_type : 'Prepaid credits'
-})
-
-// The chooser lists every entry in the card, credits included — picking one is the
-// same act as promoting a row, which is why the row menu offers it too.
-const firstOptions = computed(() => [
-	{ label: 'Prepaid credits', onClick: () => chooseCredits() },
-	...ordered.value.map((pm) => ({
-		label: pm.display_label || pm.method_type,
-		onClick: () => makeDefault(pm),
-	})),
-])
 
 async function chooseCredits(): Promise<void> {
 	try {
@@ -194,7 +183,7 @@ function onAdd(): void {
 <template>
 	<BillingCard
 		title="Payment methods"
-		title-info="Credits are always spent first. What you choose here decides what covers the rest."
+		title-info="Credits are spent first while you have them. Choose which method is charged once they run out."
 	>
 		<template #action>
 			<Button
@@ -224,31 +213,7 @@ function onAdd(): void {
 		</div>
 
 		<template v-else>
-			<div class="flex items-center justify-between gap-3 pb-3">
-				<div class="min-w-0">
-					<p class="text-sm font-medium text-ink-gray-8">Charge this first</p>
-					<p class="text-p-sm text-ink-gray-5">
-						{{
-							creditsFirst
-								? 'Your balance pays the bill. Keep it topped up.'
-								: "Whatever your credits don't cover goes here."
-						}}
-					</p>
-				</div>
-				<Dropdown
-					v-if="canManageBilling && ordered.length"
-					:options="firstOptions"
-				>
-					<Button :label="firstLabel">
-						<template #suffix>
-							<span class="lucide-chevron-down size-3.5" aria-hidden="true" />
-						</template>
-					</Button>
-				</Dropdown>
-				<span v-else class="text-p-sm text-ink-gray-6">{{ firstLabel }}</span>
-			</div>
-
-			<div class="divide-y divide-outline-gray-1 border-t border-outline-gray-1">
+			<div class="divide-y divide-outline-gray-1">
 				<div class="flex items-center gap-3 py-2.5">
 					<span
 						class="grid size-8 shrink-0 place-items-center rounded-lg bg-surface-gray-2 text-ink-gray-6"
@@ -267,6 +232,17 @@ function onAdd(): void {
 						:theme="creditsFirst ? 'blue' : 'gray'"
 						:label="creditsFirst ? 'Charged first' : 'Spent first'"
 					/>
+					<Dropdown
+						v-if="canManageBilling && !creditsFirst && ordered.length"
+						:options="[
+							{ label: 'Charge this first', onClick: () => chooseCredits() },
+						]"
+					>
+						<Button variant="ghost" size="sm" icon="lucide-more-horizontal" />
+					</Dropdown>
+					<!-- Holds the column so this row's badge lines up with the ones that
+               do have a menu. -->
+					<span v-else class="size-7 shrink-0" aria-hidden="true" />
 				</div>
 				<div
 					v-for="(pm, idx) in ordered"
@@ -314,37 +290,29 @@ function onAdd(): void {
 				</div>
 			</div>
 
-			<p class="mt-3 text-p-sm text-ink-gray-5">
-				{{
-					creditsFirst
-						? 'A short balance leaves the invoice unpaid — nothing below is charged.'
-						: ordered.length > 1
-							? "If the one charged first can't cover the invoice, we try the next, in this order."
-							: 'Add another way to pay so a failed charge has somewhere to go.'
-				}}
+			<p
+				v-if="!ordered.length"
+				class="mt-3 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-p-sm text-ink-gray-5"
+			>
+				<span>Add a card or UPI Autopay to cover what credits don't.</span>
+				<button
+					v-if="canManageBilling"
+					type="button"
+					class="font-medium text-ink-gray-7 underline underline-offset-2 hover:text-ink-gray-9"
+					@click="onAdd"
+				>
+					Add one
+				</button>
+			</p>
+			<p
+				v-else-if="ordered.length > 1"
+				class="mt-3 text-p-sm text-ink-gray-5"
+			>
+				If the one charged first can't cover the invoice, we try the next, in
+				this order.
 			</p>
 		</template>
 
-		<EmptyState
-			v-if="!loading && !ordered.length"
-			class="mt-3 border-t border-outline-gray-1 pt-3"
-			icon="lucide-credit-card"
-			title="Nothing to charge after credits"
-			description="Add a card or UPI Autopay and it covers whatever your balance doesn't."
-		>
-			<template v-if="canManageBilling" #action>
-				<Button
-					variant="solid"
-					theme="gray"
-					label="Add payment method"
-					@click="onAdd"
-				>
-					<template #prefix
-						><span class="lucide-plus size-4" aria-hidden="true" /></template
-					>
-				</Button>
-			</template>
-		</EmptyState>
 
 		<ConfirmDialog
 			v-model:target="pendingRemove"

--- a/dashboard/src/components/billing/PaymentMethodsCard.vue
+++ b/dashboard/src/components/billing/PaymentMethodsCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Badge, Button, useCall } from 'frappe-ui'
+import { Badge, Button, Dropdown, useCall } from 'frappe-ui'
 import { computed, ref } from 'vue'
 import { API, method } from '@/api/methods'
 import AddMethodDialog from '@/components/AddMethodDialog.vue'
@@ -11,17 +11,25 @@ import { useBillingOverview } from '@/composables/useBillingOverview'
 import { useBillingSetup } from '@/composables/useBillingSetup'
 import { useCapabilities } from '@/composables/useCapabilities'
 import { useSession } from '@/composables/useSession'
+import { whenTeamReady } from '@/composables/useTeamScope'
+import { money } from '@/lib/format'
 import { errorToast, successToast } from '@/lib/toast'
-import type { PaymentMethod } from '@/types/billing'
+import type { CollectionStatus, PaymentMethod } from '@/types/billing'
 
-// Payment methods — primary + backups in fallback order, rendered as the FC v2
-// prototype's clean divide-y list (rounded-square icon, Primary/Backup badge,
-// ellipsis menu) rather than a table. The card owns the calls and the destructive
-// remove confirm (a local Dialog, since this app mounts no global <Dialogs />
-// container). Charges try the methods top-down; if one fails, billing falls back
-// to the next.
+// Payment methods — one ordered list of the ways an invoice gets settled, with the
+// chooser on top naming what goes first. Choosing changes the order and nothing
+// else: no row appears or disappears because of a setting.
+//
+// Prepaid credits are the first entry because the engine spends them before it
+// charges anything (the credits waterfall, credits.md). Choosing credits as the
+// one charged first means the opposite of a fallback — it says *don't* auto-charge
+// what the balance can't cover — so the rows below then read "not charged" rather
+// than pretending to be rungs the engine would try.
+//
+// The card owns the calls and the destructive remove confirm (a local Dialog, since
+// this app mounts no global <Dialogs /> container).
 const { activeTeam } = useSession()
-const { methods, reloadMethods } = useBillingOverview()
+const { methods, credit, currency, reloadMethods } = useBillingOverview()
 const { canManageBilling } = useCapabilities()
 const { requireSetup } = useBillingSetup()
 
@@ -52,23 +60,88 @@ function methodIcon(pm: PaymentMethod): string {
 	return pm.method_type === 'Card' ? 'lucide-credit-card' : 'lucide-smartphone'
 }
 
-// Row detail line: method type, expiry (cards), and the fallback rank so the
-// top-down charge order stays legible.
-function detail(pm: PaymentMethod, rank: number): string {
-	const parts = [pm.method_type]
+// The second line has to say something the first one doesn't. A method with no
+// label of its own is titled by its type, so repeating the type underneath ("UPI
+// Autopay / UPI Autopay") is noise — that row shows the ceiling the bank will let
+// us debit instead, or nothing at all.
+function detail(pm: PaymentMethod): string {
+	const parts: string[] = []
+	if (pm.display_label) parts.push(pm.method_type)
 	if (pm.expiry_month && pm.expiry_year)
 		parts.push(
 			`expires ${String(pm.expiry_month).padStart(2, '0')}/${pm.expiry_year}`,
 		)
-	if (ordered.value.length > 1) parts.push(`fallback #${rank}`)
+	if (pm.mandate_max_amount)
+		parts.push(
+			`up to ${money(pm.mandate_max_amount, pm.mandate_currency || currency.value)} per debit`,
+		)
 	return parts.join(' · ')
+}
+
+const balance = computed(() => Number(credit.data?.balance ?? 0))
+
+// Which entry is charged first. Credits win whenever the team is prepaid; otherwise
+// the primary method does, and credits are still spent first by the engine — the
+// difference the customer feels is whether anything gets charged at all.
+const creditsFirst = computed(() => collectionMode.value === 'Prepaid')
+
+const collection = useCall<CollectionStatus, { team: string }>({
+	url: method(API.collectionStatus),
+	params: () => ({ team: activeTeam.value! }),
+	immediate: false,
+	refetch: true,
+})
+whenTeamReady(() => collection.reload())
+const collectionMode = computed(() => collection.data?.collection_mode ?? '')
+
+const setMode = useCall<unknown, { team: string; mode: string }>({
+	url: method(API.setCollectionMode),
+	method: 'POST',
+	immediate: false,
+})
+
+// What the top row says, and what each row is badged with.
+function rankLabel(idx: number): string {
+	if (creditsFirst.value) return 'Not charged'
+	return idx === 0 ? 'Charged first' : `Fallback ${idx}`
+}
+
+const firstLabel = computed(() => {
+	if (creditsFirst.value) return 'Prepaid credits'
+	const first = ordered.value[0]
+	return first ? first.display_label || first.method_type : 'Prepaid credits'
+})
+
+// The chooser lists every entry in the card, credits included — picking one is the
+// same act as promoting a row, which is why the row menu offers it too.
+const firstOptions = computed(() => [
+	{ label: 'Prepaid credits', onClick: () => chooseCredits() },
+	...ordered.value.map((pm) => ({
+		label: pm.display_label || pm.method_type,
+		onClick: () => makeDefault(pm),
+	})),
+])
+
+async function chooseCredits(): Promise<void> {
+	try {
+		await setMode.submit({ team: activeTeam.value!, mode: 'Prepaid' })
+		successToast('Nothing will be charged automatically.')
+		collection.reload()
+	} catch (e) {
+		errorToast(e)
+	}
 }
 
 async function makeDefault(pm: PaymentMethod): Promise<void> {
 	busy.value = pm.name
 	try {
 		await setDefault.submit({ payment_method: pm.name })
-		successToast('Default updated')
+		// Charging this first only means something if anything is charged at all, so
+		// a prepaid team comes off prepaid by asking for it.
+		if (creditsFirst.value)
+			await setMode.submit({ team: activeTeam.value!, mode: 'Auto Charge' })
+		successToast(`${pm.display_label || pm.method_type} is charged first.`)
+		collection.reload()
 		reloadMethods()
 	} catch (e) {
 		errorToast(e)
@@ -118,7 +191,7 @@ function onAdd(): void {
 <template>
 	<BillingCard
 		title="Payment methods"
-		title-info="The primary is charged first. If it fails, billing falls back to your next method."
+		title-info="Credits are always spent first. What you choose here decides what covers the rest."
 	>
 		<template #action>
 			<Button
@@ -147,56 +220,114 @@ function onAdd(): void {
 			</div>
 		</div>
 
-		<div v-else-if="ordered.length" class="divide-y divide-outline-gray-1">
-			<div
-				v-for="(pm, idx) in ordered"
-				:key="pm.name"
-				class="flex items-center gap-3 py-2.5"
-			>
-				<span
-					class="grid size-8 shrink-0 place-items-center rounded-md bg-surface-gray-2 text-ink-gray-6"
-				>
-					<span :class="methodIcon(pm)" class="size-4" aria-hidden="true" />
-				</span>
-				<div class="min-w-0 flex-1">
-					<p class="truncate text-sm-medium text-ink-gray-9">
-						{{ pm.display_label || pm.method_type }}
-					</p>
-					<p class="truncate text-p-sm text-ink-gray-5">
-						{{ detail(pm, idx + 1) }}
+		<template v-else>
+			<div class="flex items-center justify-between gap-3 pb-3">
+				<div class="min-w-0">
+					<p class="text-sm font-medium text-ink-gray-8">Charge this first</p>
+					<p class="text-p-sm text-ink-gray-5">
+						{{
+							creditsFirst
+								? 'Invoices are settled from your balance. Nothing is charged automatically.'
+								: "Whatever your credits don't cover goes here."
+						}}
 					</p>
 				</div>
-				<Badge
-					v-if="pm.reauth_required"
-					theme="orange"
-					label="Needs verification"
-				/>
-				<Badge
-					v-else-if="pm.status !== 'Active'"
-					theme="gray"
-					:label="pm.status"
-				/>
-				<Badge v-if="pm.is_default" theme="green" label="Primary" />
-				<Badge v-else theme="gray" label="Backup" />
-				<PaymentMethodRowActions
-					:method="pm"
-					:can-manage="canManageBilling"
-					:is-first="idx === 0"
-					:is-last="idx === ordered.length - 1"
-					:busy="busy === pm.name"
-					@make-default="makeDefault"
-					@move-up="(m) => move(m, -1)"
-					@move-down="(m) => move(m, 1)"
-					@remove="pendingRemove = $event"
-				/>
+				<Dropdown
+					v-if="canManageBilling && ordered.length"
+					:options="firstOptions"
+				>
+					<Button :label="firstLabel">
+						<template #suffix>
+							<span class="lucide-chevron-down size-3.5" aria-hidden="true" />
+						</template>
+					</Button>
+				</Dropdown>
+				<span v-else class="text-p-sm text-ink-gray-6">{{ firstLabel }}</span>
 			</div>
-		</div>
+
+			<div class="divide-y divide-outline-gray-1 border-t border-outline-gray-1">
+				<div class="flex items-center gap-3 py-2.5">
+					<span
+						class="grid size-8 shrink-0 place-items-center rounded-lg bg-surface-gray-2 text-ink-gray-6"
+					>
+						<span class="lucide-wallet size-4" aria-hidden="true" />
+					</span>
+					<div class="min-w-0 flex-1">
+						<p class="truncate text-sm font-medium text-ink-gray-9">
+							Prepaid credits
+						</p>
+						<p class="truncate text-p-sm text-ink-gray-5">
+							Balance {{ money(balance, currency) }}
+						</p>
+					</div>
+					<Badge
+						:theme="creditsFirst ? 'blue' : 'gray'"
+						:label="creditsFirst ? 'Charged first' : 'Spent first'"
+					/>
+				</div>
+				<div
+					v-for="(pm, idx) in ordered"
+					:key="pm.name"
+					class="flex items-center gap-3 py-2.5"
+				>
+					<span
+						class="grid size-8 shrink-0 place-items-center rounded-lg bg-surface-gray-2 text-ink-gray-6"
+					>
+						<span :class="methodIcon(pm)" class="size-4" aria-hidden="true" />
+					</span>
+					<div class="min-w-0 flex-1">
+						<p class="truncate text-sm font-medium text-ink-gray-9">
+							{{ pm.display_label || pm.method_type }}
+						</p>
+						<p v-if="detail(pm)" class="truncate text-p-sm text-ink-gray-5">
+							{{ detail(pm) }}
+						</p>
+					</div>
+					<Badge
+						v-if="pm.reauth_required"
+						theme="orange"
+						label="Re-auth needed"
+					/>
+					<Badge
+						v-else-if="pm.status !== 'Active'"
+						theme="gray"
+						:label="pm.status"
+					/>
+					<Badge
+						:theme="!creditsFirst && idx === 0 ? 'blue' : 'gray'"
+						:label="rankLabel(idx)"
+					/>
+					<PaymentMethodRowActions
+						:method="pm"
+						:can-manage="canManageBilling"
+						:is-first="idx === 0"
+						:is-last="idx === ordered.length - 1"
+						:busy="busy === pm.name"
+						@make-default="makeDefault"
+						@move-up="(m) => move(m, -1)"
+						@move-down="(m) => move(m, 1)"
+						@remove="pendingRemove = $event"
+					/>
+				</div>
+			</div>
+
+			<p class="mt-3 text-p-sm text-ink-gray-5">
+				{{
+					creditsFirst
+						? 'Top up before the invoice is raised, or it goes unpaid.'
+						: ordered.length > 1
+							? "If the one charged first can't cover the invoice, we try the next, in this order."
+							: 'Add another way to pay so a failed charge has somewhere to go.'
+				}}
+			</p>
+		</template>
 
 		<EmptyState
-			v-else
+			v-if="!loading && !ordered.length"
+			class="mt-3 border-t border-outline-gray-1 pt-3"
 			icon="lucide-credit-card"
-			title="No payment methods yet"
-			description="Add a card or UPI Autopay to pay invoices automatically."
+			title="Nothing to charge after credits"
+			description="Add a card or UPI Autopay and it covers whatever your balance doesn't."
 		>
 			<template v-if="canManageBilling" #action>
 				<Button

--- a/dashboard/src/components/billing/PaymentMethodsCard.vue
+++ b/dashboard/src/components/billing/PaymentMethodsCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Badge, Button, Dropdown, useCall } from 'frappe-ui'
+import { Badge, Button, useCall } from 'frappe-ui'
 import { computed, ref } from 'vue'
 import { API, method } from '@/api/methods'
 import AddMethodDialog from '@/components/AddMethodDialog.vue'
@@ -108,24 +108,15 @@ const setMode = useCall<unknown, { team: string; mode: string }>({
 	immediate: false,
 })
 
-// What each row is badged with. While credits lead, a method below is not a rung
-// the engine would try — prepaid means a short balance waits for a top-up — so it
-// says so rather than claiming a place in an order that isn't run.
+// Credits are used before any method, so the methods below them are numbered from
+// one: the order they are tried in when the balance can't cover the invoice.
 function rankLabel(idx: number): string {
-	if (creditsFirst.value) return 'Not charged'
-	return idx === 0 ? 'Charged first' : `Fallback ${idx}`
+	return `Fallback ${idx + 1}`
 }
 
-async function chooseCredits(): Promise<void> {
-	try {
-		await setMode.submit({ team: activeTeam.value!, mode: 'Prepaid' })
-		if (setMode.error) throw setMode.error
-		successToast('Your balance pays the bill now.')
-		await collection.reload()
-	} catch (e) {
-		errorToast(e, 'Could not change how you are billed.')
-	}
-}
+// Choosing which method gets charged decides nothing while there is a balance to
+// spend, so the action is offered and disabled rather than hidden.
+const canPromote = computed(() => balance.value <= 0)
 
 async function makeDefault(pm: PaymentMethod): Promise<void> {
 	busy.value = pm.name
@@ -231,19 +222,9 @@ function onAdd(): void {
 						</div>
 					</div>
 					<div class="flex shrink-0 items-center gap-1">
-						<span class="text-sm font-medium text-ink-gray-9">
-							{{ creditsFirst ? 'Charged first' : 'Spent first' }}
-						</span>
-						<Dropdown
-							v-if="canManageBilling && !creditsFirst && ordered.length"
-							:options="[
-								{ label: 'Charge this first', onClick: () => chooseCredits() },
-							]"
-						>
-							<Button variant="ghost" size="sm" icon="lucide-more-horizontal" />
-						</Dropdown>
+						<span class="text-sm font-medium text-ink-gray-9">Used first</span>
 						<!-- Holds the column so this row lines up with ones that have a menu. -->
-						<span v-else class="size-7" aria-hidden="true" />
+						<span class="size-7" aria-hidden="true" />
 					</div>
 				</div>
 				<div
@@ -285,6 +266,7 @@ function onAdd(): void {
 						<PaymentMethodRowActions
 							:method="pm"
 							:can-manage="canManageBilling"
+							:can-promote="canPromote"
 							:is-first="idx === 0"
 							:is-last="idx === ordered.length - 1"
 							:busy="busy === pm.name"

--- a/dashboard/src/components/billing/PaymentMethodsCard.vue
+++ b/dashboard/src/components/billing/PaymentMethodsCard.vue
@@ -108,13 +108,9 @@ const setMode = useCall<unknown, { team: string; mode: string }>({
 	immediate: false,
 })
 
-// Credits are *used*; methods are *charged*. So the top method says it is charged
-// first and the ones under it are the fallbacks, numbered by the order they are
-// tried. Numbering the top method as a fallback made it look like something that
-// could be promoted, when it already holds the position.
-function rankLabel(idx: number): string {
-	return idx === 0 ? 'Charged first' : `Fallback ${idx}`
-}
+// The order is the whole point of this list, and a number says it without a word.
+// Credits are step 1 because the engine spends them before it charges anything;
+// each method follows in the order it is tried.
 
 // Choosing which method gets charged decides nothing while there is a balance to
 // spend, so the action is offered and disabled rather than hidden.
@@ -181,7 +177,7 @@ function onAdd(): void {
 <template>
 	<BillingCard
 		title="Payment methods"
-		title-info="Credits are spent first while you have them. Choose which method is charged once they run out."
+		title-info="Settled in this order: credits first, then each method until one goes through."
 	>
 		<template v-if="canManageBilling" #action>
 			<Button
@@ -211,6 +207,12 @@ function onAdd(): void {
 				<div class="flex items-center justify-between gap-3 py-3">
 					<div class="flex min-w-0 items-start gap-2.5">
 						<span
+							class="mt-0.5 w-3 shrink-0 text-p-sm tabular-nums text-ink-gray-4"
+							aria-hidden="true"
+						>
+							1
+						</span>
+						<span
 							class="lucide-wallet mt-0.5 size-4 shrink-0 text-ink-gray-5"
 							aria-hidden="true"
 						/>
@@ -223,11 +225,8 @@ function onAdd(): void {
 							</div>
 						</div>
 					</div>
-					<div class="flex shrink-0 items-center gap-1">
-						<span class="text-sm font-medium text-ink-gray-9">Used first</span>
-						<!-- Holds the column so this row lines up with ones that have a menu. -->
-						<span class="size-7" aria-hidden="true" />
-					</div>
+					<!-- Holds the column so this row lines up with ones that have a menu. -->
+					<span class="size-7 shrink-0" aria-hidden="true" />
 				</div>
 				<div
 					v-for="(pm, idx) in ordered"
@@ -235,6 +234,12 @@ function onAdd(): void {
 					class="flex items-center justify-between gap-3 py-3"
 				>
 					<div class="flex min-w-0 items-start gap-2.5">
+						<span
+							class="mt-0.5 w-3 shrink-0 text-p-sm tabular-nums text-ink-gray-4"
+							aria-hidden="true"
+						>
+							{{ idx + 2 }}
+						</span>
 						<span
 							:class="methodIcon(pm)"
 							class="mt-0.5 size-4 shrink-0 text-ink-gray-5"
@@ -262,9 +267,6 @@ function onAdd(): void {
 						</div>
 					</div>
 					<div class="flex shrink-0 items-center gap-1">
-						<span class="text-sm font-medium text-ink-gray-9">
-							{{ rankLabel(idx) }}
-						</span>
 						<PaymentMethodRowActions
 							:method="pm"
 							:can-manage="canManageBilling"

--- a/dashboard/src/components/billing/PaymentMethodsCard.vue
+++ b/dashboard/src/components/billing/PaymentMethodsCard.vue
@@ -108,13 +108,17 @@ const setMode = useCall<unknown, { team: string; mode: string }>({
 	immediate: false,
 })
 
-// The order is the whole point of this list, and a number says it without a word.
-// Credits are step 1 because the engine spends them before it charges anything;
-// each method follows in the order it is tried.
+// The order is the whole point of this list, and it is the order the engine really
+// uses: an invoice applies credits first, then walks the methods until one goes
+// through (invoicing/lifecycle.py). So whatever leads is the primary and the rest
+// are numbered fallbacks — while there is a balance that is the wallet, and when it
+// runs dry the first method takes the title without anyone being asked.
+const hasCredits = computed(() => balance.value > 0)
 
-// Choosing which method gets charged decides nothing while there is a balance to
-// spend, so the action is offered and disabled rather than hidden.
-const canPromote = computed(() => balance.value <= 0)
+function methodLabel(idx: number): string {
+	if (hasCredits.value) return `Fallback ${idx + 1}`
+	return idx === 0 ? 'Primary' : `Fallback ${idx}`
+}
 
 async function makeDefault(pm: PaymentMethod): Promise<void> {
 	busy.value = pm.name
@@ -207,12 +211,6 @@ function onAdd(): void {
 				<div class="flex items-center justify-between gap-3 py-3">
 					<div class="flex min-w-0 items-start gap-2.5">
 						<span
-							class="mt-0.5 w-3 shrink-0 text-p-sm tabular-nums text-ink-gray-4"
-							aria-hidden="true"
-						>
-							1
-						</span>
-						<span
 							class="lucide-wallet mt-0.5 size-4 shrink-0 text-ink-gray-5"
 							aria-hidden="true"
 						/>
@@ -225,8 +223,16 @@ function onAdd(): void {
 							</div>
 						</div>
 					</div>
-					<!-- Holds the column so this row lines up with ones that have a menu. -->
-					<span class="size-7 shrink-0" aria-hidden="true" />
+					<div class="flex shrink-0 items-center gap-1">
+						<span
+							v-if="hasCredits"
+							class="text-sm font-medium text-ink-gray-9"
+						>
+							Primary
+						</span>
+						<!-- Holds the column so this row lines up with ones that have a menu. -->
+						<span class="size-7" aria-hidden="true" />
+					</div>
 				</div>
 				<div
 					v-for="(pm, idx) in ordered"
@@ -234,12 +240,6 @@ function onAdd(): void {
 					class="flex items-center justify-between gap-3 py-3"
 				>
 					<div class="flex min-w-0 items-start gap-2.5">
-						<span
-							class="mt-0.5 w-3 shrink-0 text-p-sm tabular-nums text-ink-gray-4"
-							aria-hidden="true"
-						>
-							{{ idx + 2 }}
-						</span>
 						<span
 							:class="methodIcon(pm)"
 							class="mt-0.5 size-4 shrink-0 text-ink-gray-5"
@@ -267,10 +267,12 @@ function onAdd(): void {
 						</div>
 					</div>
 					<div class="flex shrink-0 items-center gap-1">
+						<span class="text-sm font-medium text-ink-gray-9">
+							{{ methodLabel(idx) }}
+						</span>
 						<PaymentMethodRowActions
 							:method="pm"
 							:can-manage="canManageBilling"
-							:can-promote="canPromote"
 							:is-first="idx === 0"
 							:is-last="idx === ordered.length - 1"
 							:busy="busy === pm.name"

--- a/dashboard/src/components/billing/PaymentMethodsCard.vue
+++ b/dashboard/src/components/billing/PaymentMethodsCard.vue
@@ -20,8 +20,13 @@ import type { CollectionStatus, PaymentMethod } from '@/types/billing'
 // separate chooser above the thing it governs.
 //
 // Credits lead by default because a new team is granted some, and while they last
-// they are what pays the bill. When they run out the customer picks what takes
-// over — the balance they top up, or a method we debit.
+// they are what pays the bill. They also pay what they can when they are short —
+// the remainder is charged to a saved method, or left for the customer to settle
+// if nothing is saved.
+//
+// Everything below the first entry exists for one reason: a card that fails should
+// not end in suspension. That is what the fallback order buys, and it is why the
+// list is worth having to a team that only ever uses one card.
 //
 // Prepaid credits are the first entry because the engine spends them before it
 // charges anything (the credits waterfall, credits.md). Choosing credits as the
@@ -294,7 +299,10 @@ function onAdd(): void {
 				v-if="!ordered.length"
 				class="mt-3 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-p-sm text-ink-gray-5"
 			>
-				<span>Add a card or UPI Autopay to cover what credits don't.</span>
+				<span>
+					Credits pay what they can; the rest is yours to settle. Save a card or
+					UPI Autopay and we'll charge it instead.
+				</span>
 				<button
 					v-if="canManageBilling"
 					type="button"
@@ -304,12 +312,12 @@ function onAdd(): void {
 					Add one
 				</button>
 			</p>
-			<p
-				v-else-if="ordered.length > 1"
-				class="mt-3 text-p-sm text-ink-gray-5"
-			>
-				If the one charged first can't cover the invoice, we try the next, in
-				this order.
+			<p v-else class="mt-3 text-p-sm text-ink-gray-5">
+				{{
+					ordered.length > 1
+						? "If a charge fails we try the next one, so a single dead card doesn't end in suspension."
+						: 'Add a second card so a failed charge has somewhere to go before suspension.'
+				}}
 			</p>
 		</template>
 

--- a/dashboard/src/components/billing/PaymentMethodsCard.vue
+++ b/dashboard/src/components/billing/PaymentMethodsCard.vue
@@ -190,28 +190,24 @@ function onAdd(): void {
 		title="Payment methods"
 		title-info="Credits are spent first while you have them. Choose which method is charged once they run out."
 	>
-		<template #action>
+		<template v-if="canManageBilling" #action>
 			<Button
-				v-if="canManageBilling"
-				variant="ghost"
 				size="xs"
-				icon="lucide-plus"
-				:label="ordered.length ? 'Add backup method' : 'Add payment method'"
+				:label="ordered.length ? 'Add method' : 'Add payment method'"
+				icon-left="lucide-plus"
 				@click="onAdd"
 			/>
 		</template>
 
 		<div v-if="loading" class="space-y-3 py-1">
 			<div v-for="i in 2" :key="i" class="flex items-center gap-3">
-				<span
-					class="size-8 shrink-0 animate-pulse rounded-md bg-surface-gray-2"
-				/>
+				<span class="size-4 shrink-0 animate-pulse rounded bg-surface-gray-2" />
 				<div class="flex-1 space-y-1.5">
 					<span
-						class="block h-3.5 w-32 animate-pulse rounded bg-surface-gray-2"
+						class="block h-3.5 w-40 animate-pulse rounded bg-surface-gray-2"
 					/>
 					<span
-						class="block h-3 w-24 animate-pulse rounded bg-surface-gray-2"
+						class="block h-3 w-28 animate-pulse rounded bg-surface-gray-2"
 					/>
 				</div>
 			</div>
@@ -219,92 +215,88 @@ function onAdd(): void {
 
 		<template v-else>
 			<div class="divide-y divide-outline-gray-1">
-				<div class="flex items-center gap-3 py-2.5">
-					<span
-						class="grid size-8 shrink-0 place-items-center rounded-lg bg-surface-gray-2 text-ink-gray-6"
-					>
-						<span class="lucide-wallet size-4" aria-hidden="true" />
-					</span>
-					<div class="min-w-0 flex-1">
-						<p class="truncate text-sm font-medium text-ink-gray-9">
-							Prepaid credits
-						</p>
-						<p class="truncate text-p-sm text-ink-gray-5">
-							Balance {{ money(balance, currency) }}
-						</p>
+				<div class="flex items-center justify-between gap-3 py-3">
+					<div class="flex min-w-0 items-start gap-2.5">
+						<span
+							class="lucide-wallet mt-0.5 size-4 shrink-0 text-ink-gray-5"
+							aria-hidden="true"
+						/>
+						<div class="min-w-0">
+							<span class="truncate text-sm font-medium text-ink-gray-9">
+								Prepaid credits
+							</span>
+							<div class="truncate text-p-sm text-ink-gray-5">
+								Balance {{ money(balance, currency) }}
+							</div>
+						</div>
 					</div>
-					<Badge
-						:theme="creditsFirst ? 'blue' : 'gray'"
-						:label="creditsFirst ? 'Charged first' : 'Spent first'"
-					/>
-					<Dropdown
-						v-if="canManageBilling && !creditsFirst && ordered.length"
-						:options="[
-							{ label: 'Charge this first', onClick: () => chooseCredits() },
-						]"
-					>
-						<Button variant="ghost" size="sm" icon="lucide-more-horizontal" />
-					</Dropdown>
-					<!-- Holds the column so this row's badge lines up with the ones that
-               do have a menu. -->
-					<span v-else class="size-7 shrink-0" aria-hidden="true" />
+					<div class="flex shrink-0 items-center gap-1">
+						<span class="text-sm font-medium text-ink-gray-9">
+							{{ creditsFirst ? 'Charged first' : 'Spent first' }}
+						</span>
+						<Dropdown
+							v-if="canManageBilling && !creditsFirst && ordered.length"
+							:options="[
+								{ label: 'Charge this first', onClick: () => chooseCredits() },
+							]"
+						>
+							<Button variant="ghost" size="sm" icon="lucide-more-horizontal" />
+						</Dropdown>
+						<!-- Holds the column so this row lines up with ones that have a menu. -->
+						<span v-else class="size-7" aria-hidden="true" />
+					</div>
 				</div>
 				<div
 					v-for="(pm, idx) in ordered"
 					:key="pm.name"
-					class="flex items-center gap-3 py-2.5"
+					class="flex items-center justify-between gap-3 py-3"
 				>
-					<span
-						class="grid size-8 shrink-0 place-items-center rounded-lg bg-surface-gray-2 text-ink-gray-6"
-					>
-						<span :class="methodIcon(pm)" class="size-4" aria-hidden="true" />
-					</span>
-					<div class="min-w-0 flex-1">
-						<p class="truncate text-sm font-medium text-ink-gray-9">
-							{{ pm.display_label || pm.method_type }}
-						</p>
-						<p v-if="detail(pm)" class="truncate text-p-sm text-ink-gray-5">
-							{{ detail(pm) }}
-						</p>
+					<div class="flex min-w-0 items-start gap-2.5">
+						<span
+							:class="methodIcon(pm)"
+							class="mt-0.5 size-4 shrink-0 text-ink-gray-5"
+							aria-hidden="true"
+						/>
+						<div class="min-w-0">
+							<div class="flex items-center gap-2">
+								<span class="truncate text-sm font-medium text-ink-gray-9">
+									{{ pm.display_label || pm.method_type }}
+								</span>
+								<Badge
+									v-if="pm.reauth_required"
+									theme="orange"
+									label="Re-auth needed"
+								/>
+								<Badge
+									v-else-if="pm.status !== 'Active'"
+									theme="gray"
+									:label="pm.status"
+								/>
+							</div>
+							<div v-if="detail(pm)" class="truncate text-p-sm text-ink-gray-5">
+								{{ detail(pm) }}
+							</div>
+						</div>
 					</div>
-					<Badge
-						v-if="pm.reauth_required"
-						theme="orange"
-						label="Re-auth needed"
-					/>
-					<Badge
-						v-else-if="pm.status !== 'Active'"
-						theme="gray"
-						:label="pm.status"
-					/>
-					<Badge
-						:theme="!creditsFirst && idx === 0 ? 'blue' : 'gray'"
-						:label="rankLabel(idx)"
-					/>
-					<PaymentMethodRowActions
-						:method="pm"
-						:can-manage="canManageBilling"
-						:is-first="idx === 0"
-						:is-last="idx === ordered.length - 1"
-						:busy="busy === pm.name"
-						@make-default="makeDefault"
-						@move-up="(m) => move(m, -1)"
-						@move-down="(m) => move(m, 1)"
-						@remove="pendingRemove = $event"
-					/>
+					<div class="flex shrink-0 items-center gap-1">
+						<span class="text-sm font-medium text-ink-gray-9">
+							{{ rankLabel(idx) }}
+						</span>
+						<PaymentMethodRowActions
+							:method="pm"
+							:can-manage="canManageBilling"
+							:is-first="idx === 0"
+							:is-last="idx === ordered.length - 1"
+							:busy="busy === pm.name"
+							@make-default="makeDefault"
+							@move-up="(m) => move(m, -1)"
+							@move-down="(m) => move(m, 1)"
+							@remove="pendingRemove = $event"
+						/>
+					</div>
 				</div>
 			</div>
 
-			<Button
-				v-if="canManageBilling && !ordered.length"
-				class="mt-3"
-				label="Add payment method"
-				@click="onAdd"
-			>
-				<template #prefix>
-					<span class="lucide-plus size-4" aria-hidden="true" />
-				</template>
-			</Button>
 		</template>
 
 

--- a/dashboard/src/components/billing/PaymentMethodsCard.vue
+++ b/dashboard/src/components/billing/PaymentMethodsCard.vue
@@ -113,11 +113,20 @@ const setMode = useCall<unknown, { team: string; mode: string }>({
 // through (invoicing/lifecycle.py). So whatever leads is the primary and the rest
 // are numbered fallbacks — while there is a balance that is the wallet, and when it
 // runs dry the first method takes the title without anyone being asked.
+// One row is the Primary and the rest are its fallbacks. While there is a balance
+// the wallet holds the title, so every method is a fallback; when it runs dry the
+// top method takes it.
 const hasCredits = computed(() => balance.value > 0)
 
 function methodLabel(idx: number): string {
 	if (hasCredits.value) return `Fallback ${idx + 1}`
 	return idx === 0 ? 'Primary' : `Fallback ${idx}`
+}
+
+// Every row labelled a fallback can be made the primary. While credits are paying
+// the bill the choice decides nothing yet, so it is disabled rather than hidden.
+function isPrimaryRow(idx: number): boolean {
+	return !hasCredits.value && idx === 0
 }
 
 async function makeDefault(pm: PaymentMethod): Promise<void> {
@@ -224,10 +233,7 @@ function onAdd(): void {
 						</div>
 					</div>
 					<div class="flex shrink-0 items-center gap-1">
-						<span
-							v-if="hasCredits"
-							class="text-sm font-medium text-ink-gray-9"
-						>
+						<span v-if="hasCredits" class="text-sm font-medium text-ink-gray-9">
 							Primary
 						</span>
 						<!-- Holds the column so this row lines up with ones that have a menu. -->
@@ -273,6 +279,8 @@ function onAdd(): void {
 						<PaymentMethodRowActions
 							:method="pm"
 							:can-manage="canManageBilling"
+							:is-primary="isPrimaryRow(idx)"
+							:can-promote="!hasCredits"
 							:is-first="idx === 0"
 							:is-last="idx === ordered.length - 1"
 							:busy="busy === pm.name"

--- a/dashboard/src/composables/useAddPaymentMethod.ts
+++ b/dashboard/src/composables/useAddPaymentMethod.ts
@@ -61,6 +61,10 @@ export function useAddPaymentMethod({
 			// inline when the billing profile has no phone.
 			if (contact) params.contact = contact
 			await setup.submit(params)
+			// useCall stores the failure rather than throwing it, so rethrow it here.
+			// Otherwise a generic message replaces the server's, and the customer is
+			// told "something went wrong" when the server said exactly what was wrong.
+			if (setup.error) throw setup.error
 			const order = setup.data
 			if (!order) throw new Error('Could not start the payment method setup.')
 			const handles = await openRazorpayCheckout(order, {

--- a/dashboard/src/composables/useAddPaymentMethod.ts
+++ b/dashboard/src/composables/useAddPaymentMethod.ts
@@ -43,6 +43,7 @@ export function useAddPaymentMethod({
 		methodType: string,
 		contact?: string,
 		instrument?: string,
+		afterDecline = false,
 	): Promise<MethodResult | undefined> {
 		try {
 			const params: Record<string, unknown> = {
@@ -51,6 +52,10 @@ export function useAddPaymentMethod({
 				// What the customer tapped. The backend resolves the rail from it, so a
 				// RuPay card goes to Razorpay without anyone reading the card number.
 				instrument: instrument || methodType,
+				// Provenance: the customer arrived here from a card the other rail
+				// refused. The server checks it against a real decline before recording
+				// it, because the field feeds the gateway comparison.
+				after_decline: afterDecline,
 			}
 			// A Razorpay card mandate needs a customer contact; the dialog collects it
 			// inline when the billing profile has no phone.

--- a/dashboard/src/types/billing.ts
+++ b/dashboard/src/types/billing.ts
@@ -281,6 +281,8 @@ export interface BillingSettings {
 export interface CollectionStatus {
 	mode?: string
 	collection_mode?: string
+	/** Networks no rail will auto-charge — shown before the customer picks how to pay. */
+	mandate_gap_note?: string | null
 	action_required: boolean
 	reason: string | null
 	threshold: number | null

--- a/dashboard/src/types/billing.ts
+++ b/dashboard/src/types/billing.ts
@@ -204,6 +204,9 @@ export interface PaymentMethod {
 	reauth_required: boolean | number
 	expiry_month: number | null
 	expiry_year: number | null
+	/** Mandate ceiling — what the bank will let us debit in one go. */
+	mandate_max_amount?: number | null
+	mandate_currency?: string | null
 }
 
 /** get_payment_method_options — what the team may add, resolved from its currency. */

--- a/dashboard/src/types/billing.ts
+++ b/dashboard/src/types/billing.ts
@@ -214,7 +214,6 @@ export interface PaymentInstrument {
 	instrument:
 		| 'Card'
 		| 'RuPay Card'
-		| 'Other Network Card'
 		| 'UPI'
 		| 'UPI Autopay'
 		| 'Netbanking'
@@ -232,6 +231,8 @@ export interface PaymentMethodOptions {
 	adapter_key: 'Stripe' | 'Razorpay' | (string & {})
 	currency: Currency
 	instruments: PaymentInstrument[]
+	/** What no tile on this surface can do — e.g. cards no rail will hold a mandate on. */
+	note?: string | null
 	methods: PaymentMethodType[]
 	allow_upi: boolean
 	upi_block_reason: string | null


### PR DESCRIPTION
Follow-ups to the Stripe Primary milestone (#270), plus the payment-methods card rework.

### Fallback
- Fall back to another method only on a **terminal** decline; ambiguous failures wait for
  reconciliation instead of risking a double charge.
- Notify the customer when every method has failed, so a card that dies doesn't end in suspension.
- `fallback_reason = stripe_decline` is verified against a real declined attempt, not taken from
  the client.

### Amex and Diners
No rail registers a mandate on them: Stripe does Visa/Mastercard, Razorpay adds RuPay. The
auto-pay tile is RuPay-only, the limit is stated where the customer chooses how to pay, and the
Amex route opens the top-up already knowing it's a card.

### Stripe's pre-debit window
Stripe notifies and holds an India mandate charge for 26 hours. That `processing` state used to be
recorded as `Failed` and start dunning; the attempt now stores the gateway's deadline and
reconciliation waits for it. Mandate errors retire the method instead of counting against the card.

### Payment methods card
One ordered list: prepaid credits, then each method. Whatever leads is **Primary**, the rest are
**Fallback 1, 2**. Any fallback row can take the title, disabled while credits are still being paid.
Matches the Metered services card.

---

### Add Payment method
<img width="530" height="484" alt="Screenshot 2026-08-12 at 1 22 08 PM" src="https://github.com/user-attachments/assets/82720f75-3969-46fd-99ec-9ad593aa60e2" />

### Payment methods
<img width="769" height="335" alt="Screenshot 2026-08-12 at 1 22 30 PM" src="https://github.com/user-attachments/assets/752b7ae8-c432-4b58-924c-c0f717e3b271" />

### Switch payment method sequence
<img width="752" height="408" alt="Screenshot 2026-08-12 at 1 22 40 PM" src="https://github.com/user-attachments/assets/9f3eb5f7-1d58-4427-afb8-a0d91e93a736" />

### User with Amex/Diners card
<img width="535" height="430" alt="Screenshot 2026-08-12 at 1 22 16 PM" src="https://github.com/user-attachments/assets/18ed56ec-ffd1-4ee5-857a-4e859cfd394c" />

### Wallter topup/Prepaid Credits

<img width="526" height="489" alt="Screenshot 2026-08-12 at 1 22 23 PM" src="https://github.com/user-attachments/assets/d4ced16c-f1ca-446a-885c-d886a68b6cb5" />

