### PR TITLE
feat: Mint JWT for Datum Log service

### DIFF
--- a/central/api/pilot.py
+++ b/central/api/pilot.py
@@ -80,6 +80,25 @@ def metrics_token() -> dict:
 	}
 
 
+@frappe.whitelist(allow_guest=True, methods=["GET"])
+@pilot_credential_auth
+def log_token() -> dict:
+	"""The JWT this pilot presents to Datum when shipping logs.
+
+	Sibling of `metrics_token`: same gating (refused until Atlas binds the Asset),
+	separate token so rotation is independent. Datum reads `resource_id` and
+	`access` as top-level claims — no vmauth bridge — so the pilot re-fetches on a
+	401 or when the expiry nears, exactly as it does for metrics."""
+	from central.sso import LOG_TTL, mint_log_token
+
+	credential = frappe.local.pilot_credential
+	return {
+		"token": mint_log_token(credential.audience_id, credential.asset),
+		"expires_in": LOG_TTL,
+		"resource_id": credential.asset,
+	}
+
+
 @frappe.whitelist(allow_guest=True, methods=["POST"])
 def enroll(bootstrap_token: str) -> dict:
 	"""First-boot handshake: exchange a single-use, create-time bootstrap token for this

--- a/central/central/doctype/central_sso_settings/central_sso_settings.py
+++ b/central/central/doctype/central_sso_settings/central_sso_settings.py
@@ -78,4 +78,3 @@ class CentralSSOSettings(Document):
 		self.kid = frappe.generate_hash(length=16)
 		# Password field → private key is encrypted at rest on save.
 		self.save(ignore_permissions=True)
-		frappe.db.commit()

--- a/central/central/doctype/central_sso_settings/central_sso_settings.py
+++ b/central/central/doctype/central_sso_settings/central_sso_settings.py
@@ -78,3 +78,4 @@ class CentralSSOSettings(Document):
 		self.kid = frappe.generate_hash(length=16)
 		# Password field → private key is encrypted at rest on save.
 		self.save(ignore_permissions=True)
+		frappe.db.commit()

--- a/central/sso.py
+++ b/central/sso.py
@@ -16,8 +16,11 @@ from central.central.doctype.central_sso_settings.central_sso_settings import AL
 BENCH_LOGIN_TTL = 5 * 60  # a short-lived, single-use admin SID
 BOOTSTRAP_TTL = 30 * 60  # the first-boot enrollment window
 METRICS_TTL = 7 * 24 * 60 * 60  # short: no revocation list, and the pilot re-fetches on 401 / near expiry
+LOG_TTL = METRICS_TTL
 ENROLL_SCOPE = "enroll"
 METRICS_SCOPE = "datum"
+LOG_SCOPE = "logs"
+LOG_ACCESS = ["write"]  # Fluent Bit only writes; reads come through the admin path, not a shipper
 
 
 def central_url() -> str:
@@ -99,6 +102,32 @@ def mint_metrics_token(audience: str, resource_id: str) -> str:
 		METRICS_SCOPE,
 		METRICS_TTL,
 		{"vm_access": {"metrics_extra_labels": [f"resource_id={resource_id}"]}},
+	)
+
+
+def mint_log_token(audience: str, resource_id: str) -> str:
+	"""A token the pilot presents to Datum's logs gateway.
+
+	Unlike the metrics token, this carries `resource_id` and `access` as
+	top-level claims Datum reads directly (``Identity.from_claims`` looks for
+	``resource_id`` and ``access``) — there is no vmauth bridge in front of
+	the logs path. `scope` keeps bench and enrollment tokens, signed with this
+	same key, from writing logs. Fluent Bit only writes, so `access` is
+	``["write"]``; reads come through the admin-facing path, not from a shipper.
+	"""
+	if not resource_id:
+		frappe.throw(
+			_("This pilot has no resource yet; a log token would be unattributable."),
+			frappe.ValidationError,
+		)
+	return _mint(
+		audience,
+		LOG_SCOPE,
+		LOG_TTL,
+		{
+			"resource_id": resource_id,
+			"access": LOG_ACCESS,
+		},
 	)
 
 

--- a/central/tests/test_pilot_api.py
+++ b/central/tests/test_pilot_api.py
@@ -6,9 +6,9 @@ import jwt
 from frappe.tests import IntegrationTestCase
 from frappe.utils import add_to_date, now_datetime, set_request
 
-from central.api.pilot import heartbeat, metrics_token
+from central.api.pilot import heartbeat, log_token, metrics_token
 from central.central.doctype.pilot_credential.pilot_credential import PilotCredential
-from central.sso import METRICS_SCOPE
+from central.sso import LOG_SCOPE, METRICS_SCOPE
 from central.tests.test_iam import ensure_user
 
 
@@ -80,3 +80,45 @@ class TestPilotAPI(IntegrationTestCase):
 		carry no resource id."""
 		with self.assertRaises(frappe.ValidationError):
 			self.call_metrics_token(self.token)
+
+	def call_log_token(self, token: str | None) -> dict:
+		headers = {"X-Pilot-Token": token} if token is not None else {}
+		set_request(method="GET", path="/api/method/central.api.pilot.log_token", headers=headers)
+		return log_token()
+
+	def test_log_token_carries_resource_id_and_write_access(self):
+		"""Datum reads `resource_id` and `access` as top-level claims — no vmauth
+		bridge sits in front of the logs path, unlike metrics."""
+		frappe.db.set_value("Pilot Credential", "api-pilot-1", "asset", "vm-1")
+
+		claims = jwt.decode(self.call_log_token(self.token)["token"], options={"verify_signature": False})
+
+		self.assertEqual(claims["scope"], LOG_SCOPE)
+		self.assertEqual(claims["resource_id"], "vm-1")
+		self.assertEqual(claims["access"], ["write"])
+		# Tokens minted for the logs path must not carry the vmauth indirection
+		# the metrics path uses; a logs caller presenting this to Datum is read
+		# directly by Identity.from_claims.
+		self.assertNotIn("vm_access", claims)
+
+	def test_log_token_is_independent_of_metrics_token(self):
+		"""A separate mint so rotation of one does not invalidate the other."""
+		frappe.db.set_value("Pilot Credential", "api-pilot-1", "asset", "vm-1")
+
+		metrics_claims = jwt.decode(
+			self.call_metrics_token(self.token)["token"], options={"verify_signature": False}
+		)
+		log_claims = jwt.decode(self.call_log_token(self.token)["token"], options={"verify_signature": False})
+
+		# Different scopes and different claim shapes — they are not the same token
+		# with the same payload, so revoking one (by key rotation scoped to a
+		# purpose, if that ever arrives) does not implicitly cover the other.
+		self.assertNotEqual(metrics_claims["scope"], log_claims["scope"])
+		self.assertIn("vm_access", metrics_claims)
+		self.assertNotIn("vm_access", log_claims)
+
+	def test_log_token_waits_for_the_resource(self):
+		"""Atlas binds the Asset after provisioning; before that the logs would
+		carry no resource id, same gate as the metrics token."""
+		with self.assertRaises(frappe.ValidationError):
+			self.call_log_token(self.token)


### PR DESCRIPTION
**What**
- Central mints a log token that can be used when ingesting logs to datum
- The structure of the token is different from metric token.

**Datum PR**
[#8](https://github.com/frappe/datum/pull/8)