### PR TITLE
fix(settings): bind the dialog's renamed open model

### DIFF
--- a/dashboard/src/components/settings/SettingsModal.vue
+++ b/dashboard/src/components/settings/SettingsModal.vue
@@ -57,7 +57,10 @@ watch(tabs, (available) => {
 </script>
 
 <template>
-	<SettingsDialog v-model="settingsOpen" v-model:tab="settingsTab">
+	<!-- `v-model:open`, not a bare `v-model`: SettingsDialog names its open model
+	     (`defineModel('open')`) and declares no `modelValue`, so a bare v-model
+	     binds a prop nothing reads and the dialog never opens. -->
+	<SettingsDialog v-model:open="settingsOpen" v-model:tab="settingsTab">
 		<SettingsSidebar>
 			<!-- The dialog names itself. aria-hidden because SettingsDialog already
 			     renders a screen-reader-only <h1>Settings</h1> — this is the same


### PR DESCRIPTION
Desktop settings doesn't open on `develop`. Clicking **My profile** (or any settings entry) does nothing — no dialog, no error in the console.

frappe-ui's `SettingsDialog` renamed its open state to a named model in **v1.0.0-beta.52**:

| | |
|---|---|
| beta.51 | `defineModel<boolean>({ default: false })` — plain `modelValue` |
| beta.52+ | `defineModel<boolean>('open', …)` |

`#285` moved this app from beta.24 to beta.53 and crossed that rename. `SettingsModal.vue` still binds a bare `v-model`, which now writes to a prop nothing reads. Vue doesn't warn on an unknown model, so it fails silently.

One line: `v-model` → `v-model:open`.

`Dialog` keeps `modelValue` as a legacy binding, so the ~15 `<Dialog v-model="open">` call sites elsewhere are unaffected — `SettingsDialog` is the only component in the family that dropped the alias, and it's used once.
