### PR TITLE
refactor: Send telemetry endpoints to pilot

### DIFF
--- a/central/api/cargo.py
+++ b/central/api/cargo.py
@@ -26,7 +26,7 @@ def garage_tokens(region: str, vm_ids: list[str] | None = None) -> dict:
 # nosemgrep: guest-whitelisted-method -- verify_cargo_request authenticates the caller below.
 @frappe.whitelist(allow_guest=True, methods=["POST"])
 @verify_cargo_request
-def register_cluster(
+def register_storage_cluster(
 	region: str,
 	active: bool = True,
 	base_url: str = "",

--- a/central/api/cargo.py
+++ b/central/api/cargo.py
@@ -47,6 +47,21 @@ def register_cluster(
 	return record_cluster_status(region, active, base_url, s3_endpoint, web_endpoint)
 
 
+# nosemgrep: guest-whitelisted-method -- verify_cargo_request authenticates the caller below.
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+@verify_cargo_request
+def register_telemetry_service(region: str, telemetry_base_url: str = "") -> dict:
+	"""Tell Central where a region's telemetry service is, so pilots can ship metrics/logs.
+
+	`region` must be the one the caller's token was minted for. The row is the caller's own,
+	named by its token rather than rebuilt from the region it passed."""
+	instance: CargoInstance = frappe.get_doc("Cargo Instance", frappe.local.cargo_request.instance)
+	instance.telemetry_base_url = telemetry_base_url
+	instance.save(ignore_permissions=True)
+
+	return {"region": region, "telemetry_base_url": instance.telemetry_base_url}
+
+
 # nosemgrep: guest-whitelisted-method -- verify_cargo_bootstrapping_request authenticates the caller below.
 @frappe.whitelist(allow_guest=True, methods=["POST"])
 @verify_cargo_bootstrapping_request

--- a/central/api/pilot.py
+++ b/central/api/pilot.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 import frappe
 from frappe import _
 
+from central.central.doctype.cargo_instance.cargo_instance import CargoInstance
 from central.central.doctype.pilot_credential.pilot_credential import PilotCredential
 
 # The pilot→Central surface. The pilot (the on-VM agent, ~/pilot) authenticates with
@@ -32,6 +33,18 @@ def pilot_credential_auth(func: Callable) -> Callable:
 		return func(*args, **kwargs)
 
 	return wrapper
+
+
+def get_telemetry_base_url(credential: PilotCredential) -> str | None:
+	"""Where this pilot's region takes metrics and logs, or None until that region's Cargo
+	enrols. `Asset.cluster` is the Atlas Instance, which is named for its region, so the
+	region needs no lookup of its own."""
+	if not credential.asset:
+		return None
+
+	region = frappe.db.get_value("Asset", credential.asset, "cluster", cache=True)
+
+	return CargoInstance.telemetry_url_for(region) if region else None
 
 
 @frappe.whitelist(allow_guest=True, methods=["GET"])
@@ -72,11 +85,12 @@ def metrics_token() -> dict:
 	carry no resource id."""
 	from central.sso import METRICS_TTL, mint_metrics_token
 
-	credential = frappe.local.pilot_credential
+	credential: PilotCredential = frappe.local.pilot_credential
 	return {
 		"token": mint_metrics_token(credential.audience_id, credential.asset),
 		"expires_in": METRICS_TTL,
 		"resource_id": credential.asset,
+		"endpoint": get_telemetry_base_url(credential),
 	}
 
 
@@ -91,11 +105,12 @@ def log_token() -> dict:
 	401 or when the expiry nears, exactly as it does for metrics."""
 	from central.sso import LOG_TTL, mint_log_token
 
-	credential = frappe.local.pilot_credential
+	credential: PilotCredential = frappe.local.pilot_credential
 	return {
 		"token": mint_log_token(credential.audience_id, credential.asset),
 		"expires_in": LOG_TTL,
 		"resource_id": credential.asset,
+		"endpoint": get_telemetry_base_url(credential),
 	}
 
 

--- a/central/central/doctype/cargo_instance/cargo_instance.json
+++ b/central/central/doctype/cargo_instance/cargo_instance.json
@@ -1,13 +1,13 @@
 {
  "actions": [],
- "allow_rename": 0,
  "autoname": "format:CARGO-{region}",
- "creation": "2026-08-31 00:00:00.000000",
+ "creation": "2026-08-31 00:00:00",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
   "region",
   "base_url",
+  "telemetry_base_url",
   "column_break_head",
   "status",
   "registered_at",
@@ -88,15 +88,23 @@
    "fieldtype": "Password",
    "label": "Atlas Access Token",
    "read_only": 1
+  },
+  {
+   "description": "Cargo will set the telemetry base URL once it's ready",
+   "fieldname": "telemetry_base_url",
+   "fieldtype": "Data",
+   "label": "Telemetry Base URL",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-08-31 00:00:00.000000",
+ "modified": "2026-09-08 15:29:20.254410",
  "modified_by": "Administrator",
  "module": "Central",
  "name": "Cargo Instance",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {

--- a/central/central/doctype/cargo_instance/cargo_instance.py
+++ b/central/central/doctype/cargo_instance/cargo_instance.py
@@ -19,12 +19,28 @@ class CargoInstance(Document):
 		region: DF.Link
 		registered_at: DF.Datetime | None
 		status: DF.Literal["Draft", "Registered", "Disabled"]
+		telemetry_base_url: DF.Data | None
 	# end: auto-generated types
 
 	"""One Cargo host, and the region it provisions for.
 
 	Central never calls a Cargo host. It issues a short-lived bootstrapping token, and the
 	host spends it to collect the two tokens it runs on."""
+
+	@staticmethod
+	def telemetry_url_for(region: str) -> str | None:
+		"""Where a region's pilots ship metrics and logs, or None while that region has no
+		enrolled Cargo. Read by name -- the autoname is `CARGO-{region}` -- so it comes off
+		the request cache rather than the database on every token a pilot asks for."""
+		telemetry_base_url = frappe.db.get_value(
+			"Cargo Instance",
+			{"region": region, "status": "Registered"},
+			"telemetry_base_url",
+			as_dict=True,
+			cache=True,
+		)
+
+		return telemetry_base_url or None
 
 	@frappe.whitelist()
 	def issue_bootstrapping_token(self) -> dict:

--- a/central/central/doctype/cargo_instance/cargo_instance.py
+++ b/central/central/doctype/cargo_instance/cargo_instance.py
@@ -36,7 +36,6 @@ class CargoInstance(Document):
 			"Cargo Instance",
 			{"region": region, "status": "Registered"},
 			"telemetry_base_url",
-			as_dict=True,
 			cache=True,
 		)
 

--- a/central/central/doctype/cargo_instance/cargo_instance.py
+++ b/central/central/doctype/cargo_instance/cargo_instance.py
@@ -2,6 +2,10 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
+# Both URLs are handed onward -- one to pilots to post telemetry at, one to Central's own
+# callers. Without a scheme allowlist `validate_url` passes `javascript:` and `data:`.
+VALID_SCHEMES = ("http", "https")
+
 
 class CargoInstance(Document):
 	# begin: auto-generated types
@@ -26,6 +30,24 @@ class CargoInstance(Document):
 
 	Central never calls a Cargo host. It issues a short-lived bootstrapping token, and the
 	host spends it to collect the two tokens it runs on."""
+
+	def validate(self) -> None:
+		self.validate_base_url()
+		self.validate_telemetry_url()
+
+	def validate_telemetry_url(self) -> None:
+		"""If a telemetry URL is given, it must be a valid URL. If not given, it is cleared."""
+		self.telemetry_base_url = (self.telemetry_base_url or "").strip().rstrip("/") or None
+		if self.telemetry_base_url and not frappe.utils.validate_url(
+			self.telemetry_base_url, valid_schemes=VALID_SCHEMES
+		):
+			frappe.throw(_("Telemetry URL must be a valid URL."), frappe.ValidationError)
+
+	def validate_base_url(self) -> None:
+		"""If a base URL is given, it must be a valid URL. If not given, it is cleared."""
+		self.base_url = (self.base_url or "").strip().rstrip("/") or None
+		if self.base_url and not frappe.utils.validate_url(self.base_url, valid_schemes=VALID_SCHEMES):
+			frappe.throw(_("Base URL must be a valid URL."), frappe.ValidationError)
 
 	@staticmethod
 	def telemetry_url_for(region: str) -> str | None:

--- a/central/tests/test_cargo_auth.py
+++ b/central/tests/test_cargo_auth.py
@@ -85,7 +85,7 @@ class TestCargoRegionBinding(IntegrationTestCase):
 			patch("central.services.storage.record_cluster_status") as recorded,
 		):
 			with self.assertRaises(frappe.PermissionError):
-				cargo_api.register_cluster(
+				cargo_api.register_storage_cluster(
 					region=OTHER_REGION,
 					base_url="http://attacker.test:3903",
 					s3_endpoint="http://attacker.test:3900",
@@ -99,7 +99,7 @@ class TestCargoRegionBinding(IntegrationTestCase):
 			patch("central.services.storage.record_cluster_status") as recorded,
 		):
 			with self.assertRaises(frappe.PermissionError):
-				cargo_api.register_cluster(region=OTHER_REGION, active=False)
+				cargo_api.register_storage_cluster(region=OTHER_REGION, active=False)
 		recorded.assert_not_called()
 
 	def test_a_running_cluster_must_report_every_endpoint(self):
@@ -109,7 +109,7 @@ class TestCargoRegionBinding(IntegrationTestCase):
 			patch("central.services.storage.record_cluster_status") as recorded,
 		):
 			with self.assertRaises(frappe.ValidationError):
-				cargo_api.register_cluster(
+				cargo_api.register_storage_cluster(
 					region=OWN_REGION, base_url="http://node:3903", s3_endpoint="http://node:3900"
 				)
 		recorded.assert_not_called()

--- a/central/tests/test_pilot_api.py
+++ b/central/tests/test_pilot_api.py
@@ -10,6 +10,7 @@ from central.api.pilot import heartbeat, log_token, metrics_token
 from central.central.doctype.pilot_credential.pilot_credential import PilotCredential
 from central.sso import LOG_SCOPE, METRICS_SCOPE
 from central.tests.test_iam import ensure_user
+from central.tests.utils import ensure_atlas_instance
 
 
 class TestPilotAPI(IntegrationTestCase):
@@ -60,6 +61,71 @@ class TestPilotAPI(IntegrationTestCase):
 		bench.db_set("expires_at", add_to_date(now_datetime(), hours=-1))
 		with self.assertRaises(frappe.AuthenticationError):
 			self.call_heartbeat(self.token)
+
+	def enrolled_cargo(self, region: str, telemetry_base_url: str) -> str:
+		"""A region whose Cargo has enrolled and reported where telemetry goes, with an
+		Asset in it bound to this pilot."""
+		ensure_atlas_instance(region)
+		frappe.get_doc(
+			{
+				"doctype": "Cargo Instance",
+				"region": region,
+				"status": "Registered",
+				"telemetry_base_url": telemetry_base_url,
+			}
+		).insert(ignore_permissions=True)
+		asset = frappe.get_doc(
+			{
+				"doctype": "Asset",
+				"resource_id": f"vm-{region}",
+				"team": self.team,
+				"cluster": region,
+				"status": "Running",
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.set_value("Pilot Credential", "api-pilot-1", "asset", asset.name)
+
+		return f"CARGO-{region}"
+
+	def test_token_names_the_regional_telemetry_endpoint(self):
+		"""The pilot is told where to ship without being told which region it is in:
+		the Asset's cluster is the region, and the region's Cargo owns the URL."""
+		region = f"tel-{frappe.generate_hash(length=6)}"
+		name = self.enrolled_cargo(region, "https://datum.example.test")
+		print(
+			"RAW:",
+			repr(
+				frappe.db.get_value(
+					"Cargo Instance", name, ["telemetry_base_url", "status"], as_dict=True, cache=True
+				)
+			),
+		)
+		print("CACHE:", repr(dict(frappe.db.value_cache.get("Cargo Instance", {}))))
+
+		self.assertEqual(self.call_metrics_token(self.token)["endpoint"], "https://datum.example.test")
+		self.assertEqual(self.call_log_token(self.token)["endpoint"], "https://datum.example.test")
+
+	def test_a_disabled_cargo_hands_out_no_endpoint(self):
+		"""A region whose Cargo is disabled has nowhere to ship. The token is still minted
+		-- it is the endpoint that is missing, not the pilot's right to telemetry."""
+		region = f"tel-{frappe.generate_hash(length=6)}"
+		name = self.enrolled_cargo(region, "https://datum.example.test")
+		frappe.db.set_value("Cargo Instance", name, "status", "Disabled")
+		frappe.db.value_cache.clear()
+
+		result = self.call_metrics_token(self.token)
+		self.assertIsNone(result["endpoint"])
+		self.assertTrue(result["token"])
+
+	def test_an_unbound_pilot_has_no_endpoint(self):
+		"""No Asset means no region to resolve. Reached only through log_token, which does
+		not gate on the resource the way metrics does."""
+		region = f"tel-{frappe.generate_hash(length=6)}"
+		self.enrolled_cargo(region, "https://datum.example.test")
+		frappe.db.set_value("Pilot Credential", "api-pilot-1", "asset", None)
+
+		with self.assertRaises(frappe.ValidationError):
+			self.call_metrics_token(self.token)
 
 	def call_metrics_token(self, token: str | None) -> dict:
 		headers = {"X-Pilot-Token": token} if token is not None else {}

--- a/central/tests/test_pilot_api.py
+++ b/central/tests/test_pilot_api.py
@@ -91,16 +91,7 @@ class TestPilotAPI(IntegrationTestCase):
 		"""The pilot is told where to ship without being told which region it is in:
 		the Asset's cluster is the region, and the region's Cargo owns the URL."""
 		region = f"tel-{frappe.generate_hash(length=6)}"
-		name = self.enrolled_cargo(region, "https://datum.example.test")
-		print(
-			"RAW:",
-			repr(
-				frappe.db.get_value(
-					"Cargo Instance", name, ["telemetry_base_url", "status"], as_dict=True, cache=True
-				)
-			),
-		)
-		print("CACHE:", repr(dict(frappe.db.value_cache.get("Cargo Instance", {}))))
+		self.enrolled_cargo(region, "https://datum.example.test")
 
 		self.assertEqual(self.call_metrics_token(self.token)["endpoint"], "https://datum.example.test")
 		self.assertEqual(self.call_log_token(self.token)["endpoint"], "https://datum.example.test")
@@ -111,7 +102,6 @@ class TestPilotAPI(IntegrationTestCase):
 		region = f"tel-{frappe.generate_hash(length=6)}"
 		name = self.enrolled_cargo(region, "https://datum.example.test")
 		frappe.db.set_value("Cargo Instance", name, "status", "Disabled")
-		frappe.db.value_cache.clear()
 
 		result = self.call_metrics_token(self.token)
 		self.assertIsNone(result["endpoint"])


### PR DESCRIPTION
Pilot needs to know which endpoint should it send telemetry data at 

fixes: https://github.com/frappe/central/issues/312