### PR TITLE
feat(servers): make server flow robust

### DIFF
--- a/central/api/servers.py
+++ b/central/api/servers.py
@@ -9,7 +9,7 @@ from frappe import _
 from central.central.doctype.resource_action.resource_action import ResourceAction
 from central.errors import resource_action, throw_action_error
 from central.iam import can, resolve_team
-from central.integrations.atlas import AtlasClient, reconcile
+from central.integrations.atlas import AtlasClient, AtlasResourceGone, reconcile
 
 # Server endpoints for the console. Reads come from the Asset mirror; commands go
 # to Atlas as the operator (Atlas stays policy-unaware — capability gating happens
@@ -666,6 +666,17 @@ def _run_command(
 	).insert(ignore_permissions=True)
 	try:
 		task = AtlasClient(instance).vm_action(resource_id, atlas_method, correlation_id=tracked.name)
+	except AtlasResourceGone as exc:
+		# The VM is already gone on Atlas. Terminate is idempotent — reflect it and succeed;
+		# start/stop of a vanished server is a real (clean) error, so let it surface.
+		if action == "terminate":
+			from central.central.doctype.asset.asset import Asset
+
+			Asset.mark_terminated(resource_id, last_event_at=frappe.utils.now_datetime())
+			tracked.succeed()
+			return {"resource_id": resource_id, "task": None, "action": tracked.name}
+		tracked.fail_from_exception(exc)
+		raise
 	except Exception as exc:
 		tracked.fail_from_exception(exc)
 		raise

--- a/central/api/servers.py
+++ b/central/api/servers.py
@@ -6,7 +6,8 @@ import unicodedata
 import frappe
 from frappe import _
 
-from central.errors import server_action, throw_action_error
+from central.central.doctype.resource_action.resource_action import ResourceAction
+from central.errors import resource_action, throw_action_error
 from central.iam import can, resolve_team
 from central.integrations.atlas import AtlasClient, reconcile
 
@@ -159,6 +160,13 @@ def registry(team: str | None = None) -> dict:
 		],
 		order_by="cluster asc, resource_id asc",
 	)
+	# Overlay the transitional label of any in-flight action, so a just-clicked
+	# start/stop/terminate (or a still-provisioning create) reads as "…ing" until the
+	# mirror catches up — instead of looking like nothing happened.
+	pending = ResourceAction.pending_labels(team)
+	for asset in assets:
+		asset["pending_action"] = pending.get(asset["resource_id"])
+
 	# A site is a VM too — flat and uncapped, symmetric with servers. `name` is the FQDN
 	# (the stable id + terminate key); `subdomain` is the user-entered display name.
 	sites = frappe.get_all(
@@ -167,6 +175,10 @@ def registry(team: str | None = None) -> dict:
 		fields=["name", "subdomain", "status", "url", "region"],
 		order_by="subdomain asc",
 	)
+	# Same overlay for sites; a VM id and a site FQDN never collide, so one map covers both.
+	for site in sites:
+		site["pending_action"] = pending.get(site["name"])
+
 	return {"team": team, "assets": assets, "sites": sites}
 
 
@@ -426,7 +438,7 @@ def _plan_resources(plan: str) -> dict:
 
 
 @frappe.whitelist(methods=["POST"])
-@server_action
+@resource_action
 def create_server(
 	team: str | None = None,
 	region: str | None = None,
@@ -479,15 +491,27 @@ def create_server(
 	friendly_title, atlas_title = _server_names(title, subdomain)
 
 	client = AtlasClient.for_region(region)
-	vm = client.create_vm(
-		team=team,
-		title=atlas_title,
-		vcpus=int(vcpus or 1),
-		memory_megabytes=int(memory_megabytes or 512),
-		disk_gigabytes=int(disk_gigabytes or 10),
-		cpu_max_cores=cpu_max_cores,
-		frappe_version=frappe_version,
-	)
+
+	# Track provisioning: create is the one async path (boot→deploy→mint runs on Atlas
+	# after this returns), so the "Provisioning…" state and its eventual pass/fail land here.
+	tracked = frappe.get_doc(
+		{"doctype": "Resource Action", "resource_type": "Server", "action": "create", "team": team}
+	).insert(ignore_permissions=True)
+	try:
+		vm = client.create_vm(
+			team=team,
+			title=atlas_title,
+			vcpus=int(vcpus or 1),
+			memory_megabytes=int(memory_megabytes or 512),
+			disk_gigabytes=int(disk_gigabytes or 10),
+			cpu_max_cores=cpu_max_cores,
+			frappe_version=frappe_version,
+			correlation_id=tracked.name,
+		)
+	except Exception as exc:
+		tracked.fail_from_exception(exc)
+		raise
+
 	resource_id = vm.get("name")
 	# Record the contract for the bundle. Guarded so a raw-size call (no plan) still
 	# provisions a VM without a subscription, as before.
@@ -498,11 +522,13 @@ def create_server(
 	# Asset. Otherwise preset creates render the UUID/Pending shell until the next
 	# reconcile, instead of the user-facing title/status Atlas already returned.
 	resource_id = _mirror_provisioned_vm(region, vm, friendly_title)
-	return {"resource_id": resource_id, "server": vm, "subscription": subscription}
+	tracked.attach_resource(resource_id)
+
+	return {"resource_id": resource_id, "server": vm, "subscription": subscription, "action": tracked.name}
 
 
 @frappe.whitelist(methods=["POST"])
-@server_action
+@resource_action
 def create_composed_server(
 	team: str | None = None,
 	region: str | None = None,
@@ -552,36 +578,48 @@ def create_composed_server(
 
 	qty = composition_quantities(includes)
 	client = AtlasClient.for_region(region)
-	vm = client.create_vm(
-		team=team,
-		title=atlas_title,
-		vcpus=int(qty.get(COMPUTE, 1)) or 1,
-		memory_megabytes=int(qty.get(MEMORY, 0) * 1024) or 512,
-		disk_gigabytes=int(qty.get(DISK, 0)) or 10,
-		frappe_version=frappe_version,
-	)
+
+	tracked = frappe.get_doc(
+		{"doctype": "Resource Action", "resource_type": "Server", "action": "create", "team": team}
+	).insert(ignore_permissions=True)
+	try:
+		vm = client.create_vm(
+			team=team,
+			title=atlas_title,
+			vcpus=int(qty.get(COMPUTE, 1)) or 1,
+			memory_megabytes=int(qty.get(MEMORY, 0) * 1024) or 512,
+			disk_gigabytes=int(qty.get(DISK, 0)) or 10,
+			frappe_version=frappe_version,
+			correlation_id=tracked.name,
+		)
+	except Exception as exc:
+		tracked.fail_from_exception(exc)
+		raise
+
 	resource_id = vm.get("name")
 	provision_composed_subscription(team, region, includes, sub_category, resource_id=resource_id)
 	resource_id = _mirror_provisioned_vm(region, vm, friendly_title)
-	return {"resource_id": resource_id, "server": vm}
+	tracked.attach_resource(resource_id)
+
+	return {"resource_id": resource_id, "server": vm, "action": tracked.name}
 
 
 @frappe.whitelist(methods=["POST"])
-@server_action
+@resource_action
 def start_server(team: str | None = None, resource_id: str | None = None) -> dict:
 	"""Start a stopped server. Gated on `server:power`."""
 	return _run_command("start", "server:power", "start", team, resource_id)
 
 
 @frappe.whitelist(methods=["POST"])
-@server_action
+@resource_action
 def stop_server(team: str | None = None, resource_id: str | None = None) -> dict:
 	"""Stop a running server. Gated on `server:power`."""
 	return _run_command("stop", "server:power", "stop", team, resource_id)
 
 
 @frappe.whitelist(methods=["POST"])
-@server_action
+@resource_action
 def terminate_server(team: str | None = None, resource_id: str | None = None) -> dict:
 	"""Terminate a server. Gated on `server:terminate`."""
 	return _run_command("terminate", "server:terminate", "terminate", team, resource_id)
@@ -615,5 +653,23 @@ def _run_command(
 		throw_action_error("SERVER_BUSY_RESIZING", action=action)
 
 	instance = frappe.get_doc("Atlas Instance", asset.cluster)
-	task = AtlasClient(instance).vm_action(resource_id, atlas_method)
-	return {"resource_id": resource_id, "task": task}
+
+	# Track the action so the console shows it in flight and its outcome has a home.
+	tracked = frappe.get_doc(
+		{
+			"doctype": "Resource Action",
+			"resource_type": "Server",
+			"action": action,
+			"team": team,
+			"resource_id": resource_id,
+		}
+	).insert(ignore_permissions=True)
+	try:
+		task = AtlasClient(instance).vm_action(resource_id, atlas_method, correlation_id=tracked.name)
+	except Exception as exc:
+		tracked.fail_from_exception(exc)
+		raise
+
+	tracked.mark_sent(task)
+
+	return {"resource_id": resource_id, "task": task, "action": tracked.name}

--- a/central/api/servers.py
+++ b/central/api/servers.py
@@ -6,6 +6,7 @@ import unicodedata
 import frappe
 from frappe import _
 
+from central.errors import server_action, throw_action_error
 from central.iam import can, resolve_team
 from central.integrations.atlas import AtlasClient, reconcile
 
@@ -425,6 +426,7 @@ def _plan_resources(plan: str) -> dict:
 
 
 @frappe.whitelist(methods=["POST"])
+@server_action
 def create_server(
 	team: str | None = None,
 	region: str | None = None,
@@ -458,7 +460,7 @@ def create_server(
 	user = frappe.session.user
 	team = resolve_team(user, team)
 	if not can(user, team, "server:create"):
-		frappe.throw(_("You can't create servers for this team."), frappe.PermissionError)
+		throw_action_error("PERMISSION_DENIED", exc=frappe.PermissionError, action="create")
 	if _is_staging_trial_team(team):
 		# Trial: free credits fund it, no full profile. Size comes from the plan, not the
 		# caller, so the VM matches what the plan sells (and its rate).
@@ -472,7 +474,7 @@ def create_server(
 
 		require_billing_profile(team, "create servers")
 	if not region:
-		frappe.throw(_("Region is required."), frappe.ValidationError)
+		throw_action_error("INPUT_REQUIRED", exc=frappe.ValidationError, field="Region")
 	_validate_frappe_version(frappe_version, region)
 	friendly_title, atlas_title = _server_names(title, subdomain)
 
@@ -500,6 +502,7 @@ def create_server(
 
 
 @frappe.whitelist(methods=["POST"])
+@server_action
 def create_composed_server(
 	team: str | None = None,
 	region: str | None = None,
@@ -530,13 +533,13 @@ def create_composed_server(
 	user = frappe.session.user
 	team = resolve_team(user, team)
 	if not can(user, team, "server:create"):
-		frappe.throw(_("You can't create servers for this team."), frappe.PermissionError)
+		throw_action_error("PERMISSION_DENIED", exc=frappe.PermissionError, action="create")
 	# A server bills the team, so it needs a billing profile first.
 	from central.billing.api.dashboard._shared import require_billing_profile
 
 	require_billing_profile(team, "create servers")
 	if not region:
-		frappe.throw(_("Region is required."), frappe.ValidationError)
+		throw_action_error("INPUT_REQUIRED", exc=frappe.ValidationError, field="Region")
 	if isinstance(includes, str):
 		includes = frappe.parse_json(includes)
 	_validate_frappe_version(frappe_version, region)
@@ -564,18 +567,21 @@ def create_composed_server(
 
 
 @frappe.whitelist(methods=["POST"])
+@server_action
 def start_server(team: str | None = None, resource_id: str | None = None) -> dict:
 	"""Start a stopped server. Gated on `server:power`."""
 	return _run_command("start", "server:power", "start", team, resource_id)
 
 
 @frappe.whitelist(methods=["POST"])
+@server_action
 def stop_server(team: str | None = None, resource_id: str | None = None) -> dict:
 	"""Stop a running server. Gated on `server:power`."""
 	return _run_command("stop", "server:power", "stop", team, resource_id)
 
 
 @frappe.whitelist(methods=["POST"])
+@server_action
 def terminate_server(team: str | None = None, resource_id: str | None = None) -> dict:
 	"""Terminate a server. Gated on `server:terminate`."""
 	return _run_command("terminate", "server:terminate", "terminate", team, resource_id)
@@ -589,9 +595,9 @@ def _run_command(
 	user = frappe.session.user
 	team = resolve_team(user, team)
 	if not can(user, team, capability):
-		frappe.throw(_("You can't {0} servers for this team.").format(action), frappe.PermissionError)
+		throw_action_error("PERMISSION_DENIED", exc=frappe.PermissionError, action=action)
 	if not resource_id:
-		frappe.throw(_("resource_id is required."), frappe.ValidationError)
+		throw_action_error("INPUT_REQUIRED", exc=frappe.ValidationError, field="A server")
 
 	# The asset must be in this team's mirror — also how we route to its Atlas.
 	asset = frappe.db.get_value(
@@ -601,12 +607,12 @@ def _run_command(
 		as_dict=True,
 	)
 	if not asset:
-		frappe.throw(_("No server '{0}' for this team.").format(resource_id), frappe.DoesNotExistError)
+		throw_action_error("SERVER_NOT_FOUND", exc=frappe.DoesNotExistError, resource_id=resource_id)
 
 	# A resize power-cycles the VM in the background; a manual start/stop mid-flight would
 	# race it. Terminate is still allowed — the user may want to abandon the machine.
 	if asset.resize_in_progress and action in ("start", "stop"):
-		frappe.throw(_("This server is resizing — you can {0} it once that finishes.").format(action))
+		throw_action_error("SERVER_BUSY_RESIZING", action=action)
 
 	instance = frappe.get_doc("Atlas Instance", asset.cluster)
 	task = AtlasClient(instance).vm_action(resource_id, atlas_method)

--- a/central/api/servers.py
+++ b/central/api/servers.py
@@ -6,7 +6,7 @@ import unicodedata
 import frappe
 from frappe import _
 
-from central.central.doctype.resource_action.resource_action import ResourceAction
+from central.central.doctype.resource_action.resource_action import ResourceAction, open_action
 from central.errors import resource_action, throw_action_error
 from central.iam import can, resolve_team
 from central.integrations.atlas import AtlasClient, AtlasResourceGone, reconcile
@@ -492,25 +492,21 @@ def create_server(
 
 	client = AtlasClient.for_region(region)
 
-	# Track provisioning: create is the one async path (boot→deploy→mint runs on Atlas
-	# after this returns), so the "Provisioning…" state and its eventual pass/fail land here.
-	tracked = frappe.get_doc(
-		{"doctype": "Resource Action", "resource_type": "Server", "action": "create", "team": team}
-	).insert(ignore_permissions=True)
-	try:
-		vm = client.create_vm(
-			team=team,
-			title=atlas_title,
-			vcpus=int(vcpus or 1),
-			memory_megabytes=int(memory_megabytes or 512),
-			disk_gigabytes=int(disk_gigabytes or 10),
-			cpu_max_cores=cpu_max_cores,
-			frappe_version=frappe_version,
-			correlation_id=tracked.name,
-		)
-	except Exception as exc:
-		tracked.fail_from_exception(exc)
-		raise
+	# create is the one async path (boot→deploy→mint runs on Atlas after this returns).
+	# A rejection surfaces as an envelope and leaves no row; we open the tracking action
+	# only once Atlas has accepted, so its "Provisioning…" state and eventual outcome ride
+	# the request's own commit.
+	correlation_id = frappe.generate_hash()
+	vm = client.create_vm(
+		team=team,
+		title=atlas_title,
+		vcpus=int(vcpus or 1),
+		memory_megabytes=int(memory_megabytes or 512),
+		disk_gigabytes=int(disk_gigabytes or 10),
+		cpu_max_cores=cpu_max_cores,
+		frappe_version=frappe_version,
+		correlation_id=correlation_id,
+	)
 
 	resource_id = vm.get("name")
 	# Record the contract for the bundle. Guarded so a raw-size call (no plan) still
@@ -522,9 +518,9 @@ def create_server(
 	# Asset. Otherwise preset creates render the UUID/Pending shell until the next
 	# reconcile, instead of the user-facing title/status Atlas already returned.
 	resource_id = _mirror_provisioned_vm(region, vm, friendly_title)
-	tracked.attach_resource(resource_id)
+	open_action("Server", "create", team=team, resource_id=resource_id, correlation_id=correlation_id)
 
-	return {"resource_id": resource_id, "server": vm, "subscription": subscription, "action": tracked.name}
+	return {"resource_id": resource_id, "server": vm, "subscription": subscription, "action": correlation_id}
 
 
 @frappe.whitelist(methods=["POST"])
@@ -579,29 +575,23 @@ def create_composed_server(
 	qty = composition_quantities(includes)
 	client = AtlasClient.for_region(region)
 
-	tracked = frappe.get_doc(
-		{"doctype": "Resource Action", "resource_type": "Server", "action": "create", "team": team}
-	).insert(ignore_permissions=True)
-	try:
-		vm = client.create_vm(
-			team=team,
-			title=atlas_title,
-			vcpus=int(qty.get(COMPUTE, 1)) or 1,
-			memory_megabytes=int(qty.get(MEMORY, 0) * 1024) or 512,
-			disk_gigabytes=int(qty.get(DISK, 0)) or 10,
-			frappe_version=frappe_version,
-			correlation_id=tracked.name,
-		)
-	except Exception as exc:
-		tracked.fail_from_exception(exc)
-		raise
+	correlation_id = frappe.generate_hash()
+	vm = client.create_vm(
+		team=team,
+		title=atlas_title,
+		vcpus=int(qty.get(COMPUTE, 1)) or 1,
+		memory_megabytes=int(qty.get(MEMORY, 0) * 1024) or 512,
+		disk_gigabytes=int(qty.get(DISK, 0)) or 10,
+		frappe_version=frappe_version,
+		correlation_id=correlation_id,
+	)
 
 	resource_id = vm.get("name")
 	provision_composed_subscription(team, region, includes, sub_category, resource_id=resource_id)
 	resource_id = _mirror_provisioned_vm(region, vm, friendly_title)
-	tracked.attach_resource(resource_id)
+	open_action("Server", "create", team=team, resource_id=resource_id, correlation_id=correlation_id)
 
-	return {"resource_id": resource_id, "server": vm, "action": tracked.name}
+	return {"resource_id": resource_id, "server": vm, "action": correlation_id}
 
 
 @frappe.whitelist(methods=["POST"])
@@ -654,33 +644,28 @@ def _run_command(
 
 	instance = frappe.get_doc("Atlas Instance", asset.cluster)
 
-	# Track the action so the console shows it in flight and its outcome has a home.
-	tracked = frappe.get_doc(
-		{
-			"doctype": "Resource Action",
-			"resource_type": "Server",
-			"action": action,
-			"team": team,
-			"resource_id": resource_id,
-		}
-	).insert(ignore_permissions=True)
+	# Open the tracking action only once Atlas accepts the command. A rejection surfaces as
+	# an envelope (via the endpoint's @resource_action) and leaves no row to strand.
+	correlation_id = frappe.generate_hash()
 	try:
-		task = AtlasClient(instance).vm_action(resource_id, atlas_method, correlation_id=tracked.name)
-	except AtlasResourceGone as exc:
-		# The VM is already gone on Atlas. Terminate is idempotent — reflect it and succeed;
-		# start/stop of a vanished server is a real (clean) error, so let it surface.
+		task = AtlasClient(instance).vm_action(resource_id, atlas_method, correlation_id=correlation_id)
+	except AtlasResourceGone:
+		# The VM is already gone on Atlas. Terminate is idempotent — reflect it and record a
+		# Succeeded action; start/stop of a vanished server is a real (clean) error, surfaced.
 		if action == "terminate":
 			from central.central.doctype.asset.asset import Asset
 
 			Asset.mark_terminated(resource_id, last_event_at=frappe.utils.now_datetime())
-			tracked.succeed()
-			return {"resource_id": resource_id, "task": None, "action": tracked.name}
-		tracked.fail_from_exception(exc)
-		raise
-	except Exception as exc:
-		tracked.fail_from_exception(exc)
+			open_action(
+				"Server", action, team=team, resource_id=resource_id,
+				correlation_id=correlation_id, status="Succeeded",
+			)
+			return {"resource_id": resource_id, "task": None, "action": correlation_id}
 		raise
 
-	tracked.mark_sent(task)
+	open_action(
+		"Server", action, team=team, resource_id=resource_id,
+		correlation_id=correlation_id, atlas_task=task,
+	)
 
-	return {"resource_id": resource_id, "task": task, "action": tracked.name}
+	return {"resource_id": resource_id, "task": task, "action": correlation_id}

--- a/central/api/sites.py
+++ b/central/api/sites.py
@@ -4,6 +4,7 @@ import frappe
 from frappe import _
 
 from central.api.site_login import site_login_url
+from central.central.doctype.resource_action.resource_action import open_action
 from central.errors import resource_action
 from central.iam import can, get_user_team_names, resolve_team
 from central.integrations.atlas import AtlasClient, AtlasResourceGone
@@ -48,27 +49,22 @@ def create_site(subdomain: str, region: str | None = None) -> dict:
 	region = region or _default_region()
 	client = AtlasClient.for_region(region)
 
-	# Track provisioning: site create is async (clone→deploy→route runs on Atlas after
-	# this returns), so the "Provisioning…" state and its eventual pass/fail land here.
-	tracked = frappe.get_doc(
-		{"doctype": "Resource Action", "resource_type": "Site", "action": "create", "team": team}
-	).insert(ignore_permissions=True)
-	try:
-		site = client.create_site(team=team, subdomain=subdomain, correlation_id=tracked.name)
-	except Exception as exc:
-		tracked.fail_from_exception(exc)
-		raise
+	# site create is async (clone→deploy→route runs on Atlas after this returns). A
+	# rejection surfaces as an envelope and leaves no row; we open the tracking action
+	# only once Atlas has accepted the create.
+	correlation_id = frappe.generate_hash()
+	site = client.create_site(team=team, subdomain=subdomain, correlation_id=correlation_id)
 
 	from central.central.doctype.site.site import Site
 
 	Site.mirror_site(client.instance.name, site)
-	tracked.attach_resource(site.get("name"))
+	open_action("Site", "create", team=team, resource_id=site.get("name"), correlation_id=correlation_id)
 
 	return {
 		"name": site.get("name"),
 		"fqdn": site.get("fqdn"),
 		"status": site.get("status"),
-		"action": tracked.name,
+		"action": correlation_id,
 	}
 
 
@@ -147,27 +143,21 @@ def terminate_site(name: str) -> dict:
 
 	instance = frappe.get_doc("Atlas Instance", site.cluster)
 
-	tracked = frappe.get_doc(
-		{
-			"doctype": "Resource Action",
-			"resource_type": "Site",
-			"action": "terminate",
-			"team": site.team,
-			"resource_id": name,
-		}
-	).insert(ignore_permissions=True)
+	# Open the tracking action only once Atlas accepts. A rejection surfaces as an envelope
+	# (via @resource_action) and leaves no row to strand.
+	correlation_id = frappe.generate_hash()
 	try:
-		AtlasClient(instance).terminate_site(name, correlation_id=tracked.name)
+		AtlasClient(instance).terminate_site(name, correlation_id=correlation_id)
 	except AtlasResourceGone:
 		# Already gone on Atlas (e.g. a stale mirror row) — terminate is idempotent: reflect
-		# it on the mirror and succeed rather than surfacing a scary "region down".
+		# it on the mirror and record a Succeeded action rather than a scary "region down".
 		frappe.get_doc("Site", name).db_set("status", "Terminated", notify=True)
-		tracked.succeed()
-		return {"name": name, "status": "Terminated", "action": tracked.name}
-	except Exception as exc:
-		tracked.fail_from_exception(exc)
-		raise
+		open_action(
+			"Site", "terminate", team=site.team, resource_id=name,
+			correlation_id=correlation_id, status="Succeeded",
+		)
+		return {"name": name, "status": "Terminated", "action": correlation_id}
 
-	tracked.mark_sent()
+	open_action("Site", "terminate", team=site.team, resource_id=name, correlation_id=correlation_id)
 
-	return {"name": name, "status": "Terminating", "action": tracked.name}
+	return {"name": name, "status": "Terminating", "action": correlation_id}

--- a/central/api/sites.py
+++ b/central/api/sites.py
@@ -6,7 +6,7 @@ from frappe import _
 from central.api.site_login import site_login_url
 from central.errors import resource_action
 from central.iam import can, get_user_team_names, resolve_team
-from central.integrations.atlas import AtlasClient
+from central.integrations.atlas import AtlasClient, AtlasResourceGone
 
 # Self-serve site endpoints for the SMB onboarding flow. Reads come from the Site
 # mirror (kept fresh by the site.* events Atlas pushes); writes go to Atlas as the
@@ -158,6 +158,12 @@ def terminate_site(name: str) -> dict:
 	).insert(ignore_permissions=True)
 	try:
 		AtlasClient(instance).terminate_site(name, correlation_id=tracked.name)
+	except AtlasResourceGone:
+		# Already gone on Atlas (e.g. a stale mirror row) — terminate is idempotent: reflect
+		# it on the mirror and succeed rather than surfacing a scary "region down".
+		frappe.get_doc("Site", name).db_set("status", "Terminated", notify=True)
+		tracked.succeed()
+		return {"name": name, "status": "Terminated", "action": tracked.name}
 	except Exception as exc:
 		tracked.fail_from_exception(exc)
 		raise

--- a/central/api/sites.py
+++ b/central/api/sites.py
@@ -4,6 +4,7 @@ import frappe
 from frappe import _
 
 from central.api.site_login import site_login_url
+from central.errors import resource_action
 from central.iam import can, get_user_team_names, resolve_team
 from central.integrations.atlas import AtlasClient
 
@@ -28,6 +29,7 @@ def _default_region() -> str:
 
 
 @frappe.whitelist(methods=["POST"])
+@resource_action
 def create_site(subdomain: str, region: str | None = None) -> dict:
 	"""Provision a self-serve site for the user's team. Gated on `server:create`.
 
@@ -45,12 +47,29 @@ def create_site(subdomain: str, region: str | None = None) -> dict:
 
 	region = region or _default_region()
 	client = AtlasClient.for_region(region)
-	site = client.create_site(team=team, subdomain=subdomain)
+
+	# Track provisioning: site create is async (clone→deploy→route runs on Atlas after
+	# this returns), so the "Provisioning…" state and its eventual pass/fail land here.
+	tracked = frappe.get_doc(
+		{"doctype": "Resource Action", "resource_type": "Site", "action": "create", "team": team}
+	).insert(ignore_permissions=True)
+	try:
+		site = client.create_site(team=team, subdomain=subdomain, correlation_id=tracked.name)
+	except Exception as exc:
+		tracked.fail_from_exception(exc)
+		raise
 
 	from central.central.doctype.site.site import Site
 
 	Site.mirror_site(client.instance.name, site)
-	return {"name": site.get("name"), "fqdn": site.get("fqdn"), "status": site.get("status")}
+	tracked.attach_resource(site.get("name"))
+
+	return {
+		"name": site.get("name"),
+		"fqdn": site.get("fqdn"),
+		"status": site.get("status"),
+		"action": tracked.name,
+	}
 
 
 @frappe.whitelist(methods=["GET"])
@@ -106,6 +125,7 @@ def site_domain(region: str | None = None) -> dict:
 
 
 @frappe.whitelist(methods=["POST"])
+@resource_action
 def terminate_site(name: str) -> dict:
 	"""Terminate a self-serve site (and its 1:1 backing VM). Gated on `server:terminate` —
 	a site is a VM, so removing it is authorized like tearing down a server (site-level
@@ -126,6 +146,22 @@ def terminate_site(name: str) -> dict:
 		frappe.throw(_("Site {0} has no backing region to terminate.").format(name), frappe.ValidationError)
 
 	instance = frappe.get_doc("Atlas Instance", site.cluster)
-	AtlasClient(instance).terminate_site(name)
 
-	return {"name": name, "status": "Terminating"}
+	tracked = frappe.get_doc(
+		{
+			"doctype": "Resource Action",
+			"resource_type": "Site",
+			"action": "terminate",
+			"team": site.team,
+			"resource_id": name,
+		}
+	).insert(ignore_permissions=True)
+	try:
+		AtlasClient(instance).terminate_site(name, correlation_id=tracked.name)
+	except Exception as exc:
+		tracked.fail_from_exception(exc)
+		raise
+
+	tracked.mark_sent()
+
+	return {"name": name, "status": "Terminating", "action": tracked.name}

--- a/central/central/doctype/atlas_event/atlas_event.py
+++ b/central/central/doctype/atlas_event/atlas_event.py
@@ -9,7 +9,11 @@ from frappe.utils.password import get_decrypted_password
 class AtlasEvent(Document):
 	def after_insert(self):
 		"""Queue the mirror write once the row is durably committed, so the inbound
-		webhook gets a fast ack and processing survives a lost immediate job."""
+		webhook gets a fast ack and processing survives a lost immediate job. An Ignored
+		row (a type Central doesn't mirror yet) is recorded only, never applied."""
+		if self.status != "Received":
+			return
+
 		frappe.enqueue(
 			"central.integrations.atlas.apply_event",
 			queue="short",

--- a/central/central/doctype/resource_action/resource_action.json
+++ b/central/central/doctype/resource_action/resource_action.json
@@ -3,7 +3,7 @@
  "allow_rename": 0,
  "autoname": "hash",
  "creation": "2026-08-17 00:00:00.000000",
- "description": "One tenant-triggered lifecycle action on a fleet resource (a server or a site) and its outcome. The name is the correlation id Central sends to Atlas and matches on the returning event.",
+ "description": "One tenant-triggered lifecycle action on a fleet resource (a server or a site) and its outcome. Opened only once Atlas accepts the command, so a synchronous rejection never leaves a row.",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
@@ -12,6 +12,7 @@
   "action",
   "team",
   "resource_id",
+  "correlation_id",
   "column_break_main",
   "status",
   "atlas_task",
@@ -62,17 +63,26 @@
    "read_only": 1
   },
   {
+   "description": "The id Central sends to Atlas with the command; the returning event echoes it so the outcome lands on this row.",
+   "fieldname": "correlation_id",
+   "fieldtype": "Data",
+   "label": "Correlation ID",
+   "read_only": 1,
+   "reqd": 1,
+   "unique": 1
+  },
+  {
    "fieldname": "column_break_main",
    "fieldtype": "Column Break"
   },
   {
-   "default": "Queued",
+   "default": "Sent",
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Queued\nSent\nIn Progress\nSucceeded\nFailed\nTimed Out",
+   "options": "Sent\nIn Progress\nSucceeded\nFailed\nTimed Out",
    "read_only": 1,
    "reqd": 1
   },
@@ -142,6 +152,7 @@
    "write": 1
   },
   {
+   "create": 1,
    "read": 1,
    "role": "Central User"
   }

--- a/central/central/doctype/resource_action/resource_action.json
+++ b/central/central/doctype/resource_action/resource_action.json
@@ -1,0 +1,152 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-08-17 00:00:00.000000",
+ "description": "One tenant-triggered lifecycle action on a fleet resource (a server or a site) and its outcome. The name is the correlation id Central sends to Atlas and matches on the returning event.",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "resource_type",
+  "action",
+  "team",
+  "resource_id",
+  "column_break_main",
+  "status",
+  "atlas_task",
+  "completed_at",
+  "section_break_error",
+  "error_code",
+  "retriable",
+  "error_message",
+  "remediation"
+ ],
+ "fields": [
+  {
+   "fieldname": "resource_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Resource Type",
+   "options": "Server\nSite",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "action",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Action",
+   "options": "create\nstart\nstop\nterminate\nresize",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "team",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Team",
+   "options": "Team",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "description": "The server (VM id) or site (FQDN) this action targets, snapshotted so the row stays meaningful after the resource is gone.",
+   "fieldname": "resource_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Resource ID",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_main",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Queued",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Queued\nSent\nIn Progress\nSucceeded\nFailed\nTimed Out",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "description": "The Atlas Task this action produced, for operator cross-reference.",
+   "fieldname": "atlas_task",
+   "fieldtype": "Data",
+   "label": "Atlas Task",
+   "read_only": 1
+  },
+  {
+   "fieldname": "completed_at",
+   "fieldtype": "Datetime",
+   "label": "Completed At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_error",
+   "fieldtype": "Section Break",
+   "label": "Failure"
+  },
+  {
+   "description": "Stable error code from the failure envelope (central/errors.py).",
+   "fieldname": "error_code",
+   "fieldtype": "Data",
+   "label": "Error Code",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "retriable",
+   "fieldtype": "Check",
+   "label": "Retriable",
+   "read_only": 1
+  },
+  {
+   "fieldname": "error_message",
+   "fieldtype": "Small Text",
+   "label": "Error Message",
+   "read_only": 1
+  },
+  {
+   "fieldname": "remediation",
+   "fieldtype": "Small Text",
+   "label": "Remediation",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-08-17 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Central",
+ "name": "Resource Action",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Central User"
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/central/central/doctype/resource_action/resource_action.py
+++ b/central/central/doctype/resource_action/resource_action.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import frappe
 from frappe.model.document import Document
 
-from central.errors import build_envelope, to_error_response
+from central.errors import build_envelope
 
 # Which mirror status means "this action reached its goal". Servers and sites share the
 # same status vocabulary, so one map covers both.
@@ -26,11 +26,15 @@ PENDING_LABEL = {
 	"resize": "Resizing",
 }
 
-PENDING_STATES = ("Queued", "Sent", "In Progress")
+PENDING_STATES = ("Sent", "In Progress")
 TERMINAL_STATES = ("Succeeded", "Failed", "Timed Out")
 
 
 class ResourceAction(Document):
+	"""A lifecycle action, opened only once Atlas has accepted the command (status Sent).
+	A synchronous rejection never reaches here — it surfaces as an error envelope and leaves
+	no row — so every write rides the request's own commit and none of them force one."""
+
 	# begin: auto-generated types
 	from typing import TYPE_CHECKING
 
@@ -40,34 +44,40 @@ class ResourceAction(Document):
 		action: DF.Literal["create", "start", "stop", "terminate", "resize"]
 		atlas_task: DF.Data | None
 		completed_at: DF.Datetime | None
+		correlation_id: DF.Data
 		error_code: DF.Data | None
 		error_message: DF.SmallText | None
 		remediation: DF.SmallText | None
 		resource_id: DF.Data | None
 		resource_type: DF.Literal["Server", "Site"]
 		retriable: DF.Check
-		status: DF.Literal["Queued", "Sent", "In Progress", "Succeeded", "Failed", "Timed Out"]
+		status: DF.Literal["Sent", "In Progress", "Succeeded", "Failed", "Timed Out"]
 		team: DF.Link
 	# end: auto-generated types
 
-	def attach_resource(self, resource_id: str) -> None:
-		"""Bind the id a create only learns after Atlas replies, then mark it sent."""
-		self.resource_id = resource_id
-		self.mark_sent()
+	def before_save(self) -> None:
+		"""One owner for the completion stamp: any terminal status carries its timestamp."""
+		if self.status in TERMINAL_STATES and not self.completed_at:
+			self.completed_at = frappe.utils.now_datetime()
 
-	def mark_sent(self, atlas_task: str | None = None) -> None:
-		"""Atlas accepted the command; the action is now in flight pending its outcome."""
-		if self.status in TERMINAL_STATES:
+	def on_update(self) -> None:
+		"""Nudge the console to re-read after every state change (insert included), so the
+		transitional badge flips live over the same list channel the mirror already uses."""
+		if not self.resource_id:
 			return
 
-		self.status = "Sent"
-		if atlas_task:
-			self.atlas_task = atlas_task
-		self._apply()
+		mirror = "Site" if self.resource_type == "Site" else "Asset"
+		frappe.publish_realtime(
+			"list_update",
+			{"doctype": mirror, "name": self.resource_id},
+			doctype=mirror,
+			after_commit=True,
+		)
 
-	def fail_from_exception(self, exc: Exception) -> None:
-		"""Record a synchronous failure from the envelope the exception already carries."""
-		self._finish_error("Failed", to_error_response(exc))
+	# Outcome writes below record what Atlas reported, not what a tenant asked for. They run
+	# from the HMAC-verified webhook (as Guest) or the sweep (as Administrator), never from the
+	# portal, and a tenant must never be able to rewrite an outcome — so these bypass the
+	# doc permission check that the create path (open_action) deliberately honours.
 
 	def _finish_error(self, status: str, envelope: dict) -> None:
 		self.status = status
@@ -75,26 +85,24 @@ class ResourceAction(Document):
 		self.error_message = envelope.get("message")
 		self.remediation = envelope.get("remediation")
 		self.retriable = 1 if envelope.get("retriable") else 0
-		self.completed_at = frappe.utils.now_datetime()
-		# Commit before any caller re-raises: the request rolls back on the way out, which
-		# would otherwise discard the outcome and leave the action stuck in flight.
-		self._apply(commit=True)
+		self.save(ignore_permissions=True)
 
 	def succeed(self) -> None:
 		self.status = "Succeeded"
-		self.completed_at = frappe.utils.now_datetime()
-		self._apply()
+		self.save(ignore_permissions=True)
 
 	@classmethod
 	def record_mirror_status(cls, correlation_id: str | None, mirror_status: str | None) -> None:
-		"""Transition the action a returning Atlas event confirms. The event's correlation id
-		is this row's name; an unknown or already-finished action is ignored."""
+		"""Transition the action a returning Atlas event confirms, matched by correlation id.
+		An unknown or already-finished action is ignored."""
 		if not (correlation_id and mirror_status):
 			return
-		if not frappe.db.exists("Resource Action", correlation_id):
+
+		name = frappe.db.get_value("Resource Action", {"correlation_id": correlation_id})
+		if not name:
 			return
 
-		doc = frappe.get_doc("Resource Action", correlation_id)
+		doc = frappe.get_doc("Resource Action", name)
 		if doc.status in TERMINAL_STATES:
 			return
 
@@ -104,7 +112,7 @@ class ResourceAction(Document):
 			doc.succeed()
 		elif mirror_status in IN_PROGRESS_MIRROR_STATUS and doc.status != "In Progress":
 			doc.status = "In Progress"
-			doc._apply()
+			doc.save(ignore_permissions=True)
 
 	@classmethod
 	def pending_labels(cls, team: str) -> dict[str, str]:
@@ -145,22 +153,32 @@ class ResourceAction(Document):
 		else:
 			doc._finish_error("Timed Out", build_envelope("ACTION_TIMED_OUT", action=doc.action))
 
-	def _apply(self, *, commit: bool = False) -> None:
-		self.save(ignore_permissions=True)
-		if commit:
-			frappe.db.commit()
-		self._poke_console()
 
-	def _poke_console(self) -> None:
-		"""Nudge the console to re-read once this row commits, so the transitional state flips
-		live over the same list channel the mirror already uses — no polling."""
-		if not self.resource_id:
-			return
+def open_action(
+	resource_type: str,
+	action: str,
+	*,
+	team: str,
+	resource_id: str,
+	correlation_id: str,
+	status: str = "Sent",
+	atlas_task: str | None = None,
+) -> ResourceAction:
+	"""Open a tracking row once Atlas has accepted the command. `status` is Sent for an
+	in-flight action, or Succeeded for one Atlas confirmed synchronously (idempotent
+	terminate of an already-gone resource).
 
-		mirror = "Site" if self.resource_type == "Site" else "Asset"
-		frappe.publish_realtime(
-			"list_update",
-			{"doctype": mirror, "name": self.resource_id},
-			doctype=mirror,
-			after_commit=True,
-		)
+	Runs as the acting tenant: the create permission is real (Central User + a server-mutating
+	capability on the team, see central/permissions.py), so no permission is bypassed here."""
+	return frappe.get_doc(
+		{
+			"doctype": "Resource Action",
+			"resource_type": resource_type,
+			"action": action,
+			"team": team,
+			"resource_id": resource_id,
+			"correlation_id": correlation_id,
+			"status": status,
+			"atlas_task": atlas_task,
+		}
+	).insert()

--- a/central/central/doctype/resource_action/resource_action.py
+++ b/central/central/doctype/resource_action/resource_action.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import frappe
+from frappe.model.document import Document
+
+from central.errors import build_envelope, to_error_response
+
+# Which mirror status means "this action reached its goal". Servers and sites share the
+# same status vocabulary, so one map covers both.
+SUCCESS_MIRROR_STATUS = {
+	"create": "Running",
+	"start": "Running",
+	"stop": "Stopped",
+	"terminate": "Terminated",
+}
+
+# Mirror statuses that mean the action is still working, not yet done or failed.
+IN_PROGRESS_MIRROR_STATUS = {"Pending", "Provisioning", "Deploying"}
+
+# The transitional label the console shows while an action is in flight.
+PENDING_LABEL = {
+	"create": "Provisioning",
+	"start": "Starting",
+	"stop": "Stopping",
+	"terminate": "Terminating",
+	"resize": "Resizing",
+}
+
+PENDING_STATES = ("Queued", "Sent", "In Progress")
+TERMINAL_STATES = ("Succeeded", "Failed", "Timed Out")
+
+
+class ResourceAction(Document):
+	# begin: auto-generated types
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		action: DF.Literal["create", "start", "stop", "terminate", "resize"]
+		atlas_task: DF.Data | None
+		completed_at: DF.Datetime | None
+		error_code: DF.Data | None
+		error_message: DF.SmallText | None
+		remediation: DF.SmallText | None
+		resource_id: DF.Data | None
+		resource_type: DF.Literal["Server", "Site"]
+		retriable: DF.Check
+		status: DF.Literal["Queued", "Sent", "In Progress", "Succeeded", "Failed", "Timed Out"]
+		team: DF.Link
+	# end: auto-generated types
+
+	def attach_resource(self, resource_id: str) -> None:
+		"""Bind the id a create only learns after Atlas replies, then mark it sent."""
+		self.resource_id = resource_id
+		self.mark_sent()
+
+	def mark_sent(self, atlas_task: str | None = None) -> None:
+		"""Atlas accepted the command; the action is now in flight pending its outcome."""
+		if self.status in TERMINAL_STATES:
+			return
+
+		self.status = "Sent"
+		if atlas_task:
+			self.atlas_task = atlas_task
+		self._apply()
+
+	def fail_from_exception(self, exc: Exception) -> None:
+		"""Record a synchronous failure from the envelope the exception already carries."""
+		self._finish_error("Failed", to_error_response(exc))
+
+	def _finish_error(self, status: str, envelope: dict) -> None:
+		self.status = status
+		self.error_code = envelope.get("code")
+		self.error_message = envelope.get("message")
+		self.remediation = envelope.get("remediation")
+		self.retriable = 1 if envelope.get("retriable") else 0
+		self.completed_at = frappe.utils.now_datetime()
+		# Commit before any caller re-raises: the request rolls back on the way out, which
+		# would otherwise discard the outcome and leave the action stuck in flight.
+		self._apply(commit=True)
+
+	def _succeed(self) -> None:
+		self.status = "Succeeded"
+		self.completed_at = frappe.utils.now_datetime()
+		self._apply()
+
+	@classmethod
+	def record_mirror_status(cls, correlation_id: str | None, mirror_status: str | None) -> None:
+		"""Transition the action a returning Atlas event confirms. The event's correlation id
+		is this row's name; an unknown or already-finished action is ignored."""
+		if not (correlation_id and mirror_status):
+			return
+		if not frappe.db.exists("Resource Action", correlation_id):
+			return
+
+		doc = frappe.get_doc("Resource Action", correlation_id)
+		if doc.status in TERMINAL_STATES:
+			return
+
+		if mirror_status == "Failed":
+			doc._finish_error("Failed", build_envelope("ACTION_FAILED", action=doc.action))
+		elif mirror_status == SUCCESS_MIRROR_STATUS.get(doc.action):
+			doc._succeed()
+		elif mirror_status in IN_PROGRESS_MIRROR_STATUS and doc.status != "In Progress":
+			doc.status = "In Progress"
+			doc._apply()
+
+	@classmethod
+	def pending_labels(cls, team: str) -> dict[str, str]:
+		"""resource_id -> transitional label for the team's in-flight actions, so the console
+		shows "Terminating…"/"Provisioning…" from the click until the mirror catches up. A
+		VM id and a site FQDN never collide, so one map serves both lists. Latest wins."""
+		rows = frappe.get_all(
+			"Resource Action",
+			filters={"team": team, "status": ["in", PENDING_STATES], "resource_id": ["is", "set"]},
+			fields=["resource_id", "action"],
+			order_by="creation asc",
+		)
+		return {row.resource_id: PENDING_LABEL[row.action] for row in rows}
+
+	@classmethod
+	def sweep_stale(cls, minutes: int = 15) -> int:
+		"""Resolve actions stuck in flight past `minutes`: if the mirror already shows the goal
+		(the confirming event was lost but reconcile caught up) mark them Succeeded, otherwise
+		Timed Out with a clear message. Keeps a lost event from spinning the UI forever."""
+		cutoff = frappe.utils.add_to_date(frappe.utils.now_datetime(), minutes=-minutes)
+		stuck = frappe.get_all(
+			"Resource Action",
+			filters={"status": ["in", PENDING_STATES], "creation": ["<", cutoff]},
+			pluck="name",
+		)
+		for name in stuck:
+			cls._resolve_stale(frappe.get_doc("Resource Action", name))
+
+		return len(stuck)
+
+	@classmethod
+	def _resolve_stale(cls, doc: "ResourceAction") -> None:
+		mirror = "Site" if doc.resource_type == "Site" else "Asset"
+		goal = SUCCESS_MIRROR_STATUS.get(doc.action)
+		reached = doc.resource_id and goal and frappe.db.get_value(mirror, doc.resource_id, "status") == goal
+		if reached:
+			doc._succeed()
+		else:
+			doc._finish_error("Timed Out", build_envelope("ACTION_TIMED_OUT", action=doc.action))
+
+	def _apply(self, *, commit: bool = False) -> None:
+		self.save(ignore_permissions=True)
+		if commit:
+			frappe.db.commit()
+		self._poke_console()
+
+	def _poke_console(self) -> None:
+		"""Nudge the console to re-read once this row commits, so the transitional state flips
+		live over the same list channel the mirror already uses — no polling."""
+		if not self.resource_id:
+			return
+
+		mirror = "Site" if self.resource_type == "Site" else "Asset"
+		frappe.publish_realtime(
+			"list_update",
+			{"doctype": mirror, "name": self.resource_id},
+			doctype=mirror,
+			after_commit=True,
+		)

--- a/central/central/doctype/resource_action/resource_action.py
+++ b/central/central/doctype/resource_action/resource_action.py
@@ -80,7 +80,7 @@ class ResourceAction(Document):
 		# would otherwise discard the outcome and leave the action stuck in flight.
 		self._apply(commit=True)
 
-	def _succeed(self) -> None:
+	def succeed(self) -> None:
 		self.status = "Succeeded"
 		self.completed_at = frappe.utils.now_datetime()
 		self._apply()
@@ -101,7 +101,7 @@ class ResourceAction(Document):
 		if mirror_status == "Failed":
 			doc._finish_error("Failed", build_envelope("ACTION_FAILED", action=doc.action))
 		elif mirror_status == SUCCESS_MIRROR_STATUS.get(doc.action):
-			doc._succeed()
+			doc.succeed()
 		elif mirror_status in IN_PROGRESS_MIRROR_STATUS and doc.status != "In Progress":
 			doc.status = "In Progress"
 			doc._apply()
@@ -141,7 +141,7 @@ class ResourceAction(Document):
 		goal = SUCCESS_MIRROR_STATUS.get(doc.action)
 		reached = doc.resource_id and goal and frappe.db.get_value(mirror, doc.resource_id, "status") == goal
 		if reached:
-			doc._succeed()
+			doc.succeed()
 		else:
 			doc._finish_error("Timed Out", build_envelope("ACTION_TIMED_OUT", action=doc.action))
 

--- a/central/errors.py
+++ b/central/errors.py
@@ -1,0 +1,187 @@
+"""User-facing error envelopes for server-flow actions.
+
+A failed action must tell the user what happened and what to do about it — never a
+FrappeException or a raw traceback. Every server-action failure is shaped into a small
+envelope ({code, title, message, remediation, retriable}) built from `ERROR_CATALOG`,
+and carried to the client on the message it raises (Frappe serializes each message-log
+entry, extra keys included, into `_server_messages`). The stable `code` is what the UI
+switches on; `message`/`remediation` are the words a person reads (see the Wix "write
+better error messages" guidance: plain language, cause, reassurance, next step).
+
+Wire this at the two ends of the Server flow: `throw_action_error` where Central raises a
+known failure, and the `@server_action` decorator on the whitelisted endpoints so nothing
+— not even an unexpected bug — reaches the user as a bare exception.
+"""
+
+from __future__ import annotations
+
+import functools
+
+import frappe
+from frappe import _
+
+# The message key the envelope rides on inside each _server_messages entry.
+ENVELOPE_KEY = "server_action_error"
+
+
+class ServerActionError(frappe.ValidationError):
+	"""A server-flow failure already shaped into a user-facing envelope."""
+
+
+# code -> user-facing copy. Templates are formatted with the call's context (action,
+# region, resource_id, field); a missing placeholder renders empty rather than crashing
+# the error path. `message` may be overridden at the call site (e.g. Atlas's own sentence).
+ERROR_CATALOG: dict[str, dict] = {
+	"PERMISSION_DENIED": {
+		"title": "You don't have access",
+		"message": "Your role on this team isn't allowed to {action} servers.",
+		"remediation": "Ask a team admin to grant you server access, or switch to a team where you have it.",
+		"retriable": False,
+	},
+	"INPUT_REQUIRED": {
+		"title": "Missing information",
+		"message": "{field} is required to continue.",
+		"remediation": "",
+		"retriable": False,
+	},
+	"SERVER_NOT_FOUND": {
+		"title": "Server not found",
+		"message": "We couldn't find the server '{resource_id}' on this team.",
+		"remediation": "It may have been terminated, or it belongs to another team. Refresh your server list and try again.",
+		"retriable": False,
+	},
+	"SERVER_BUSY_RESIZING": {
+		"title": "Server is resizing",
+		"message": "This server is resizing right now. You can {action} it as soon as the resize finishes.",
+		"remediation": "",
+		"retriable": True,
+	},
+	"REGION_UNAVAILABLE": {
+		"title": "Region isn't responding",
+		"message": "We couldn't {action} — the region ({region}) isn't responding right now, and nothing was changed.",
+		"remediation": "This is usually temporary. Please try again in a moment; if it keeps happening, contact support.",
+		"retriable": True,
+	},
+	"ATLAS_REJECTED": {
+		"title": "Couldn't {action}",
+		"message": "The region couldn't complete this request.",
+		"remediation": "",
+		"retriable": False,
+	},
+	"VALIDATION_ERROR": {
+		"title": "Please check and try again",
+		"message": "We couldn't complete that action.",
+		"remediation": "",
+		"retriable": False,
+	},
+	"UNEXPECTED": {
+		"title": "Something went wrong on our end",
+		"message": "We hit an unexpected problem completing that action, and nothing was changed.",
+		"remediation": "Please try again in a moment. If it keeps happening, contact support so we can look into it.",
+		"retriable": True,
+	},
+}
+
+
+class _SafeContext(dict):
+	"""format_map source that renders a missing placeholder as empty, so building an
+	error message can never itself raise."""
+
+	def __missing__(self, key: str) -> str:
+		return ""
+
+
+def build_envelope(code: str, *, message: str | None = None, remediation: str | None = None, **context) -> dict:
+	"""Shape one catalog entry into an envelope, filling templates from `context`.
+	`message`/`remediation` override the catalog copy when the caller has better words
+	(e.g. the region's own error sentence)."""
+	entry = ERROR_CATALOG.get(code, ERROR_CATALOG["UNEXPECTED"])
+	source = _SafeContext(context)
+
+	return {
+		"code": code if code in ERROR_CATALOG else "UNEXPECTED",
+		"title": _(entry["title"]).format_map(source),
+		"message": (message or _(entry["message"])).format_map(source),
+		"remediation": (remediation if remediation is not None else _(entry["remediation"])).format_map(source),
+		"retriable": entry["retriable"],
+	}
+
+
+def throw_action_error(code: str, *, exc: type[Exception] = ServerActionError, **context) -> None:
+	"""Raise a known server-flow failure as a clean, structured error. Pass `exc` to keep
+	the right HTTP status (e.g. frappe.PermissionError for 403); pass `message`/`remediation`
+	in `context` to override the catalog copy."""
+	envelope = build_envelope(code, **context)
+	_carry(envelope)
+
+	error = exc(envelope["message"])
+	error.envelope = envelope
+	raise error
+
+
+def to_error_response(exc: Exception) -> dict:
+	"""Shape an already-raised exception into an envelope. A message the user was meant to
+	see (any frappe exception) is preserved verbatim; a genuinely unexpected error is logged
+	for operators and shown a generic, honest message instead of its internals."""
+	if getattr(exc, "envelope", None):
+		return exc.envelope
+
+	if isinstance(exc, frappe.PermissionError):
+		return build_envelope("PERMISSION_DENIED", message=str(exc) or None)
+
+	if isinstance(exc, frappe.DoesNotExistError):
+		return build_envelope("SERVER_NOT_FOUND", message=str(exc) or None)
+
+	if isinstance(exc, frappe.ValidationError):
+		return build_envelope("VALIDATION_ERROR", message=str(exc) or None)
+
+	frappe.log_error(title="Unexpected server-action error", message=frappe.get_traceback())
+	return build_envelope("UNEXPECTED")
+
+
+def server_action(func):
+	"""Guarantee a whitelisted server action fails as a clean envelope, never a bare
+	exception. An error already shaped by `throw_action_error` passes through untouched;
+	anything else is converted, preserving the user's message and the exception's status."""
+
+	@functools.wraps(func)
+	def wrapper(*args, **kwargs):
+		try:
+			return func(*args, **kwargs)
+		except Exception as exc:
+			if getattr(exc, "envelope", None):
+				raise
+
+			envelope = to_error_response(exc)
+			_reraise_with_envelope(exc, envelope)
+
+	return wrapper
+
+
+def _reraise_with_envelope(exc: Exception, envelope: dict) -> None:
+	"""Attach the envelope to what the client receives. A frappe exception already logged
+	its message, so enrich that entry and keep the original type (and status); anything
+	else gets a fresh message and is re-raised as a ServerActionError."""
+	if isinstance(exc, (frappe.ValidationError, frappe.PermissionError)) and frappe.message_log:
+		frappe.message_log[-1][ENVELOPE_KEY] = envelope
+		exc.envelope = envelope
+		raise exc
+
+	_carry(envelope)
+
+	error = ServerActionError(envelope["message"])
+	error.envelope = envelope
+	raise error from exc
+
+
+def _carry(envelope: dict) -> None:
+	"""Append the message-log entry that carries this envelope to the client."""
+	frappe.message_log.append(
+		frappe._dict(
+			message=envelope["message"],
+			title=envelope["title"],
+			indicator="red",
+			raise_exception=1,
+			**{ENVELOPE_KEY: envelope},
+		)
+	)

--- a/central/errors.py
+++ b/central/errors.py
@@ -68,6 +68,12 @@ ERROR_CATALOG: dict[str, dict] = {
 		"remediation": "",
 		"retriable": False,
 	},
+	"RESOURCE_GONE": {
+		"title": "No longer exists",
+		"message": "This server no longer exists in its region — it may already have been removed.",
+		"remediation": "Refresh your list to see the current state.",
+		"retriable": False,
+	},
 	"ACTION_FAILED": {
 		"title": "The {action} didn't complete",
 		"message": "Your server reported a failure while trying to {action}, and it's now in a failed state.",

--- a/central/errors.py
+++ b/central/errors.py
@@ -9,7 +9,7 @@ switches on; `message`/`remediation` are the words a person reads (see the Wix "
 better error messages" guidance: plain language, cause, reassurance, next step).
 
 Wire this at the two ends of the Server flow: `throw_action_error` where Central raises a
-known failure, and the `@server_action` decorator on the whitelisted endpoints so nothing
+known failure, and the `@resource_action` decorator on the whitelisted endpoints so nothing
 — not even an unexpected bug — reaches the user as a bare exception.
 """
 
@@ -21,10 +21,10 @@ import frappe
 from frappe import _
 
 # The message key the envelope rides on inside each _server_messages entry.
-ENVELOPE_KEY = "server_action_error"
+ENVELOPE_KEY = "action_error"
 
 
-class ServerActionError(frappe.ValidationError):
+class ResourceActionError(frappe.ValidationError):
 	"""A server-flow failure already shaped into a user-facing envelope."""
 
 
@@ -68,6 +68,18 @@ ERROR_CATALOG: dict[str, dict] = {
 		"remediation": "",
 		"retriable": False,
 	},
+	"ACTION_FAILED": {
+		"title": "The {action} didn't complete",
+		"message": "Your server reported a failure while trying to {action}, and it's now in a failed state.",
+		"remediation": "Try the action again. If it keeps failing, contact support so we can look into it.",
+		"retriable": True,
+	},
+	"ACTION_TIMED_OUT": {
+		"title": "The {action} is taking too long",
+		"message": "We haven't heard back that the {action} finished. It may still complete on its own.",
+		"remediation": "Refresh your server list in a few minutes. If it still looks stuck, contact support.",
+		"retriable": True,
+	},
 	"VALIDATION_ERROR": {
 		"title": "Please check and try again",
 		"message": "We couldn't complete that action.",
@@ -91,7 +103,9 @@ class _SafeContext(dict):
 		return ""
 
 
-def build_envelope(code: str, *, message: str | None = None, remediation: str | None = None, **context) -> dict:
+def build_envelope(
+	code: str, *, message: str | None = None, remediation: str | None = None, **context
+) -> dict:
 	"""Shape one catalog entry into an envelope, filling templates from `context`.
 	`message`/`remediation` override the catalog copy when the caller has better words
 	(e.g. the region's own error sentence)."""
@@ -102,12 +116,14 @@ def build_envelope(code: str, *, message: str | None = None, remediation: str | 
 		"code": code if code in ERROR_CATALOG else "UNEXPECTED",
 		"title": _(entry["title"]).format_map(source),
 		"message": (message or _(entry["message"])).format_map(source),
-		"remediation": (remediation if remediation is not None else _(entry["remediation"])).format_map(source),
+		"remediation": (remediation if remediation is not None else _(entry["remediation"])).format_map(
+			source
+		),
 		"retriable": entry["retriable"],
 	}
 
 
-def throw_action_error(code: str, *, exc: type[Exception] = ServerActionError, **context) -> None:
+def throw_action_error(code: str, *, exc: type[Exception] = ResourceActionError, **context) -> None:
 	"""Raise a known server-flow failure as a clean, structured error. Pass `exc` to keep
 	the right HTTP status (e.g. frappe.PermissionError for 403); pass `message`/`remediation`
 	in `context` to override the catalog copy."""
@@ -139,8 +155,8 @@ def to_error_response(exc: Exception) -> dict:
 	return build_envelope("UNEXPECTED")
 
 
-def server_action(func):
-	"""Guarantee a whitelisted server action fails as a clean envelope, never a bare
+def resource_action(func):
+	"""Guarantee a whitelisted action endpoint fails as a clean envelope, never a bare
 	exception. An error already shaped by `throw_action_error` passes through untouched;
 	anything else is converted, preserving the user's message and the exception's status."""
 
@@ -161,7 +177,7 @@ def server_action(func):
 def _reraise_with_envelope(exc: Exception, envelope: dict) -> None:
 	"""Attach the envelope to what the client receives. A frappe exception already logged
 	its message, so enrich that entry and keep the original type (and status); anything
-	else gets a fresh message and is re-raised as a ServerActionError."""
+	else gets a fresh message and is re-raised as a ResourceActionError."""
 	if isinstance(exc, (frappe.ValidationError, frappe.PermissionError)) and frappe.message_log:
 		frappe.message_log[-1][ENVELOPE_KEY] = envelope
 		exc.envelope = envelope
@@ -169,7 +185,7 @@ def _reraise_with_envelope(exc: Exception, envelope: dict) -> None:
 
 	_carry(envelope)
 
-	error = ServerActionError(envelope["message"])
+	error = ResourceActionError(envelope["message"])
 	error.envelope = envelope
 	raise error from exc
 

--- a/central/errors.py
+++ b/central/errors.py
@@ -179,6 +179,7 @@ def _reraise_with_envelope(exc: Exception, envelope: dict) -> None:
 	its message, so enrich that entry and keep the original type (and status); anything
 	else gets a fresh message and is re-raised as a ResourceActionError."""
 	if isinstance(exc, (frappe.ValidationError, frappe.PermissionError)) and frappe.message_log:
+		frappe.message_log[-1]["message"] = _display_message(envelope)
 		frappe.message_log[-1][ENVELOPE_KEY] = envelope
 		exc.envelope = envelope
 		raise exc
@@ -190,11 +191,18 @@ def _reraise_with_envelope(exc: Exception, envelope: dict) -> None:
 	raise error from exc
 
 
+def _display_message(envelope: dict) -> str:
+	"""What the user reads: what happened, then how to resolve it. frappe-ui surfaces only
+	this line and drops the structured envelope, so the remediation has to ride here too."""
+	remediation = envelope.get("remediation")
+	return f"{envelope['message']} {remediation}".strip() if remediation else envelope["message"]
+
+
 def _carry(envelope: dict) -> None:
 	"""Append the message-log entry that carries this envelope to the client."""
 	frappe.message_log.append(
 		frappe._dict(
-			message=envelope["message"],
+			message=_display_message(envelope),
 			title=envelope["title"],
 			indicator="red",
 			raise_exception=1,

--- a/central/hooks.py
+++ b/central/hooks.py
@@ -188,6 +188,9 @@ scheduler_events = {
 		# Asset mirror: reconcile against every Active Atlas every 10 minutes — the
 		# backstop that corrects drift the event push (central.api.atlas.event) missed.
 		"*/10 * * * *": ["central.integrations.atlas.reconcile"],
+		# Resource actions: resolve any action stuck in flight because its confirming event
+		# was lost — mark it Succeeded if the mirror already reached the goal, else Timed Out.
+		"*/5 * * * *": ["central.central.doctype.resource_action.resource_action.sweep_stale"],
 	},
 	"daily": [
 		"central.central.doctype.team_invitation.team_invitation.expire_pending_invitations",
@@ -337,6 +340,7 @@ before_request = ["central.oauth.install_oauth_claim_patch"]
 permission_query_conditions = {
 	"Asset": "central.permissions.asset_query_conditions",
 	"IAM Permission Probe": "central.permissions.iam_permission_probe_query_conditions",
+	"Resource Action": "central.permissions.resource_action_query_conditions",
 	"Site": "central.permissions.site_query_conditions",
 	"Team": "central.permissions.team_query_conditions",
 	"Team Invitation": "central.permissions.team_invitation_query_conditions",
@@ -346,6 +350,7 @@ permission_query_conditions = {
 has_permission = {
 	"Asset": "central.permissions.asset_has_permission",
 	"IAM Permission Probe": "central.permissions.iam_permission_probe_has_permission",
+	"Resource Action": "central.permissions.resource_action_has_permission",
 	"Site": "central.permissions.site_has_permission",
 	"Team": "central.permissions.team_has_permission",
 	"Team Invitation": "central.permissions.team_invitation_has_permission",

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -45,6 +45,16 @@ class AtlasError(frappe.ValidationError):
 	pass
 
 
+class AtlasResourceGone(AtlasError):
+	"""Atlas has no such resource (HTTP 404). For terminate this means already gone —
+	the caller can treat it as idempotent success; for other actions it's a clean error."""
+
+
+# Generous bound for a synchronous lifecycle call (Atlas runs terminate/start on the host
+# in-request); long enough for a real op, short enough that a dead region can't pin a worker.
+LIFECYCLE_TIMEOUT = 120
+
+
 # The last line of a Python traceback is always "<dotted.ExcType>: <message>". That is
 # the only part of a remote failure worth showing a caller, so it is what we lift out of
 # the traceback FrappeClient hands us (see `_post`).
@@ -73,6 +83,18 @@ def _remote_error_message(exception: Exception) -> str | None:
 		if match:
 			return match.group("message").strip() or None
 	return None
+
+
+def _server_message(response: requests.Response) -> str | None:
+	"""Atlas's own error sentence from a failed response's `_server_messages`, or None."""
+	try:
+		raw = response.json().get("_server_messages")
+		if not raw:
+			return None
+		first = frappe.parse_json(frappe.parse_json(raw)[0])
+		return frappe.utils.strip_html_tags(first.get("message") or "") or None
+	except Exception:
+		return None
 
 
 def get_atlas_instance(region: str):
@@ -137,6 +159,48 @@ class AtlasClient:
 				"REGION_UNAVAILABLE", exc=AtlasError, action=action, region=self.instance.region
 			)
 
+	def _run_doc_method(self, dt: str, dn: str, method: str, args: dict | None, *, action: str) -> Any:
+		"""Invoke a whitelisted controller method on Atlas, reading the real HTTP status so a
+		missing doc (404) is told apart from an unreachable region — unlike FrappeClient, which
+		collapses both into an opaque failure. Returns the method's result; raises
+		AtlasResourceGone on 404 (for terminate that means already gone), AtlasError otherwise."""
+		if self.instance.status == "Disabled":
+			frappe.throw(_("Atlas '{0}' is disabled.").format(self.instance.region), AtlasError)
+		if not self.instance.api_key:
+			frappe.throw(_("Atlas '{0}' has no admin API key.").format(self.instance.region), AtlasError)
+
+		url = self._data_url().rstrip("/") + "/api/method/run_doc_method"
+		params = {"dt": dt, "dn": dn, "method": method}
+		if args:
+			params["args"] = json.dumps(args)
+		secret = self.instance.get_password("api_secret")
+
+		try:
+			response = requests.post(
+				url,
+				headers={"Authorization": f"token {self.instance.api_key}:{secret}"},
+				data=params,
+				timeout=LIFECYCLE_TIMEOUT,
+			)
+		except requests.RequestException:
+			throw_action_error(
+				"REGION_UNAVAILABLE", exc=AtlasError, action=action, region=self.instance.region
+			)
+
+		if response.ok:
+			return response.json().get("message")
+
+		# Keep the full body for operators; hand the caller Atlas's own sentence.
+		frappe.log_error(
+			title=f"Atlas '{self.instance.region}': {action} failed", message=response.text[:2000]
+		)
+		if response.status_code == 404:
+			throw_action_error("RESOURCE_GONE", exc=AtlasResourceGone, action=action)
+		sentence = _server_message(response)
+		if sentence:
+			throw_action_error("ATLAS_REJECTED", exc=AtlasError, message=sentence, action=action)
+		throw_action_error("REGION_UNAVAILABLE", exc=AtlasError, action=action, region=self.instance.region)
+
 	def ping(self) -> dict:
 		"""Reachability + auth check against the frappe ping endpoint."""
 		return self.client().get_api("ping")
@@ -145,11 +209,9 @@ class AtlasClient:
 		"""Invoke a Virtual Machine lifecycle method (start/stop/terminate) as the operator;
 		return the resulting Task name. `correlation_id` rides back on the resulting event so
 		Central can match it to the Resource Action that requested it."""
-		params = {"dt": "Virtual Machine", "dn": name, "method": method}
-		if correlation_id:
-			params["args"] = json.dumps({"correlation_id": correlation_id})
+		args = {"correlation_id": correlation_id} if correlation_id else None
 
-		return self._post("run_doc_method", params, action=f"{method} this server")
+		return self._run_doc_method("Virtual Machine", name, method, args, action=f"{method} this server")
 
 	def resize_vm(
 		self,
@@ -424,12 +486,11 @@ class AtlasClient:
 
 	def terminate_site(self, name: str, *, correlation_id: str | None = None) -> dict:
 		"""Tear down a self-serve site and its 1:1 backing VM. The Atlas Site controller
-		terminates the guest + VM; the site.* events flip the mirror to Terminated."""
-		params = {"dt": "Site", "dn": name, "method": "terminate"}
-		if correlation_id:
-			params["args"] = json.dumps({"correlation_id": correlation_id})
+		terminates the guest + VM; the site.* events flip the mirror to Terminated. Raises
+		AtlasResourceGone if the site is already gone on Atlas, so terminate stays idempotent."""
+		args = {"correlation_id": correlation_id} if correlation_id else None
 
-		return self._post("run_doc_method", params, action="terminate this site")
+		return self._run_doc_method("Site", name, "terminate", args, action="terminate this site")
 
 	def check_subdomain(self, subdomain: str, region: str | None = None) -> dict:
 		"""Best-effort availability pre-check: {available, reason, fqdn, domain}."""

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -18,6 +18,7 @@ from frappe.utils.password import get_decrypted_password
 
 from central.central.doctype.asset.asset import Asset
 from central.central.doctype.pilot_credential.pilot_credential import PilotCredential
+from central.central.doctype.resource_action.resource_action import ResourceAction
 from central.central.doctype.site.site import Site
 from central.errors import throw_action_error
 from central.host_task import run_host_task
@@ -132,20 +133,23 @@ class AtlasClient:
 			# failure is a network/timeout — transient, and safe to retry.
 			if sentence:
 				throw_action_error("ATLAS_REJECTED", exc=AtlasError, message=sentence, action=action)
-			throw_action_error("REGION_UNAVAILABLE", exc=AtlasError, action=action, region=self.instance.region)
+			throw_action_error(
+				"REGION_UNAVAILABLE", exc=AtlasError, action=action, region=self.instance.region
+			)
 
 	def ping(self) -> dict:
 		"""Reachability + auth check against the frappe ping endpoint."""
 		return self.client().get_api("ping")
 
-	def vm_action(self, name: str, method: str) -> str:
-		"""Invoke a Virtual Machine lifecycle method (start/stop/terminate) as the
-		operator; return the resulting Task name."""
-		return self._post(
-			"run_doc_method",
-			{"dt": "Virtual Machine", "dn": name, "method": method},
-			action=f"{method} this server",
-		)
+	def vm_action(self, name: str, method: str, *, correlation_id: str | None = None) -> str:
+		"""Invoke a Virtual Machine lifecycle method (start/stop/terminate) as the operator;
+		return the resulting Task name. `correlation_id` rides back on the resulting event so
+		Central can match it to the Resource Action that requested it."""
+		params = {"dt": "Virtual Machine", "dn": name, "method": method}
+		if correlation_id:
+			params["args"] = json.dumps({"correlation_id": correlation_id})
+
+		return self._post("run_doc_method", params, action=f"{method} this server")
 
 	def resize_vm(
 		self,
@@ -186,6 +190,7 @@ class AtlasClient:
 		disk_gigabytes: int,
 		cpu_max_cores: float | None = None,
 		frappe_version: str | None = None,
+		correlation_id: str | None = None,
 	) -> dict:
 		"""Provision a VM on this Atlas for a Central team (the operator write).
 		Returns the new VM in the Asset-mirror shape so the caller can upsert it.
@@ -205,6 +210,8 @@ class AtlasClient:
 			params["cpu_max_cores"] = cpu_max_cores
 		if frappe_version:
 			params["frappe_version"] = frappe_version
+		if correlation_id:
+			params["correlation_id"] = correlation_id
 		# Same enrollment carriage as create_site: mint the single-use bootstrap token and
 		# credential id so the bench can run `bench admin enroll` on first boot. Without it
 		# a server provisions fine but never enrols, and Open Console refuses it with
@@ -342,16 +349,20 @@ class AtlasClient:
 		team: str,
 		subdomain: str,
 		region: str | None = None,
+		correlation_id: str | None = None,
 	) -> dict:
 		"""
 		Provision a self-serve site on this Atlas for a Central team (the operator
 		write). Returns the site in the Site-mirror shape so the caller can upsert it.
+		`correlation_id` rides back on the site.* events so Central can match the outcome.
 		"""
 
 		params: dict = {"team": team, "subdomain": subdomain}
 
 		if region:
 			params["region"] = region
+		if correlation_id:
+			params["correlation_id"] = correlation_id
 		params.update(self._pilot_credential(team))
 
 		# Durability: minting the bootstrap token lazily generates Central's signing key on
@@ -411,14 +422,14 @@ class AtlasClient:
 			action="refresh this site's login link",
 		)
 
-	def terminate_site(self, name: str) -> dict:
+	def terminate_site(self, name: str, *, correlation_id: str | None = None) -> dict:
 		"""Tear down a self-serve site and its 1:1 backing VM. The Atlas Site controller
 		terminates the guest + VM; the site.* events flip the mirror to Terminated."""
-		return self._post(
-			"run_doc_method",
-			{"dt": "Site", "dn": name, "method": "terminate"},
-			action="terminate this site",
-		)
+		params = {"dt": "Site", "dn": name, "method": "terminate"}
+		if correlation_id:
+			params["args"] = json.dumps({"correlation_id": correlation_id})
+
+		return self._post("run_doc_method", params, action="terminate this site")
 
 	def check_subdomain(self, subdomain: str, region: str | None = None) -> dict:
 		"""Best-effort availability pre-check: {available, reason, fqdn, domain}."""
@@ -562,6 +573,8 @@ def _on_vm(cluster: str, payload: dict, occurred_at) -> None:
 	Asset.mirror_vm(cluster, payload, occurred_at=occurred_at)
 	# Once Atlas echoes the pilot_credential_id, bind the credential to its VM.
 	PilotCredential.link_asset(payload.get("pilot_credential_id"), payload.get("name"))
+	# Confirm the action that asked for this change (create/start/stop/restart) against its outcome.
+	ResourceAction.record_mirror_status(payload.get("correlation_id"), payload.get("status"))
 
 
 def _on_vm_deleted(cluster: str, payload: dict, occurred_at) -> None:
@@ -572,10 +585,14 @@ def _on_vm_deleted(cluster: str, payload: dict, occurred_at) -> None:
 		Asset.mark_terminated(resource_id, last_event_at=occurred_at)
 	# The pilot dies with its VM — kill its Central credential so a leaked token is inert.
 	PilotCredential.revoke_by_id(payload.get("pilot_credential_id"))
+	# A delete is the terminal outcome of a terminate action.
+	ResourceAction.record_mirror_status(payload.get("correlation_id"), "Terminated")
 
 
 def _on_site(cluster: str, payload: dict, occurred_at) -> None:
 	Site.mirror_site(cluster, payload, occurred_at=occurred_at)
+	# Confirm the site action (create/terminate) this status carries the outcome of.
+	ResourceAction.record_mirror_status(payload.get("correlation_id"), payload.get("status"))
 
 
 _EVENT_HANDLERS = {

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -443,11 +443,13 @@ def ingest_event(
 	signature: str | None = None,
 	signature_timestamp: str | None = None,
 ) -> dict:
-	"""Persist the event under the caller-verified `cluster`, then queue the mirror write.
-	raw_body/signature/signature_timestamp are kept verbatim so the row stays
-	self-verifying; raw_payload is reserialized and never verifies."""
+	"""Persist the event under the caller-verified `cluster`, then queue the mirror write
+	for the types Central mirrors. raw_body/signature/signature_timestamp are kept verbatim
+	so the row stays self-verifying; raw_payload is reserialized and never verifies."""
 
-	if event_type not in _EVENT_HANDLERS:
+	# A validly-signed but malformed event (no id or type) can't be stored or deduped —
+	# ack it so Atlas stops retrying, as before. Real events always carry both.
+	if not (event_id and event_type):
 		return {"ok": True, "queued": False}
 
 	# A redelivery carries the same event_id, so skip anything we've already stored.
@@ -456,7 +458,11 @@ def ingest_event(
 	if frappe.db.exists("Atlas Event", {"event_id": event_id}):
 		return {"ok": True, "queued": False}
 
-	# after_insert enqueues the mirror write once this row commits.
+	# Record every authenticated event. A type Central doesn't mirror yet lands as Ignored
+	# rather than vanishing — so the audit trail is complete and a handler added later has
+	# history to replay. after_insert queues the mirror write only for a Received row.
+	handled = event_type in _EVENT_HANDLERS
+
 	frappe.get_doc(
 		{
 			"doctype": "Atlas Event",
@@ -468,11 +474,11 @@ def ingest_event(
 			"signature_timestamp": signature_timestamp,
 			"raw_body": raw_body.decode() if isinstance(raw_body, bytes) else raw_body,
 			"raw_payload": frappe.as_json(payload or {}),
-			"status": "Received",
+			"status": "Received" if handled else "Ignored",
 		}
 	).insert(ignore_permissions=True)
 
-	return {"ok": True, "queued": True}
+	return {"ok": True, "queued": handled}
 
 
 def apply_event(event_name: str) -> None:
@@ -520,18 +526,18 @@ def _authenticate_atlas_webhook(raw_body: bytes) -> frappe._dict:
 	timestamp = frappe.get_request_header("X-Atlas-Timestamp")
 	signature = frappe.get_request_header("X-Atlas-Signature")
 	if not (region and timestamp and signature):
-		_reject_signature()
+		_reject_signature("missing signature headers")
 
 	instance = frappe.db.get_value("Atlas Instance", {"region": region, "status": ["!=", "Disabled"]})
 	if not instance:
-		_reject_signature()
+		_reject_signature(f"unknown or disabled region '{region}'")
 
 	secret = get_decrypted_password("Atlas Instance", instance, "webhook_secret", raise_exception=False)
 	if not secret:
-		_reject_signature()
+		_reject_signature(f"no webhook secret for region '{region}'")
 
 	if not signature_matches(secret, timestamp, raw_body, signature):
-		_reject_signature()
+		_reject_signature(f"signature mismatch for region '{region}'")
 
 	return frappe._dict(cluster=instance, raw=raw_body, signature=signature, timestamp=timestamp)
 
@@ -542,7 +548,12 @@ def signature_matches(secret: str, timestamp, raw_body: bytes, signature: str) -
 	return hmac.compare_digest(expected.encode(), signature.encode())
 
 
-def _reject_signature():
+def _reject_signature(reason: str):
+	"""Log the specific reason for operators — repeated rejections mean secret drift or a
+	forged caller, invisible before this — but throw one uniform 403 so a caller can't
+	probe which check failed. A file logger, not Error Log, so a flood can't bloat the DB."""
+	frappe.logger("atlas_webhook").warning(f"rejected inbound webhook: {reason}")
+
 	# Uniform 403. Don't set http_status_code — Frappe's exception handler overrides it.
 	frappe.throw(_("Invalid webhook signature."), frappe.PermissionError)
 

--- a/central/integrations/atlas.py
+++ b/central/integrations/atlas.py
@@ -19,6 +19,7 @@ from frappe.utils.password import get_decrypted_password
 from central.central.doctype.asset.asset import Asset
 from central.central.doctype.pilot_credential.pilot_credential import PilotCredential
 from central.central.doctype.site.site import Site
+from central.errors import throw_action_error
 from central.host_task import run_host_task
 
 # Central's integration with the regional Atlas clusters (Edge B), all in one place:
@@ -125,14 +126,13 @@ class AtlasClient:
 				title=f"Atlas '{self.instance.region}': {action} failed",
 				message=str(exception),
 			)
-			message = _remote_error_message(exception)
-			frappe.throw(
-				message
-				or _("Could not {0} — Atlas '{1}' is unreachable. Try again shortly.").format(
-					action, self.instance.region
-				),
-				AtlasError,
-			)
+			sentence = _remote_error_message(exception)
+
+			# The region's own sentence is the best message a user can get; without one the
+			# failure is a network/timeout — transient, and safe to retry.
+			if sentence:
+				throw_action_error("ATLAS_REJECTED", exc=AtlasError, message=sentence, action=action)
+			throw_action_error("REGION_UNAVAILABLE", exc=AtlasError, action=action, region=self.instance.region)
 
 	def ping(self) -> dict:
 		"""Reachability + auth check against the frappe ping endpoint."""
@@ -549,10 +549,10 @@ def signature_matches(secret: str, timestamp, raw_body: bytes, signature: str) -
 
 
 def _reject_signature(reason: str):
-	"""Log the specific reason for operators — repeated rejections mean secret drift or a
-	forged caller, invisible before this — but throw one uniform 403 so a caller can't
-	probe which check failed. A file logger, not Error Log, so a flood can't bloat the DB."""
-	frappe.logger("atlas_webhook").warning(f"rejected inbound webhook: {reason}")
+	"""Log the specific reason to the Error Log for operators — repeated rejections mean
+	secret drift or a forged caller, invisible before this — but throw one uniform 403 so a
+	caller can't probe which check failed."""
+	frappe.log_error(title="Rejected inbound Atlas webhook", message=reason)
 
 	# Uniform 403. Don't set http_status_code — Frappe's exception handler overrides it.
 	frappe.throw(_("Invalid webhook signature."), frappe.PermissionError)

--- a/central/permissions.py
+++ b/central/permissions.py
@@ -90,6 +90,15 @@ def asset_has_permission(doc, user: str | None = None, ptype: str | None = None,
 	return _team_field_has_permission(doc, ("server:view",), (), user, ptype)
 
 
+def resource_action_query_conditions(user: str | None = None) -> str:
+	return _team_field_query_conditions("Resource Action", "server:view", user)
+
+
+def resource_action_has_permission(doc, user: str | None = None, ptype: str | None = None, **kwargs) -> bool:
+	# Read-only for tenants: actions are written server-side by the API, never in the portal.
+	return _team_field_has_permission(doc, ("server:view",), (), user, ptype)
+
+
 def site_query_conditions(user: str | None = None) -> str:
 	return _team_field_query_conditions("Site", "server:view", user)
 

--- a/central/permissions.py
+++ b/central/permissions.py
@@ -95,8 +95,12 @@ def resource_action_query_conditions(user: str | None = None) -> str:
 
 
 def resource_action_has_permission(doc, user: str | None = None, ptype: str | None = None, **kwargs) -> bool:
-	# Read-only for tenants: actions are written server-side by the API, never in the portal.
-	return _team_field_has_permission(doc, ("server:view",), (), user, ptype)
+	# Read needs server:view; opening an action needs any server-mutating capability on the
+	# team (the endpoint additionally gates the specific action). Outcomes are written by the
+	# Atlas webhook / sweep, not the portal, so tenants get no write/delete here.
+	return _team_field_has_permission(
+		doc, ("server:view",), ("server:create", "server:power", "server:terminate"), user, ptype
+	)
 
 
 def site_query_conditions(user: str | None = None) -> str:

--- a/central/tests/test_atlas_errors.py
+++ b/central/tests/test_atlas_errors.py
@@ -6,13 +6,19 @@ string, so before `AtlasClient._post` an Atlas-side `frappe.throw` ("region full
 Atlas internals — the actionable sentence buried in the last line.
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import frappe
+import requests
 from frappe.frappeclient import FrappeException
 from frappe.tests import IntegrationTestCase
 
-from central.integrations.atlas import AtlasClient, AtlasError, _remote_error_message
+from central.integrations.atlas import (
+	AtlasClient,
+	AtlasError,
+	AtlasResourceGone,
+	_remote_error_message,
+)
 
 # A verbatim capture of what FrappeClient raised for a create that hit a full region.
 CONSOLIDATION_TRACEBACK = """FrappeClient Request Failed
@@ -91,3 +97,54 @@ class TestAtlasClientPost(IntegrationTestCase):
 				self.client._post("atlas.api.provision.create_vm", {}, action="create this server"),
 				{"name": "vm-1"},
 			)
+
+
+class TestRunDocMethod(IntegrationTestCase):
+	"""The lifecycle path reads the real HTTP status, so a missing doc (404) is told apart
+	from an unreachable region — the fix for terminate mislabelling a gone resource."""
+
+	def _client(self):
+		instance = frappe._dict(
+			region="blr-rdm",
+			status="Active",
+			tunnel_status=None,
+			tunnel_url=None,
+			base_url="https://atlas.example.test",
+			api_key="k",
+		)
+		instance.get_password = lambda field, *a, **k: "s"
+		return AtlasClient(instance)
+
+	def test_404_raises_resource_gone(self):
+		response = MagicMock(ok=False, status_code=404, text="{}")
+		with patch("central.integrations.atlas.requests.post", return_value=response):
+			with self.assertRaises(AtlasResourceGone):
+				self._client()._run_doc_method("Site", "x", "terminate", None, action="terminate this site")
+
+	def test_connection_error_reads_as_region_unavailable(self):
+		with patch("central.integrations.atlas.requests.post", side_effect=requests.ConnectionError()):
+			with self.assertRaises(AtlasError) as caught:
+				self._client()._run_doc_method("Site", "x", "terminate", None, action="terminate this site")
+		self.assertNotIsInstance(caught.exception, AtlasResourceGone)
+		self.assertIn("terminate this site", str(caught.exception))
+
+	def test_remote_sentence_surfaces_on_other_error(self):
+		body = {"_server_messages": frappe.as_json([frappe.as_json({"message": "No capacity here."})])}
+		response = MagicMock(ok=False, status_code=417, text=frappe.as_json(body))
+		response.json.return_value = body
+		with patch("central.integrations.atlas.requests.post", return_value=response):
+			with self.assertRaises(AtlasError) as caught:
+				self._client()._run_doc_method(
+					"Virtual Machine", "x", "start", None, action="start this server"
+				)
+		self.assertNotIsInstance(caught.exception, AtlasResourceGone)
+		self.assertIn("No capacity here.", str(caught.exception))
+
+	def test_success_returns_the_message(self):
+		response = MagicMock(ok=True)
+		response.json.return_value = {"message": "task-9"}
+		with patch("central.integrations.atlas.requests.post", return_value=response):
+			out = self._client()._run_doc_method(
+				"Virtual Machine", "x", "start", None, action="start this server"
+			)
+		self.assertEqual(out, "task-9")

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -982,3 +982,88 @@ class TestAtlasMirror(IntegrationTestCase):
 			"2026-07-02 10:00:00",
 		)
 		self.assertEqual(frappe.db.get_value("Resource Action", result["action"], "status"), "Succeeded")
+
+
+class TestTerminateIdempotency(IntegrationTestCase):
+	"""Terminating a resource Atlas no longer has (e.g. a stale mirror row) is idempotent
+	success, not a scary 'region unreachable' — the reported terminate bug."""
+
+	def setUp(self):
+		from central.tests.test_iam import ensure_user
+
+		frappe.set_user("Administrator")
+		self.owner = ensure_user("term.owner@example.test")
+		self.team = frappe.db.get_value("Team", {"owner_user": self.owner}, "name")
+		self.region = "blr-term"
+		if not frappe.db.exists("Region", self.region):
+			frappe.get_doc(
+				{"doctype": "Region", "region": self.region, "display_name": "Term", "provider": "Fake"}
+			).insert(ignore_permissions=True)
+		if not frappe.db.exists("Atlas Instance", self.region):
+			frappe.get_doc(
+				{
+					"doctype": "Atlas Instance",
+					"region": self.region,
+					"base_url": "https://atlas.example.test",
+					"status": "Active",
+					"api_key": "k",
+					"api_secret": "s",
+				}
+			).insert(ignore_permissions=True)
+		self._no_commit = patch.object(frappe.db, "commit")
+		self._no_commit.start()
+
+	def tearDown(self):
+		self._no_commit.stop()
+		frappe.set_user("Administrator")
+
+	def _asset(self, resource_id):
+		frappe.get_doc(
+			{
+				"doctype": "Asset",
+				"resource_id": resource_id,
+				"team": self.team,
+				"cluster": self.region,
+				"status": "Running",
+			}
+		).insert(ignore_permissions=True)
+		return resource_id
+
+	def test_terminate_succeeds_when_atlas_says_gone(self):
+		from central.integrations.atlas import AtlasResourceGone
+
+		asset = self._asset("vm-gone")
+		frappe.set_user(self.owner)
+		try:
+			with patch(
+				"central.integrations.atlas.AtlasClient.vm_action",
+				side_effect=AtlasResourceGone("gone"),
+			):
+				result = terminate_server(team=self.team, resource_id=asset)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value("Asset", asset, "status"), "Terminated")
+		self.assertEqual(frappe.db.get_value("Resource Action", result["action"], "status"), "Succeeded")
+
+	def test_start_still_errors_when_atlas_says_gone(self):
+		from central.integrations.atlas import AtlasResourceGone
+
+		asset = self._asset("vm-gone2")
+		frappe.db.set_value("Asset", asset, "status", "Stopped")
+		# In production _run_doc_method raises this via throw_action_error, so it carries an
+		# envelope and propagates as-is through the @resource_action decorator.
+		gone = AtlasResourceGone("This server no longer exists in its region.")
+		gone.envelope = {
+			"code": "RESOURCE_GONE",
+			"message": "This server no longer exists in its region.",
+			"remediation": "",
+			"retriable": False,
+		}
+		frappe.set_user(self.owner)
+		try:
+			with patch("central.integrations.atlas.AtlasClient.vm_action", side_effect=gone):
+				with self.assertRaises(AtlasResourceGone):
+					start_server(team=self.team, resource_id=asset)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value("Asset", asset, "status"), "Stopped")

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -3,7 +3,9 @@ from unittest.mock import patch
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from central.api.servers import refresh_assets, registry, start_server
+from central.api.servers import refresh_assets, registry, start_server, terminate_server
+from central.api.sites import create_site, terminate_site
+from central.central.doctype.resource_action.resource_action import ResourceAction
 from central.integrations.atlas import apply_event, ingest_event, reconcile, reconcile_atlas
 from central.tests.test_iam import ensure_user
 
@@ -49,7 +51,13 @@ class TestAtlasMirror(IntegrationTestCase):
 		else:
 			frappe.db.set_value("Atlas Instance", self.region, "service_user", self.service_user)
 
+		# Neutralise commits: a _fail-path commit would otherwise flush this transaction and
+		# leak fixtures across tests. Every assertion here reads within the test transaction.
+		self._no_commit = patch.object(frappe.db, "commit")
+		self._no_commit.start()
+
 	def tearDown(self):
+		self._no_commit.stop()
 		frappe.set_user("Administrator")
 
 	def _push(self, event_type, vm, occurred_at):
@@ -627,7 +635,9 @@ class TestAtlasMirror(IntegrationTestCase):
 			frappe.set_user("Administrator")
 		self.assertEqual(result, {"ok": True, "queued": False})
 		enqueue.assert_not_called()
-		self.assertEqual(frappe.db.get_value("Atlas Event", {"event_id": "evt-unknown-1"}, "status"), "Ignored")
+		self.assertEqual(
+			frappe.db.get_value("Atlas Event", {"event_id": "evt-unknown-1"}, "status"), "Ignored"
+		)
 
 	def test_event_without_id_is_acked_without_storing(self):
 		# A validly-signed but malformed event (no id/type) can't be deduped or stored —
@@ -801,11 +811,174 @@ class TestAtlasMirror(IntegrationTestCase):
 		finally:
 			frappe.set_user("Administrator")
 		self.assertEqual(caught.exception.envelope["code"], "SERVER_BUSY_RESIZING")
-		self.assertEqual(frappe.message_log[-1]["server_action_error"]["code"], "SERVER_BUSY_RESIZING")
+		self.assertEqual(frappe.message_log[-1]["action_error"]["code"], "SERVER_BUSY_RESIZING")
 
 	def test_start_allowed_once_resize_clears(self):
 		asset = self._stopped_asset("vm-idle", resize_in_progress=0)
 		frappe.set_user(self.owner)
 		with patch("central.integrations.atlas.AtlasClient.vm_action", return_value="task-1") as vm_action:
-			start_server(team=self.team.name, resource_id=asset)
-		vm_action.assert_called_once_with(asset, "start")
+			result = start_server(team=self.team.name, resource_id=asset)
+		self.assertEqual(vm_action.call_args.args, (asset, "start"))
+		self.assertEqual(vm_action.call_args.kwargs["correlation_id"], result["action"])
+
+	# --- server action tracking -----------------------------------------------
+
+	def test_start_tracks_action_and_marks_it_sent(self):
+		asset = self._stopped_asset("vm-track-start")
+		frappe.set_user(self.owner)
+		try:
+			with patch(
+				"central.integrations.atlas.AtlasClient.vm_action", return_value="task-7"
+			) as vm_action:
+				result = start_server(team=self.team.name, resource_id=asset)
+		finally:
+			frappe.set_user("Administrator")
+		action = frappe.get_doc("Resource Action", result["action"])
+		self.assertEqual((action.action, action.status, action.resource_id), ("start", "Sent", asset))
+		self.assertEqual(action.atlas_task, "task-7")
+		# The correlation id sent to Atlas is the action's own name.
+		self.assertEqual(vm_action.call_args.kwargs["correlation_id"], action.name)
+
+	def test_confirming_event_marks_action_succeeded(self):
+		asset = self._stopped_asset("vm-track-ok")
+		frappe.set_user(self.owner)
+		try:
+			with patch("central.integrations.atlas.AtlasClient.vm_action", return_value="task-8"):
+				result = start_server(team=self.team.name, resource_id=asset)
+		finally:
+			frappe.set_user("Administrator")
+		# Atlas echoes the correlation id on the Running event its op produced.
+		self._push(
+			"vm.status_changed",
+			{"name": asset, "team": self.team.name, "status": "Running", "correlation_id": result["action"]},
+			"2026-07-02 10:05:00",
+		)
+		self.assertEqual(frappe.db.get_value("Resource Action", result["action"], "status"), "Succeeded")
+
+	def test_terminate_action_succeeds_on_delete_event(self):
+		asset = self._stopped_asset("vm-track-term")
+		frappe.set_user(self.owner)
+		try:
+			with patch("central.integrations.atlas.AtlasClient.vm_action", return_value="t"):
+				result = terminate_server(team=self.team.name, resource_id=asset)
+		finally:
+			frappe.set_user("Administrator")
+		self._push("vm.deleted", {"name": asset, "correlation_id": result["action"]}, "2026-07-02 11:00:00")
+		self.assertEqual(frappe.db.get_value("Resource Action", result["action"], "status"), "Succeeded")
+
+	def test_registry_exposes_pending_action_while_in_flight(self):
+		asset = self._stopped_asset("vm-pending")
+		frappe.set_user(self.owner)
+		try:
+			with patch("central.integrations.atlas.AtlasClient.vm_action", return_value="t"):
+				start_server(team=self.team.name, resource_id=asset)
+			rows = {a["resource_id"]: a for a in registry(team=self.team.name)["assets"]}
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(rows[asset]["pending_action"], "Starting")
+
+	def test_failed_command_marks_action_failed_with_envelope(self):
+		from central.integrations.atlas import AtlasError
+
+		asset = self._stopped_asset("vm-track-fail")
+		error = AtlasError("No capacity — retry shortly.")
+		error.envelope = {
+			"code": "ATLAS_REJECTED",
+			"message": "No capacity — retry shortly.",
+			"remediation": "",
+			"retriable": False,
+		}
+		frappe.set_user(self.owner)
+		try:
+			with patch("central.integrations.atlas.AtlasClient.vm_action", side_effect=error):
+				with self.assertRaises(AtlasError):
+					start_server(team=self.team.name, resource_id=asset)
+		finally:
+			frappe.set_user("Administrator")
+		action = frappe.get_doc("Resource Action", {"resource_id": asset, "action": "start"})
+		self.assertEqual((action.status, action.error_code), ("Failed", "ATLAS_REJECTED"))
+
+	def test_sweep_times_out_a_stuck_action(self):
+		action = frappe.get_doc(
+			{
+				"doctype": "Resource Action",
+				"resource_type": "Server",
+				"action": "start",
+				"team": self.team.name,
+				"resource_id": "vm-ghost",
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.set_value("Resource Action", action.name, "status", "Sent")
+		frappe.db.set_value("Resource Action", action.name, "creation", "2020-01-01 00:00:00")
+		swept = ResourceAction.sweep_stale(minutes=15)
+		self.assertGreaterEqual(swept, 1)
+		self.assertEqual(frappe.db.get_value("Resource Action", action.name, "status"), "Timed Out")
+
+	# --- site actions (self-serve / signup) -----------------------------------
+
+	def _single_team_user(self, email):
+		"""A user whose only team is the personal one auto-created on insert, so
+		resolve_team(user) is unambiguous — the self-serve/signup contract create_site uses."""
+		owner = ensure_user(email)
+		return owner, frappe.db.get_value("Team", {"owner_user": owner}, "name")
+
+	def test_create_site_tracks_a_site_action_and_confirms_on_running(self):
+		owner, team = self._single_team_user("site.creator@example.test")
+		mirror = {
+			"name": "acme.blr1.frappe.dev",
+			"fqdn": "acme.blr1.frappe.dev",
+			"team": team,
+			"subdomain": "acme",
+			"status": "Pending",
+		}
+		frappe.set_user(owner)
+		try:
+			with patch("central.integrations.atlas.AtlasClient.create_site", return_value=mirror) as create:
+				result = create_site(subdomain="acme")
+		finally:
+			frappe.set_user("Administrator")
+		action = frappe.get_doc("Resource Action", result["action"])
+		self.assertEqual((action.resource_type, action.action, action.status), ("Site", "create", "Sent"))
+		self.assertEqual(action.resource_id, "acme.blr1.frappe.dev")
+		self.assertEqual(create.call_args.kwargs["correlation_id"], action.name)
+		# Atlas echoes the correlation id on the site's Running event.
+		self._push(
+			"site.status_changed",
+			{
+				"name": "acme.blr1.frappe.dev",
+				"team": team,
+				"subdomain": "acme",
+				"status": "Running",
+				"correlation_id": result["action"],
+			},
+			"2026-07-02 10:05:00",
+		)
+		self.assertEqual(frappe.db.get_value("Resource Action", result["action"], "status"), "Succeeded")
+
+	def test_terminate_site_tracks_and_confirms_on_terminated(self):
+		owner, team = self._single_team_user("site.remover@example.test")
+		self._push(
+			"site.created",
+			{"name": "bye.blr1.frappe.dev", "team": team, "subdomain": "bye", "status": "Running"},
+			"2026-07-02 09:00:00",
+		)
+		frappe.set_user(owner)
+		try:
+			with patch("central.integrations.atlas.AtlasClient.terminate_site", return_value={}):
+				result = terminate_site(name="bye.blr1.frappe.dev")
+		finally:
+			frappe.set_user("Administrator")
+		action = frappe.get_doc("Resource Action", result["action"])
+		self.assertEqual((action.resource_type, action.action, action.status), ("Site", "terminate", "Sent"))
+		self._push(
+			"site.status_changed",
+			{
+				"name": "bye.blr1.frappe.dev",
+				"team": self.team.name,
+				"subdomain": "bye",
+				"status": "Terminated",
+				"correlation_id": result["action"],
+			},
+			"2026-07-02 10:00:00",
+		)
+		self.assertEqual(frappe.db.get_value("Resource Action", result["action"], "status"), "Succeeded")

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -833,11 +833,12 @@ class TestAtlasMirror(IntegrationTestCase):
 				result = start_server(team=self.team.name, resource_id=asset)
 		finally:
 			frappe.set_user("Administrator")
-		action = frappe.get_doc("Resource Action", result["action"])
+		action = frappe.get_doc("Resource Action", {"correlation_id": result["action"]})
 		self.assertEqual((action.action, action.status, action.resource_id), ("start", "Sent", asset))
 		self.assertEqual(action.atlas_task, "task-7")
-		# The correlation id sent to Atlas is the action's own name.
-		self.assertEqual(vm_action.call_args.kwargs["correlation_id"], action.name)
+		# The id returned to the client is the correlation id sent to Atlas.
+		self.assertEqual(vm_action.call_args.kwargs["correlation_id"], result["action"])
+		self.assertEqual(action.correlation_id, result["action"])
 
 	def test_confirming_event_marks_action_succeeded(self):
 		asset = self._stopped_asset("vm-track-ok")
@@ -853,7 +854,10 @@ class TestAtlasMirror(IntegrationTestCase):
 			{"name": asset, "team": self.team.name, "status": "Running", "correlation_id": result["action"]},
 			"2026-07-02 10:05:00",
 		)
-		self.assertEqual(frappe.db.get_value("Resource Action", result["action"], "status"), "Succeeded")
+		self.assertEqual(
+			frappe.db.get_value("Resource Action", {"correlation_id": result["action"]}, "status"),
+			"Succeeded",
+		)
 
 	def test_terminate_action_succeeds_on_delete_event(self):
 		asset = self._stopped_asset("vm-track-term")
@@ -864,7 +868,10 @@ class TestAtlasMirror(IntegrationTestCase):
 		finally:
 			frappe.set_user("Administrator")
 		self._push("vm.deleted", {"name": asset, "correlation_id": result["action"]}, "2026-07-02 11:00:00")
-		self.assertEqual(frappe.db.get_value("Resource Action", result["action"], "status"), "Succeeded")
+		self.assertEqual(
+			frappe.db.get_value("Resource Action", {"correlation_id": result["action"]}, "status"),
+			"Succeeded",
+		)
 
 	def test_registry_exposes_pending_action_while_in_flight(self):
 		asset = self._stopped_asset("vm-pending")
@@ -877,7 +884,7 @@ class TestAtlasMirror(IntegrationTestCase):
 			frappe.set_user("Administrator")
 		self.assertEqual(rows[asset]["pending_action"], "Starting")
 
-	def test_failed_command_marks_action_failed_with_envelope(self):
+	def test_rejected_command_surfaces_envelope_and_opens_no_row(self):
 		from central.integrations.atlas import AtlasError
 
 		asset = self._stopped_asset("vm-track-fail")
@@ -891,12 +898,14 @@ class TestAtlasMirror(IntegrationTestCase):
 		frappe.set_user(self.owner)
 		try:
 			with patch("central.integrations.atlas.AtlasClient.vm_action", side_effect=error):
-				with self.assertRaises(AtlasError):
+				with self.assertRaises(AtlasError) as caught:
 					start_server(team=self.team.name, resource_id=asset)
 		finally:
 			frappe.set_user("Administrator")
-		action = frappe.get_doc("Resource Action", {"resource_id": asset, "action": "start"})
-		self.assertEqual((action.status, action.error_code), ("Failed", "ATLAS_REJECTED"))
+		# A synchronous rejection surfaces the envelope and opens no tracking row — nothing is
+		# in flight, so there is nothing for the sweep to later false-time-out.
+		self.assertEqual(caught.exception.envelope["code"], "ATLAS_REJECTED")
+		self.assertFalse(frappe.db.exists("Resource Action", {"resource_id": asset, "action": "start"}))
 
 	def test_sweep_times_out_a_stuck_action(self):
 		action = frappe.get_doc(
@@ -906,9 +915,10 @@ class TestAtlasMirror(IntegrationTestCase):
 				"action": "start",
 				"team": self.team.name,
 				"resource_id": "vm-ghost",
+				"correlation_id": frappe.generate_hash(),
+				"status": "Sent",
 			}
 		).insert(ignore_permissions=True)
-		frappe.db.set_value("Resource Action", action.name, "status", "Sent")
 		frappe.db.set_value("Resource Action", action.name, "creation", "2020-01-01 00:00:00")
 		swept = ResourceAction.sweep_stale(minutes=15)
 		self.assertGreaterEqual(swept, 1)
@@ -937,10 +947,10 @@ class TestAtlasMirror(IntegrationTestCase):
 				result = create_site(subdomain="acme")
 		finally:
 			frappe.set_user("Administrator")
-		action = frappe.get_doc("Resource Action", result["action"])
+		action = frappe.get_doc("Resource Action", {"correlation_id": result["action"]})
 		self.assertEqual((action.resource_type, action.action, action.status), ("Site", "create", "Sent"))
 		self.assertEqual(action.resource_id, "acme.blr1.frappe.dev")
-		self.assertEqual(create.call_args.kwargs["correlation_id"], action.name)
+		self.assertEqual(create.call_args.kwargs["correlation_id"], result["action"])
 		# Atlas echoes the correlation id on the site's Running event.
 		self._push(
 			"site.status_changed",
@@ -953,7 +963,10 @@ class TestAtlasMirror(IntegrationTestCase):
 			},
 			"2026-07-02 10:05:00",
 		)
-		self.assertEqual(frappe.db.get_value("Resource Action", result["action"], "status"), "Succeeded")
+		self.assertEqual(
+			frappe.db.get_value("Resource Action", {"correlation_id": result["action"]}, "status"),
+			"Succeeded",
+		)
 
 	def test_terminate_site_tracks_and_confirms_on_terminated(self):
 		owner, team = self._single_team_user("site.remover@example.test")
@@ -968,7 +981,7 @@ class TestAtlasMirror(IntegrationTestCase):
 				result = terminate_site(name="bye.blr1.frappe.dev")
 		finally:
 			frappe.set_user("Administrator")
-		action = frappe.get_doc("Resource Action", result["action"])
+		action = frappe.get_doc("Resource Action", {"correlation_id": result["action"]})
 		self.assertEqual((action.resource_type, action.action, action.status), ("Site", "terminate", "Sent"))
 		self._push(
 			"site.status_changed",
@@ -981,7 +994,35 @@ class TestAtlasMirror(IntegrationTestCase):
 			},
 			"2026-07-02 10:00:00",
 		)
-		self.assertEqual(frappe.db.get_value("Resource Action", result["action"], "status"), "Succeeded")
+		self.assertEqual(
+			frappe.db.get_value("Resource Action", {"correlation_id": result["action"]}, "status"),
+			"Succeeded",
+		)
+
+	def test_create_opens_no_row_when_a_post_accept_step_fails(self):
+		# Regression: create_site commits internally, so a row inserted *before* the Atlas call
+		# would be frozen mid-flight if a later step threw — the sweep would then false-time-out
+		# a create that never tracked anything. Opening the row only after the whole create
+		# succeeds means a post-accept failure simply leaves no orphan row to strand.
+		owner, team = self._single_team_user("site.halfway@example.test")
+		mirror = {
+			"name": "half.blr1.frappe.dev",
+			"fqdn": "half.blr1.frappe.dev",
+			"team": team,
+			"subdomain": "half",
+			"status": "Pending",
+		}
+		frappe.set_user(owner)
+		try:
+			with patch("central.integrations.atlas.AtlasClient.create_site", return_value=mirror):
+				with patch(
+					"central.central.doctype.site.site.Site.mirror_site", side_effect=RuntimeError("boom")
+				):
+					with self.assertRaises(Exception):
+						create_site(subdomain="half")
+		finally:
+			frappe.set_user("Administrator")
+		self.assertFalse(frappe.db.exists("Resource Action", {"resource_id": "half.blr1.frappe.dev"}))
 
 
 class TestTerminateIdempotency(IntegrationTestCase):
@@ -1043,7 +1084,10 @@ class TestTerminateIdempotency(IntegrationTestCase):
 		finally:
 			frappe.set_user("Administrator")
 		self.assertEqual(frappe.db.get_value("Asset", asset, "status"), "Terminated")
-		self.assertEqual(frappe.db.get_value("Resource Action", result["action"], "status"), "Succeeded")
+		self.assertEqual(
+			frappe.db.get_value("Resource Action", {"correlation_id": result["action"]}, "status"),
+			"Succeeded",
+		)
 
 	def test_start_still_errors_when_atlas_says_gone(self):
 		from central.integrations.atlas import AtlasResourceGone

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -614,11 +614,28 @@ class TestAtlasMirror(IntegrationTestCase):
 		# nothing written on the request thread — the worker does it
 		self.assertFalse(frappe.db.exists("Asset", "vm-q"))
 
-	def test_unknown_event_type_is_acked_without_queuing(self):
+	def test_unknown_event_type_is_recorded_ignored_not_queued(self):
+		# A type Central doesn't mirror yet is stored Ignored (audit trail stays complete),
+		# but never queued for a mirror write — so a missing handler can't strand a row.
 		frappe.set_user(self.service_user)
 		try:
 			with patch("frappe.enqueue") as enqueue:
-				result = ingest_event(self.region, "vm.rebooted", {"name": "vm-z"}, "2026-06-18 10:00:00")
+				result = ingest_event(
+					self.region, "vm.rebooted", {"name": "vm-z"}, "2026-06-18 10:00:00", "evt-unknown-1"
+				)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(result, {"ok": True, "queued": False})
+		enqueue.assert_not_called()
+		self.assertEqual(frappe.db.get_value("Atlas Event", {"event_id": "evt-unknown-1"}, "status"), "Ignored")
+
+	def test_event_without_id_is_acked_without_storing(self):
+		# A validly-signed but malformed event (no id/type) can't be deduped or stored —
+		# ack it so Atlas stops retrying, and write nothing.
+		frappe.set_user(self.service_user)
+		try:
+			with patch("frappe.enqueue") as enqueue:
+				result = ingest_event(self.region, None, {}, "2026-06-18 10:00:00", None)
 		finally:
 			frappe.set_user("Administrator")
 		self.assertEqual(result, {"ok": True, "queued": False})

--- a/central/tests/test_atlas_sync.py
+++ b/central/tests/test_atlas_sync.py
@@ -790,6 +790,19 @@ class TestAtlasMirror(IntegrationTestCase):
 		with self.assertRaisesRegex(frappe.ValidationError, "resizing"):
 			start_server(team=self.team.name, resource_id=asset)
 
+	def test_blocked_action_reaches_the_client_as_an_envelope(self):
+		# The whole point of the server-action wiring: a blocked action surfaces a stable
+		# code + clean message, not a bare FrappeException.
+		asset = self._stopped_asset("vm-resizing-env", resize_in_progress=1)
+		frappe.set_user(self.owner)
+		try:
+			with self.assertRaises(frappe.ValidationError) as caught:
+				start_server(team=self.team.name, resource_id=asset)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(caught.exception.envelope["code"], "SERVER_BUSY_RESIZING")
+		self.assertEqual(frappe.message_log[-1]["server_action_error"]["code"], "SERVER_BUSY_RESIZING")
+
 	def test_start_allowed_once_resize_clears(self):
 		asset = self._stopped_asset("vm-idle", resize_in_progress=0)
 		frappe.set_user(self.owner)

--- a/central/tests/test_atlas_webhook_signature.py
+++ b/central/tests/test_atlas_webhook_signature.py
@@ -230,8 +230,12 @@ class TestEventEndpointSignatureGate(IntegrationTestCase):
 		).encode()
 		with patch("frappe.enqueue") as enqueue:
 			result = self._post(body)
-		self.assertEqual(result, {"ok": True, "queued": False})  # vm.rebooted isn't a known handler
+		# vm.rebooted isn't a known handler: recorded Ignored for the audit trail, never queued.
+		self.assertEqual(result, {"ok": True, "queued": False})
 		enqueue.assert_not_called()
+		self.assertEqual(
+			frappe.db.get_value("Atlas Event", {"event_id": "evt-e2e-1"}, "status"), "Ignored"
+		)
 
 	def test_badly_signed_post_is_rejected_before_any_write(self) -> None:
 		# The gate throws rather than returning a body: the decorator runs before the

--- a/central/tests/test_errors.py
+++ b/central/tests/test_errors.py
@@ -1,0 +1,118 @@
+"""The server-flow error envelope: known failures become clean, structured messages,
+and no action ever reaches the user as a bare exception or raw traceback."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from central.errors import (
+	ENVELOPE_KEY,
+	ERROR_CATALOG,
+	ServerActionError,
+	build_envelope,
+	server_action,
+	throw_action_error,
+	to_error_response,
+)
+
+
+class TestErrorCatalog(IntegrationTestCase):
+	def test_every_catalog_entry_is_complete(self):
+		for code, entry in ERROR_CATALOG.items():
+			for key in ("title", "message", "remediation", "retriable"):
+				self.assertIn(key, entry, f"{code} missing {key}")
+
+	def test_build_envelope_fills_context_and_keeps_shape(self):
+		env = build_envelope("SERVER_NOT_FOUND", resource_id="vm-9")
+		self.assertEqual(env["code"], "SERVER_NOT_FOUND")
+		self.assertIn("vm-9", env["message"])
+		self.assertFalse(env["retriable"])
+		self.assertTrue(env["title"])
+
+	def test_missing_placeholder_renders_empty_not_crash(self):
+		env = build_envelope("SERVER_NOT_FOUND")
+		self.assertEqual(env["code"], "SERVER_NOT_FOUND")
+
+	def test_message_override_wins(self):
+		env = build_envelope("ATLAS_REJECTED", message="No capacity — retry shortly.", action="create this server")
+		self.assertEqual(env["message"], "No capacity — retry shortly.")
+		self.assertIn("create this server", env["title"])
+
+	def test_unknown_code_falls_back_to_unexpected(self):
+		self.assertEqual(build_envelope("NOPE")["code"], "UNEXPECTED")
+
+
+class TestThrowActionError(IntegrationTestCase):
+	def setUp(self):
+		frappe.clear_messages()
+
+	def test_carries_envelope_on_the_message_log(self):
+		with self.assertRaises(ServerActionError) as caught:
+			throw_action_error("SERVER_BUSY_RESIZING", action="start")
+		self.assertEqual(caught.exception.envelope["code"], "SERVER_BUSY_RESIZING")
+		self.assertEqual(frappe.message_log[-1][ENVELOPE_KEY]["code"], "SERVER_BUSY_RESIZING")
+
+	def test_exc_override_keeps_the_status_type(self):
+		with self.assertRaises(frappe.PermissionError):
+			throw_action_error("PERMISSION_DENIED", exc=frappe.PermissionError, action="terminate")
+
+
+class TestToErrorResponse(IntegrationTestCase):
+	def test_preserves_a_user_facing_validation_message(self):
+		env = to_error_response(frappe.ValidationError("Disk can't shrink below 40 GB."))
+		self.assertEqual(env["code"], "VALIDATION_ERROR")
+		self.assertIn("shrink", env["message"])
+
+	def test_permission_maps_to_permission_denied(self):
+		self.assertEqual(to_error_response(frappe.PermissionError("nope"))["code"], "PERMISSION_DENIED")
+
+	def test_unexpected_error_is_logged_and_generalised(self):
+		with patch("central.errors.frappe.log_error") as log:
+			env = to_error_response(KeyError("internal detail"))
+		self.assertEqual(env["code"], "UNEXPECTED")
+		self.assertNotIn("internal detail", env["message"])
+		log.assert_called_once()
+
+	def test_prebuilt_envelope_passes_through(self):
+		error = ServerActionError("x")
+		error.envelope = {"code": "ATLAS_REJECTED"}
+		self.assertEqual(to_error_response(error)["code"], "ATLAS_REJECTED")
+
+
+class TestServerActionDecorator(IntegrationTestCase):
+	def setUp(self):
+		frappe.clear_messages()
+
+	def test_unexpected_exception_becomes_a_clean_envelope(self):
+		@server_action
+		def boom():
+			raise KeyError("internal detail")
+
+		with patch("central.errors.frappe.log_error"):
+			with self.assertRaises(ServerActionError) as caught:
+				boom()
+		self.assertEqual(caught.exception.envelope["code"], "UNEXPECTED")
+		# The raw exception text must never surface to the user.
+		self.assertNotIn("internal detail", caught.exception.envelope["message"])
+
+	def test_clean_validation_error_passes_through_enriched(self):
+		@server_action
+		def bad():
+			frappe.throw("Region is required.", frappe.ValidationError)
+
+		with self.assertRaises(frappe.ValidationError) as caught:
+			bad()
+		self.assertEqual(caught.exception.envelope["code"], "VALIDATION_ERROR")
+		self.assertIn("Region is required", str(caught.exception))
+
+	def test_prebuilt_error_is_not_reprocessed(self):
+		@server_action
+		def rejected():
+			throw_action_error("ATLAS_REJECTED", message="No capacity.", action="create this server")
+
+		with self.assertRaises(ServerActionError) as caught:
+			rejected()
+		self.assertEqual(caught.exception.envelope["message"], "No capacity.")

--- a/central/tests/test_errors.py
+++ b/central/tests/test_errors.py
@@ -61,6 +61,15 @@ class TestThrowActionError(IntegrationTestCase):
 		with self.assertRaises(frappe.PermissionError):
 			throw_action_error("PERMISSION_DENIED", exc=frappe.PermissionError, action="terminate")
 
+	def test_surfaced_message_folds_in_the_remediation(self):
+		# frappe-ui drops the structured envelope, so the "how to resolve" has to ride the
+		# message the client actually reads.
+		with self.assertRaises(frappe.PermissionError):
+			throw_action_error("PERMISSION_DENIED", exc=frappe.PermissionError, action="terminate")
+		surfaced = frappe.message_log[-1]["message"]
+		self.assertIn("isn't allowed to terminate", surfaced)
+		self.assertIn("Ask a team admin", surfaced)
+
 
 class TestToErrorResponse(IntegrationTestCase):
 	def test_preserves_a_user_facing_validation_message(self):

--- a/central/tests/test_errors.py
+++ b/central/tests/test_errors.py
@@ -11,9 +11,9 @@ from frappe.tests import IntegrationTestCase
 from central.errors import (
 	ENVELOPE_KEY,
 	ERROR_CATALOG,
-	ServerActionError,
+	ResourceActionError,
 	build_envelope,
-	server_action,
+	resource_action,
 	throw_action_error,
 	to_error_response,
 )
@@ -37,7 +37,9 @@ class TestErrorCatalog(IntegrationTestCase):
 		self.assertEqual(env["code"], "SERVER_NOT_FOUND")
 
 	def test_message_override_wins(self):
-		env = build_envelope("ATLAS_REJECTED", message="No capacity — retry shortly.", action="create this server")
+		env = build_envelope(
+			"ATLAS_REJECTED", message="No capacity — retry shortly.", action="create this server"
+		)
 		self.assertEqual(env["message"], "No capacity — retry shortly.")
 		self.assertIn("create this server", env["title"])
 
@@ -50,7 +52,7 @@ class TestThrowActionError(IntegrationTestCase):
 		frappe.clear_messages()
 
 	def test_carries_envelope_on_the_message_log(self):
-		with self.assertRaises(ServerActionError) as caught:
+		with self.assertRaises(ResourceActionError) as caught:
 			throw_action_error("SERVER_BUSY_RESIZING", action="start")
 		self.assertEqual(caught.exception.envelope["code"], "SERVER_BUSY_RESIZING")
 		self.assertEqual(frappe.message_log[-1][ENVELOPE_KEY]["code"], "SERVER_BUSY_RESIZING")
@@ -77,29 +79,29 @@ class TestToErrorResponse(IntegrationTestCase):
 		log.assert_called_once()
 
 	def test_prebuilt_envelope_passes_through(self):
-		error = ServerActionError("x")
+		error = ResourceActionError("x")
 		error.envelope = {"code": "ATLAS_REJECTED"}
 		self.assertEqual(to_error_response(error)["code"], "ATLAS_REJECTED")
 
 
-class TestServerActionDecorator(IntegrationTestCase):
+class TestResourceActionDecorator(IntegrationTestCase):
 	def setUp(self):
 		frappe.clear_messages()
 
 	def test_unexpected_exception_becomes_a_clean_envelope(self):
-		@server_action
+		@resource_action
 		def boom():
 			raise KeyError("internal detail")
 
 		with patch("central.errors.frappe.log_error"):
-			with self.assertRaises(ServerActionError) as caught:
+			with self.assertRaises(ResourceActionError) as caught:
 				boom()
 		self.assertEqual(caught.exception.envelope["code"], "UNEXPECTED")
 		# The raw exception text must never surface to the user.
 		self.assertNotIn("internal detail", caught.exception.envelope["message"])
 
 	def test_clean_validation_error_passes_through_enriched(self):
-		@server_action
+		@resource_action
 		def bad():
 			frappe.throw("Region is required.", frappe.ValidationError)
 
@@ -109,10 +111,10 @@ class TestServerActionDecorator(IntegrationTestCase):
 		self.assertIn("Region is required", str(caught.exception))
 
 	def test_prebuilt_error_is_not_reprocessed(self):
-		@server_action
+		@resource_action
 		def rejected():
 			throw_action_error("ATLAS_REJECTED", message="No capacity.", action="create this server")
 
-		with self.assertRaises(ServerActionError) as caught:
+		with self.assertRaises(ResourceActionError) as caught:
 			rejected()
 		self.assertEqual(caught.exception.envelope["message"], "No capacity.")

--- a/dashboard/src/components/common/ConfirmDialog.vue
+++ b/dashboard/src/components/common/ConfirmDialog.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts" generic="T">
-import { Dialog } from 'frappe-ui'
+import { Dialog, ErrorMessage } from 'frappe-ui'
 import { computed } from 'vue'
 
 // One confirm dialog for the "hold a pending target, ask before acting" pattern.
 // Controlled by the caller: bind the pending item (or null) with v-model:target —
 // null closes it. Emits confirm(target) for the caller to run the mutation; pass
-// :loading while it runs. Body is the message prop, or a default slot for richer copy.
+// :loading while it runs. On failure the caller keeps the target set and passes :error,
+// so the dialog stays open with the reason inline instead of vanishing behind a toast.
 const props = withDefaults(
 	defineProps<{
 		target: T | null
@@ -15,6 +16,7 @@ const props = withDefaults(
 		/** Set 'red' for a destructive action; omit for a neutral solid confirm. */
 		theme?: 'red'
 		loading?: boolean
+		error?: string
 	}>(),
 	{ confirmLabel: 'Confirm' },
 )
@@ -53,5 +55,6 @@ const actions = computed(() => [
 		:actions="actions"
 	>
 		<slot />
+		<ErrorMessage v-if="error" class="mt-2" :message="error" />
 	</Dialog>
 </template>

--- a/dashboard/src/components/servers/ServerRowActions.vue
+++ b/dashboard/src/components/servers/ServerRowActions.vue
@@ -47,6 +47,9 @@ const options = computed(() => {
 		icon: 'lucide-gauge',
 		onClick: () => emit('overview', props.server),
 	})
+	// An action is in flight (Provisioning/Starting/Terminating/…): offer nothing else until
+	// it settles, mirroring the API which rejects a second command mid-flight.
+	if (props.server.pending_action) return items
 	// Mid-resize the VM is power-cycling in the background: power + resize actions are
 	// blocked (the API rejects them too) until the reshape job clears the flag.
 	const resizing = isResizing(props.server)

--- a/dashboard/src/components/servers/SiteRowActions.vue
+++ b/dashboard/src/components/servers/SiteRowActions.vue
@@ -6,7 +6,7 @@ import RowActionsMenu from '@/components/common/RowActionsMenu.vue'
 // 1:1-backed VM, so it reuses the server capabilities (site-level caps are
 // deferred). Presentational — it emits the verb; the page owns the calls.
 const props = defineProps<{
-	site: { name: string; url: string | null }
+	site: { name: string; url: string | null; pending_action?: string | null }
 	canOpen: boolean
 	canTerminate: boolean
 	busy?: boolean
@@ -25,7 +25,9 @@ const options = computed(() => {
 			icon: 'lucide-external-link',
 			onClick: () => emit('open', props.site.name),
 		})
-	if (props.canTerminate)
+	// An action is in flight: don't offer Terminate until it settles, mirroring the API
+	// which rejects a second command mid-flight (same rule as ServerRowActions).
+	if (props.canTerminate && !props.site.pending_action)
 		items.push({
 			label: 'Terminate',
 			icon: 'lucide-trash-2',

--- a/dashboard/src/composables/useFleetRows.ts
+++ b/dashboard/src/composables/useFleetRows.ts
@@ -54,7 +54,7 @@ export function useFleetRows(
 				// The user-entered name ("demo.in"); the full FQDN drops to the secondary
 				// line (specs) so a site reads like the VM it is, not a routing string.
 				name: site.subdomain || site.name,
-				visual: siteVisual(site.status),
+				visual: siteVisual(site.status, site.pending_action),
 				specs: site.name,
 				cluster: site.region ?? '',
 				region,

--- a/dashboard/src/composables/useFleetRows.ts
+++ b/dashboard/src/composables/useFleetRows.ts
@@ -61,7 +61,11 @@ export function useFleetRows(
 				regionLabel: region ? regionLabel(region) : (site.region ?? ''),
 				flag: flagEmoji(region?.country_code),
 				provider: region?.provider ?? null,
-				site: { name: site.name, url: site.url },
+				site: {
+					name: site.name,
+					url: site.url,
+					pending_action: site.pending_action,
+				},
 			}
 		}),
 	)

--- a/dashboard/src/composables/useServerMapData.ts
+++ b/dashboard/src/composables/useServerMapData.ts
@@ -21,6 +21,8 @@ export interface SiteRow {
 	status: string
 	region: string | null
 	url: string | null
+	// Transitional label while a site action is in flight (see AssetRow.pending_action).
+	pending_action?: string | null
 }
 
 type RegistryResponse = { team: string; assets: AssetRow[]; sites: SiteRow[] }

--- a/dashboard/src/composables/useServers.ts
+++ b/dashboard/src/composables/useServers.ts
@@ -27,7 +27,12 @@ export type AssetRow = Pick<
 	| 'gateway_url'
 	| 'resize_in_progress'
 	| 'last_synced_at'
->
+> & {
+	// Transitional label ("Terminating"/"Provisioning"/…) while an action is in flight.
+	// Overlaid by central.api.servers.registry from the active Resource Action, not an
+	// Asset field — so the row reads as "…ing" until the mirror catches up.
+	pending_action?: string | null
+}
 
 // The server lifecycle command path (create / power / terminate / open-in-bench /
 // mirror refresh). The fleet *list* is read separately through useServerMapData;

--- a/dashboard/src/composables/useServers.ts
+++ b/dashboard/src/composables/useServers.ts
@@ -122,6 +122,9 @@ async function runCommand(
 	call: typeof startCall,
 	server: AssetRow,
 	verb: Verb,
+	// A quick, reversible power action toasts on failure; a destructive one (terminate)
+	// throws so the caller can hold its confirm dialog open and show the reason inline.
+	surface: 'toast' | 'throw' = 'toast',
 ): Promise<void> {
 	busy.value = server.resource_id
 	try {
@@ -131,8 +134,12 @@ async function runCommand(
 			resource_id: server.resource_id,
 		})
 		if (call.error) throw call.error
-		successToast(`${verb} requested for ${server.title || server.resource_id}`)
+		if (surface === 'toast')
+			successToast(
+				`${verb} requested for ${server.title || server.resource_id}`,
+			)
 	} catch (e) {
+		if (surface === 'throw') throw e
 		errorToast(e)
 	} finally {
 		busy.value = ''
@@ -156,7 +163,7 @@ export function useServers() {
 		return runCommand(stopCall, server, 'Stop')
 	}
 	function terminate(server: AssetRow) {
-		return runCommand(terminateCall, server, 'Terminate')
+		return runCommand(terminateCall, server, 'Terminate', 'throw')
 	}
 
 	// Open the VM's bench via a scoped SSO assertion. The tab is opened

--- a/dashboard/src/lib/serverMap.ts
+++ b/dashboard/src/lib/serverMap.ts
@@ -179,7 +179,7 @@ export interface MapPin {
 	/** The raw asset row, for the server actions menu the page wires in. */
 	server?: AssetRow
 	// — Site-only (undefined on server pins) —
-	site?: { name: string; url: string | null }
+	site?: { name: string; url: string | null; pending_action?: string | null }
 }
 
 /** A server or site decorated into one list/map shape. A site is a 1:1-backed VM,
@@ -197,7 +197,7 @@ export interface ResourceRow {
 	flag: string
 	provider: string | null
 	asset?: AssetRow
-	site?: { name: string; url: string | null }
+	site?: { name: string; url: string | null; pending_action?: string | null }
 }
 
 /** An empty Active region — a "+" affordance on the map. */

--- a/dashboard/src/lib/serverMap.ts
+++ b/dashboard/src/lib/serverMap.ts
@@ -78,6 +78,17 @@ const STATUS_VISUAL: Record<string, ServerVisual> = {
 }
 
 export function statusVisual(server: AssetRow): ServerVisual {
+	// A live action wins: show its transitional label, pulsing to read as "working now",
+	// from the click until the mirror confirms — so the row never looks like nothing happened.
+	if (server.pending_action) {
+		return {
+			key: 'settingUp',
+			label: server.pending_action,
+			badgeTheme: 'amber',
+			dot: 'var(--ink-amber-6)',
+			pulse: true,
+		}
+	}
 	if (isResizing(server)) return VISUALS.resizing
 	return STATUS_VISUAL[displayStatus(server)] ?? VISUALS.settingUp
 }
@@ -432,7 +443,19 @@ export function computeNodes({
 
 // A site's status mapped onto the shared server visual vocabulary, so the unified
 // assets list (and its status filter) can treat a site like the VM it is.
-export function siteVisual(status: string): ServerVisual {
+export function siteVisual(
+	status: string,
+	pendingAction?: string | null,
+): ServerVisual {
+	// A live site action wins, same as servers — show its label, pulsing, until the mirror confirms.
+	if (pendingAction)
+		return {
+			key: 'settingUp',
+			label: pendingAction,
+			badgeTheme: 'amber',
+			dot: 'var(--ink-amber-6)',
+			pulse: true,
+		}
 	if (status === 'Running')
 		return {
 			key: 'active',

--- a/dashboard/src/lib/status.ts
+++ b/dashboard/src/lib/status.ts
@@ -13,11 +13,14 @@ export function isResizing(server: { resize_in_progress?: 0 | 1 }): boolean {
 	return server.resize_in_progress === 1
 }
 
-/** The status to show for a row: "Resizing" while a reshape job runs, else the mirror. */
+/** The status to show for a row: a live action's transitional label ("Terminating"…)
+ *  takes precedence, then "Resizing" while a reshape job runs, else the mirror status. */
 export function displayStatus(server: {
 	status?: AssetStatus
 	resize_in_progress?: 0 | 1
-}): AssetStatus {
+	pending_action?: string | null
+}): string {
+	if (server.pending_action) return server.pending_action
 	return isResizing(server) ? 'Resizing' : (server.status ?? 'Pending')
 }
 
@@ -93,5 +96,10 @@ export function paymentAttemptDisplay(status: string | null | undefined): {
 	theme: BadgeTheme
 } {
 	const key = String(status ?? '').toLowerCase()
-	return ATTEMPT_DISPLAY[key] ?? { label: String(status ?? 'Unknown'), theme: 'gray' }
+	return (
+		ATTEMPT_DISPLAY[key] ?? {
+			label: String(status ?? 'Unknown'),
+			theme: 'gray',
+		}
+	)
 }

--- a/dashboard/src/pages/servers/NewServerPage.vue
+++ b/dashboard/src/pages/servers/NewServerPage.vue
@@ -425,7 +425,7 @@ async function submit() {
 								type="text"
 								placeholder="e.g. Acme Production"
 								:maxlength="60"
-								class="mt-2 max-w-xs"
+								class="mt-2 max-w-xs auto-f" autofocus
 							/>
 							<div class="mt-3 max-w-xs">
 								<div class="flex items-center justify-between">

--- a/dashboard/src/pages/servers/ServersPage.vue
+++ b/dashboard/src/pages/servers/ServersPage.vue
@@ -33,7 +33,7 @@ import {
 	type ServerVisual,
 	STATUS_FILTERS,
 } from '@/lib/serverMap'
-import { errorToast, successToast } from '@/lib/toast'
+import { errorToast, getErrorMessage, successToast } from '@/lib/toast'
 import type { Region } from '@/types/Central/Region'
 import signingInHtml from './signing-in.html?raw'
 
@@ -306,9 +306,25 @@ const doStart = (server: AssetRow): Promise<void> => withReload(start(server))
 const doStop = (server: AssetRow): Promise<void> => withReload(stop(server))
 
 const pendingTerminate = ref<AssetRow | null>(null)
+const terminateError = ref('')
+// Reset the inline error whenever the dialog opens on a different server or closes.
+watch(pendingTerminate, () => {
+	terminateError.value = ''
+})
 async function confirmTerminate(server: AssetRow): Promise<void> {
-	pendingTerminate.value = null
-	await withReload(terminate(server))
+	terminateError.value = ''
+	try {
+		// Destructive: keep the dialog open and show the reason inline on failure, rather
+		// than closing and firing a toast the user may miss. The row then shows "Terminating…".
+		await terminate(server)
+		pendingTerminate.value = null
+		reload()
+	} catch (e) {
+		terminateError.value = getErrorMessage(
+			e,
+			"We couldn't terminate this server.",
+		)
+	}
 }
 
 const pendingResize = ref<AssetRow | null>(null)
@@ -526,6 +542,7 @@ async function confirmSiteTerminate(): Promise<void> {
 			confirm-label="Yes, terminate"
 			theme="red"
 			:loading="busy === pendingTerminate?.resource_id"
+			:error="terminateError"
 			@confirm="confirmTerminate"
 		>
 			<p class="text-p-base text-ink-gray-7">

--- a/dashboard/src/types/Central/ResourceAction.ts
+++ b/dashboard/src/types/Central/ResourceAction.ts
@@ -1,0 +1,40 @@
+export interface ResourceAction {
+	name: string
+	creation: string
+	modified: string
+	owner: string
+	modified_by: string
+	docstatus: 0 | 1 | 2
+	parent?: string
+	parentfield?: string
+	parenttype?: string
+	idx?: number
+	/**	Resource Type : Select	*/
+	resource_type: 'Server' | 'Site'
+	/**	Action : Select	*/
+	action: 'create' | 'start' | 'stop' | 'terminate' | 'resize'
+	/**	Team : Link - Team	*/
+	team: string
+	/**	Resource ID : Data - The server (VM id) or site (FQDN) this action targets, snapshotted so the row stays meaningful after the resource is gone.	*/
+	resource_id?: string
+	/**	Status : Select	*/
+	status:
+		| 'Queued'
+		| 'Sent'
+		| 'In Progress'
+		| 'Succeeded'
+		| 'Failed'
+		| 'Timed Out'
+	/**	Atlas Task : Data - The Atlas Task this action produced, for operator cross-reference.	*/
+	atlas_task?: string
+	/**	Completed At : Datetime	*/
+	completed_at?: string
+	/**	Error Code : Data - Stable error code from the failure envelope (central/errors.py).	*/
+	error_code?: string
+	/**	Retriable : Check	*/
+	retriable?: 0 | 1
+	/**	Error Message : Small Text	*/
+	error_message?: string
+	/**	Remediation : Small Text	*/
+	remediation?: string
+}


### PR DESCRIPTION
Adds structured, user-facing error handling and action tracking for the server/site flows.

- New Resource Action doctype tracks each server/site lifecycle action (create/start/stop/terminate) with a state machine and its outcome.
- Errors now return a clean envelope (code + message + how-to-fix) instead of raw FrappeExceptions. Explicit actions show errors inline; background ones toast. Closes #174 
Sends a correlation id to Atlas and matches the returning event back to its action, so outcomes (and failures) land on the right record.
- Console shows live "Provisioning/Starting/Stopping/Terminating…" badges and blocks a second action while one is in flight.
Records every inbound Atlas event (unknown types stored as Ignored, not dropped) and logs webhook rejections.

Fix: terminate is now idempotent — a resource already gone on Atlas (HTTP 404) succeeds and clears the mirror instead of showing a false "region unreachable"; Atlas HTTP errors are classified accurately (gone vs unreachable vs the region's own message).

This also has a counterpart in Atlas - 